### PR TITLE
producertable: Adding dump file to record all producer activities to file

### DIFF
--- a/common/json.h
+++ b/common/json.h
@@ -8,10 +8,10 @@
 
 namespace swss {
 
-class JSon {
+class JSon
+{
 public:
    static std::string buildJson(const std::vector<FieldValueTuple> &fv);
-
    static void readJson(const std::string &json, std::vector<FieldValueTuple> &fv);
 };
 

--- a/common/producertable.h
+++ b/common/producertable.h
@@ -1,6 +1,8 @@
 #ifndef __PRODUCERTABLE__
 #define __PRODUCERTABLE__
 
+#include <fstream>
+#include <iostream>
 #include <string>
 #include <vector>
 
@@ -14,6 +16,8 @@ class ProducerTable : public Table
 {
 public:
     ProducerTable(DBConnector *db, std::string tableName);
+    ProducerTable(DBConnector *db, std::string tableName, std::string dumpFile);
+    ~ProducerTable();
 
     /* Implements set() and del() commands using notification messages */
     virtual void set(std::string key, std::vector<FieldValueTuple> &values,
@@ -24,6 +28,9 @@ private:
     /* Disable copy-constructor and operator = */
     ProducerTable(const ProducerTable &other);
     ProducerTable & operator = (const ProducerTable &other);
+
+    std::ofstream m_dumpFile;
+    bool m_firstItem = true;
 
     void enqueueDbChange(std::string key, std::string value, std::string op);
 };

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -13,7 +13,8 @@ LDADD_GTEST = $(top_srcdir)/googletest/build/googlemock/gtest/libgtest_main.a \
         $(top_srcdir)/googletest/build/googlemock/gtest/libgtest.a
 
 tests_SOURCES = redis_ut.cpp    \
-                tokenize_ut.cpp
+                tokenize_ut.cpp \
+                json_ut.cpp
 
 tests_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST)
 tests_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST)

--- a/tests/json_ut.cpp
+++ b/tests/json_ut.cpp
@@ -1,0 +1,71 @@
+#include "common/json.hpp"
+#include "common/producertable.h"
+#include "gtest/gtest.h"
+
+using namespace std;
+using namespace swss;
+using json = nlohmann::json;
+
+#define TEST_VIEW       (7)
+#define TEST_DUMP_FILE  "ut_dump_file.txt"
+
+TEST(JSON, test)
+{
+    /* Construct the file */
+    DBConnector db(TEST_VIEW, "localhost", 6379, 0);
+    ProducerTable *p;
+    p = new ProducerTable(&db, "UT_REDIS", TEST_DUMP_FILE);
+
+    vector<FieldValueTuple> fvTuples;
+    FieldValueTuple fv1("test_field_1", "test_value_1");
+    fvTuples.push_back(fv1);
+
+    p->set("test_key_1", fvTuples);
+
+    FieldValueTuple fv2("test_field_2", "test_value_2");
+    fvTuples.push_back(fv2);
+
+    p->set("test_key_2", fvTuples);
+
+    p->del("test_key_1");
+
+    delete(p);
+
+    /* Read the file and validate the content */
+    fstream file(TEST_DUMP_FILE, fstream::in);
+    json j;
+    file >> j;
+
+    EXPECT_TRUE(j.is_array());
+    EXPECT_TRUE(j.size() == 3);
+
+    for (size_t i = 0; i < j.size(); i++)
+    {
+        auto item = j[i];
+        EXPECT_TRUE(item.is_object());
+        EXPECT_TRUE(item.size() == 2);
+
+        for (auto it = item.begin(); it != item.end(); it++)
+        {
+            if (it.key() == "OP")
+                EXPECT_TRUE(it.value() == "SET" || it.value() == "DEL");
+            else
+            {
+                EXPECT_TRUE(it.key() == "UT_REDIS:test_key_1" || it.key() == "UT_REDIS:test_key_2");
+                auto subitem = it.value();
+                EXPECT_TRUE(subitem.is_object());
+                if (subitem.size() > 0)
+                {
+                    for (auto subit = subitem.begin(); subit != subitem.end(); subit++)
+                    {
+                        if (subit.key() == "test_field_1")
+                            EXPECT_EQ(subit.value(), "test_value_1");
+                        if (subit.key() == "test_field_2")
+                            EXPECT_EQ(subit.value(), "test_value_2");
+                    }
+                }
+            }
+        }
+    }
+    file.close();
+}


### PR DESCRIPTION
- Use json.hpp to construct the JSON data and store into the m_dumpFile,
    which could be used as input file for swssconfig.
- Add unit test for verification