### PR TITLE
[tokenize]: Add tokenizeFirst function

### DIFF
--- a/common/tokenize.cpp
+++ b/common/tokenize.cpp
@@ -15,5 +15,23 @@ vector<string> tokenize(const string &str, const char token)
 
     return ret;
 }
+vector<string> tokenize(const string &str, const char token, const size_t firstN)
+{
+    vector<string> ret;
+    string tmp = str;
+    size_t i = 0;
+    auto pos = tmp.find(token);
+
+    while (pos != string::npos && i++ < firstN)
+    {
+        ret.push_back(tmp.substr(0, pos));
+        tmp = tmp.substr(pos+1);
+        pos = tmp.find(token);
+    }
+
+    ret.push_back(tmp);
+
+    return ret;
+}
 
 }

--- a/common/tokenize.h
+++ b/common/tokenize.h
@@ -7,6 +7,7 @@
 namespace swss {
 
 std::vector<std::string> tokenize(const std::string &, const char token);
+std::vector<std::string> tokenize(const std::string &, const char token, const size_t firstN);
 
 }
 

--- a/tests/tokenize_ut.cpp
+++ b/tests/tokenize_ut.cpp
@@ -53,3 +53,65 @@ TEST(TOKENIZE, IP_2)
 
     EXPECT_EQ(origin, result);
 }
+
+TEST(TOKENIZEFIRST, zero)
+{
+    string key("Hello world!");
+    auto tokens = tokenize(key, ' ', 0);
+    EXPECT_EQ(tokens[0], key);
+}
+
+TEST(TOKENIZEFIRST, out_of_bound)
+{
+    string key("Hello world!");
+    auto tokens = tokenize(key, ' ', 999);
+    EXPECT_EQ(tokens[0], "Hello");
+    EXPECT_EQ(tokens[1], "world!");
+    EXPECT_EQ(tokens.size(), (size_t) 2);
+}
+
+TEST(TOKENIZEFIRST, MAC)
+{
+    string key("neigh:00:00:00:00:00:00");
+    auto tokens = tokenize(key, ':', 1);
+
+    EXPECT_EQ(tokens[0], "neigh");
+    EXPECT_EQ(tokens[1], "00:00:00:00:00:00");
+}
+
+TEST(TOKENIZEFIRST, IPv6)
+{
+    string key("NEIGH_TABLE:lo:fc00::79");
+    auto tokens = tokenize(key, ':', 1);
+
+    EXPECT_EQ(tokens[0], "NEIGH_TABLE");
+
+    tokens = tokenize(tokens[1], ':', 1);
+
+    EXPECT_EQ(tokens[0], "lo");
+    EXPECT_EQ(tokens[1], "fc00::79");
+}
+
+TEST(TOKENIZEFIRST, IPv6_2)
+{
+    string key("NEIGH_TABLE:lo:fc00::79");
+
+    auto tokens = tokenize(key, ':', 2);
+
+    EXPECT_EQ(tokens[0], "NEIGH_TABLE");
+    EXPECT_EQ(tokens[1], "lo");
+    EXPECT_EQ(tokens[2], "fc00::79");
+}
+
+TEST(TOKENIZEFISRT, not_found)
+{
+    string key("neigh:00:00:00:00:00:00");
+    auto tokens = tokenize(key, '|', 1);
+
+    EXPECT_EQ(tokens[0], key);
+
+    string key_2("neigh:");
+    auto tokens_2 = tokenize(key_2, ':', 1);
+
+    EXPECT_EQ(tokens_2[0], key_2);
+}


### PR DESCRIPTION
This function is helpful when trying to tokenize a key-value string
that the tokenizer used between key and value also appears in value.

i.e. "neigh:00:00:00:00:00:00" and "NEIGH_TABLE:lo:fc00::79"