### PR TITLE
Fix #71: ProducerStateTable does not support field/value names with space characters

### DIFF
--- a/common/producerstatetable.cpp
+++ b/common/producerstatetable.cpp
@@ -11,23 +11,23 @@ using namespace std;
 
 namespace swss {
 
-ProducerStateTable::ProducerStateTable(DBConnector *db, std::string tableName)
+ProducerStateTable::ProducerStateTable(DBConnector *db, string tableName)
     : TableName_KeySet(tableName)
     , m_db(db)
 {
 }
 
-void ProducerStateTable::set(std::string key, std::vector<FieldValueTuple> &values,
-                 std::string op /*= SET_COMMAND*/, std::string prefix)
+void ProducerStateTable::set(string key, vector<FieldValueTuple> &values,
+                 string op /*= SET_COMMAND*/, string prefix)
 {
-    static std::string luaScript =
+    static string luaScript =
         "redis.call('SADD', KEYS[2], ARGV[2])\n"
         "for i = 0, #KEYS - 3 do\n"
         "    redis.call('HSET', KEYS[3 + i], ARGV[3 + i * 2], ARGV[4 + i * 2])\n"
         "end\n"
         "redis.call('PUBLISH', KEYS[1], ARGV[1])\n";
 
-    static std::string sha = loadRedisScript(m_db, luaScript);
+    static string sha = loadRedisScript(m_db, luaScript);
 
     // Assembly redis command args into a string vector
     vector<string> args;
@@ -50,7 +50,7 @@ void ProducerStateTable::set(std::string key, std::vector<FieldValueTuple> &valu
 
     // Transform data structure
     vector<const char *> args1;
-    transform(args.begin(), args.end(), std::back_inserter(args1), [](const string s) { return s.c_str(); } ); 
+    transform(args.begin(), args.end(), back_inserter(args1), [](const string s) { return s.c_str(); } ); 
     
     // Invoke redis command
     RedisCommand command;
@@ -58,14 +58,14 @@ void ProducerStateTable::set(std::string key, std::vector<FieldValueTuple> &valu
     RedisReply r(m_db, command, REDIS_REPLY_NIL);
 }
 
-void ProducerStateTable::del(std::string key, std::string op /*= DEL_COMMAND*/, std::string prefix)
+void ProducerStateTable::del(string key, string op /*= DEL_COMMAND*/, string prefix)
 {
-    static std::string luaScript =
+    static string luaScript =
         "redis.call('SADD', KEYS[2], ARGV[2])\n"
         "redis.call('DEL', KEYS[3])\n"
         "redis.call('PUBLISH', KEYS[1], ARGV[1])\n";
 
-    static std::string sha = loadRedisScript(m_db, luaScript);
+    static string sha = loadRedisScript(m_db, luaScript);
     
     // Assembly redis command args into a string vector
     vector<string> args;
@@ -81,7 +81,7 @@ void ProducerStateTable::del(std::string key, std::string op /*= DEL_COMMAND*/, 
 
     // Transform data structure
     vector<const char *> args1;
-    transform(args.begin(), args.end(), std::back_inserter(args1), [](const string s) { return s.c_str(); } ); 
+    transform(args.begin(), args.end(), back_inserter(args1), [](const string s) { return s.c_str(); } ); 
     
     // Invoke redis command
     RedisCommand command;

--- a/common/rediscommand.h
+++ b/common/rediscommand.h
@@ -1,6 +1,5 @@
 #pragma once
 #include <string.h>
-#include <assert.h>
 #include <tuple>
 
 namespace swss {
@@ -16,10 +15,10 @@ typedef std::tuple<std::string, std::string, std::vector<FieldValueTuple> > KeyO
 class RedisCommand {
 public:
     RedisCommand() : temp(NULL) { }
-    ~RedisCommand() { redisFreeCommand(temp); templen = 0; }
+    ~RedisCommand() { redisFreeCommand(temp); }
     RedisCommand(RedisCommand& that);
     RedisCommand& operator=(RedisCommand& that);
-
+    
     void format(const char *fmt, ...) {
         va_list ap;
         va_start(ap, fmt);
@@ -28,24 +27,16 @@ public:
             throw std::bad_alloc();
         } else if (len == -2) {
             throw std::invalid_argument("fmt");
-        } else if (len < 0) {
-            throw std::logic_error("redisvFormatCommand returns unexpected value");
         }
-        assert((size_t)len == strlen(temp));
-        templen = (size_t)len;
     }
-
+    
     void formatArgv(int argc, const char **argv, const size_t *argvlen) {
         int len = redisFormatCommandArgv(&temp, argc, argv, argvlen);
         if (len == -1) {
             throw std::bad_alloc();
-        } else if (len < 0) {
-            throw std::logic_error("redisFormatCommandArgv returns unexpected value");
         }
-        assert((size_t)len == strlen(temp));
-        templen = (size_t)len;
     }
-
+    
     /* Format HMSET key multiple field value command */
     void formatHMSET(const std::string &key,
                      const std::vector<FieldValueTuple> &values)
@@ -61,7 +52,7 @@ public:
             args.push_back(fvField(fvt).c_str());
             args.push_back(fvValue(fvt).c_str());
         }
-
+        
         formatArgv((int)args.size(), args.data(), NULL);
     }
 
@@ -83,20 +74,19 @@ public:
     {
         return format("HDEL %s %s", key.c_str(), field.c_str());
     }
-
+    
     const char *c_str() const
     {
         return temp;
     }
-
+    
     size_t length() const
     {
-        return templen;
+        return strlen(temp);
     }
-
+    
 private:
     char *temp;
-    size_t templen;
 };
 
 }

--- a/common/rediscommand.h
+++ b/common/rediscommand.h
@@ -35,30 +35,6 @@ public:
         templen = (size_t)len;
     }
 
-    void append(const char *fmt, ...) {
-        va_list ap;
-        va_start(ap, fmt);
-        char *tail;
-        int len = redisvFormatCommand(&tail, fmt, ap);
-        if (len == -1) {
-            throw std::bad_alloc();
-        } else if (len == -2) {
-            throw std::invalid_argument("fmt");
-        } else if (len < 0) {
-            throw std::logic_error("redisvFormatCommand returns unexpected value");
-        }
-        assert((size_t)len == strlen(tail));
-
-        void *temp1 = realloc(temp, templen + len + 1);
-        if (temp1 == NULL) {
-            redisFreeCommand(tail);
-            throw std::bad_alloc();
-        }
-        temp = (char *)temp1;
-        strcpy(temp + templen, tail);
-        templen += len;
-    }
-
     void formatArgv(int argc, const char **argv, const size_t *argvlen) {
         int len = redisFormatCommandArgv(&temp, argc, argv, argvlen);
         if (len == -1) {

--- a/tests/redis_state_ut.cpp
+++ b/tests/redis_state_ut.cpp
@@ -28,18 +28,18 @@ static inline int getMaxFields(int i)
 
 static inline string key(int i)
 {
-    return string("key") + to_string(i);
+    return string("key ") + to_string(i);
 }
 
 static inline string field(int i)
 {
-    return string("field") + to_string(i);
+    return string("field ") + to_string(i);
 }
 
 static inline string value(int i)
 {
     if (i == 0) return string(); // emtpy
-    return string("value") + to_string(i);
+    return string("value ") + to_string(i);
 }
 
 static inline bool IsDigit(char ch)


### PR DESCRIPTION
Fix #71: ProducerStateTable does not support field/value names with space characters