### PR TITLE
Consumer should populate table, not producer

### DIFF
--- a/common/consumertable.cpp
+++ b/common/consumertable.cpp
@@ -84,6 +84,31 @@ void ConsumerTable::pop(KeyOpFieldsValuesTuple &kco)
     JSon::readJson(pop_front(m_results), fieldsValues);
 
     kco = std::make_tuple(key, op, fieldsValues);
+
+    // NOTE: not entire pop operation is atomic
+    // since we first get values from the queue
+    // and then put them into table, but that
+    // is fine since we are the only consumer
+    // of this data
+
+    multi();
+
+    if (op == DEL_COMMAND)
+    {
+
+        std::string del("DEL ");
+        del += getKeyName(key);
+
+        enqueue(del, REDIS_REPLY_INTEGER);
+    }
+    else
+    {
+        for (FieldValueTuple &i : fieldsValues)
+            enqueue(formatHSET(getKeyName(key), fvField(i), fvValue(i)),
+                    REDIS_REPLY_INTEGER, true);
+    }
+
+    exec();
 }
 
 void ConsumerTable::addFd(fd_set *fd)

--- a/common/producertable.cpp
+++ b/common/producertable.cpp
@@ -45,9 +45,6 @@ void ProducerTable::enqueueDbChange(string key, string value, string op)
 void ProducerTable::set(string key, vector<FieldValueTuple> &values, string op)
 {
     multi();
-    for (FieldValueTuple &i : values)
-        enqueue(formatHSET(getKeyName(key), fvField(i), fvValue(i)),
-                REDIS_REPLY_INTEGER, true);
 
     enqueueDbChange(key, JSon::buildJson(values), op);
     exec();
@@ -61,7 +58,6 @@ void ProducerTable::del(string key, string op)
     multi();
 
     enqueueDbChange(key, "{}", op);
-    enqueue(del, REDIS_REPLY_INTEGER);
 
     exec();
 }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -16,6 +16,6 @@ tests_SOURCES = redis_ut.cpp
 
 tests_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST)
 tests_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST)
-tests_LDADD = -lnl-genl-3 -lhiredis -lhiredis -lpthread \
-	-L$(top_srcdir)/common -lswsscommon $(LDADD_GTEST)
+tests_LDADD = $(LDADD_GTEST) -lnl-genl-3 -lhiredis -lhiredis -lpthread \
+	-L$(top_srcdir)/common -lswsscommon
 


### PR DESCRIPTION
Adding alterTable flag which will help to address db freeze scenario:
OA is restarting, but in the same time some APP decided to add/del some entries in app view, then after OA restarts, current app view could be altered (added/chanded/deleted entries) and also the same message is still in the producer queue which is not desired: for example event was to set entry, and OA will read the same operation again and execute it.

Also note: should this implemented behavior should be as default?