### PR TITLE
Fix duplicated notifications bug

### DIFF
--- a/common/notificationconsumer.h
+++ b/common/notificationconsumer.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <vector>
+#include <queue>
 
 #include <hiredis/hiredis.h>
 
@@ -34,12 +35,13 @@ private:
     NotificationConsumer(const NotificationConsumer &other);
     NotificationConsumer& operator = (const NotificationConsumer &other);
 
+    void processReply(redisReply *reply);
     void subscribe();
 
     swss::DBConnector *m_db;
     swss::DBConnector *m_subscribe;
     std::string m_channel;
-    std::string m_msg;
+    std::queue<std::string> m_queue;
 };
 
 }

--- a/common/select.cpp
+++ b/common/select.cpp
@@ -40,6 +40,8 @@ void Select::addFd(int fd)
 
 int Select::select(Selectable **c, int *fd, unsigned int timeout)
 {
+    SWSS_LOG_ENTER();
+
     struct timeval t = {0, (suseconds_t)(timeout)*1000};
     struct timeval *pTimeout = NULL;
     fd_set fs;
@@ -55,6 +57,7 @@ int Select::select(Selectable **c, int *fd, unsigned int timeout)
     for (Selectable *i : m_objects)
     {
         err = i->readCache();
+
         if (err == Selectable::ERROR)
             return Select::ERROR;
         else if (err == Selectable::DATA) {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -15,6 +15,7 @@ LDADD_GTEST = $(top_srcdir)/googletest/build/googlemock/gtest/libgtest_main.a \
 tests_SOURCES = redis_ut.cpp    \
                 tokenize_ut.cpp \
                 json_ut.cpp     \
+                ntf_ut.cpp      \
                 ipprefix_ut.cpp
 
 tests_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST)

--- a/tests/ntf_ut.cpp
+++ b/tests/ntf_ut.cpp
@@ -1,0 +1,78 @@
+#include <gtest/gtest.h>
+#include "common/ipprefix.h"
+
+#include <iostream>
+#include <thread>
+
+#include <unistd.h>
+
+#include "common/notificationconsumer.h"
+#include "common/notificationproducer.h"
+#include "common/selectableevent.h"
+#include "common/select.h"
+#include "common/logger.h"
+
+std::shared_ptr<std::thread> notification_thread;
+
+volatile int messages = 5000;
+
+void ntf_thread()
+{
+    SWSS_LOG_ENTER();
+
+    auto g_dbNtf = new swss::DBConnector(ASIC_DB, "localhost", 6379, 0);
+    auto g_redisNotifications = new swss::NotificationConsumer(g_dbNtf, "NOTIFICATIONS");
+
+    swss::Select s;
+
+    s.addSelectable(g_redisNotifications);
+
+    int collected = 0;
+
+    while (collected < messages)
+    {
+        swss::Selectable *sel;
+
+        int fd;
+
+        int result = s.select(&sel, &fd);
+
+        if (result == swss::Select::OBJECT)
+        {
+            swss::KeyOpFieldsValuesTuple kco;
+
+            std::string op;
+            std::string data;
+            std::vector<swss::FieldValueTuple> values;
+
+            g_redisNotifications->pop(op, data, values);
+
+            SWSS_LOG_INFO("notification: op = %s, data = %s", op.c_str(), data.c_str());
+
+            collected++;
+        }
+    }
+}
+
+TEST(Notifications, test)
+{
+    SWSS_LOG_ENTER();
+
+    notification_thread = std::make_shared<std::thread>(std::thread(ntf_thread));
+
+    sleep(1); // give time to subscribe to not miss notification
+
+    auto dbNtf = new swss::DBConnector(ASIC_DB, "localhost", 6379, 0);
+    auto notifications = new swss::NotificationProducer(dbNtf, "NOTIFICATIONS");
+
+    std::vector<swss::FieldValueTuple> entry;
+
+    for(int i = 0; i < messages; i++)
+    {
+        std::string s = std::to_string(i+1);
+
+        notifications->send("ntf", s, entry);
+    }
+
+    notification_thread->join();
+}


### PR DESCRIPTION
In previous implementation on high volume of notifications on the stream messages were swallowed in readCache method, and previous "m_msg" was not populated, and since readCache returned DATA result, readMe method (which populates m_msg) was not called which was causing duplicated notifications poped. Now queue was introduced and populated every time we get valid redis reply, and pop is accessing queue directly.