### PR TITLE
[ConsumerTable]: Set pop batch size as a constructor parameter

### DIFF
--- a/common/consumerstatetable.cpp
+++ b/common/consumerstatetable.cpp
@@ -11,10 +11,10 @@
 
 namespace swss {
 
-ConsumerStateTable::ConsumerStateTable(DBConnector *db, std::string tableName)
+ConsumerStateTable::ConsumerStateTable(DBConnector *db, std::string tableName, int popBatchSize)
     : RedisTransactioner(db)
     , TableName_KeySet(tableName)
-    , POP_BATCH_SIZE(128)
+    , POP_BATCH_SIZE(popBatchSize)
 {
     for (;;)
     {

--- a/common/consumerstatetable.h
+++ b/common/consumerstatetable.h
@@ -11,9 +11,10 @@ namespace swss {
 class ConsumerStateTable : public RedisTransactioner, public RedisSelect, public TableName_KeySet, public TableEntryPoppable
 {
 public:
+    /* TODO: Inherit ConsumerStateTable from ConsumerTable to merge same functions and variables */
     const int POP_BATCH_SIZE;
 
-    ConsumerStateTable(DBConnector *db, std::string tableName);
+    ConsumerStateTable(DBConnector *db, std::string tableName, int popBatchSize = DEFAULT_POP_BATCH_SIZE);
 
     /* Get a singlesubscribe channel rpop */
     /* If there is nothing to pop, the output paramter will have empty key and op */

--- a/common/consumertable.cpp
+++ b/common/consumertable.cpp
@@ -14,10 +14,10 @@ using namespace std;
 
 namespace swss {
 
-ConsumerTable::ConsumerTable(DBConnector *db, string tableName)
+ConsumerTable::ConsumerTable(DBConnector *db, string tableName, int popBatchSize)
     : RedisTransactioner(db)
     , TableName_KeyValueOpQueues(tableName)
-    , POP_BATCH_SIZE(128)
+    , POP_BATCH_SIZE(popBatchSize)
 {
     for (;;)
     {

--- a/common/consumertable.h
+++ b/common/consumertable.h
@@ -17,7 +17,7 @@ class ConsumerTable : public RedisTransactioner, public RedisSelect, public Tabl
 public:
     const int POP_BATCH_SIZE;
 
-    ConsumerTable(DBConnector *db, std::string tableName);
+    ConsumerTable(DBConnector *db, std::string tableName, int popBatchSize = DEFAULT_POP_BATCH_SIZE);
 
     /* Get a singlesubscribe channel rpop */
     void pop(KeyOpFieldsValuesTuple &kco, std::string prefix = EMPTY_PREFIX);

--- a/common/table.h
+++ b/common/table.h
@@ -27,6 +27,9 @@ typedef std::map<std::string,TableMap> TableDump;
 
 class TableBase {
 public:
+    /* The default value of pop batch size is 128 */
+    static constexpr int DEFAULT_POP_BATCH_SIZE = 128;
+
     TableBase(std::string tableName) : m_tableName(tableName) { }
 
     std::string getTableName() const { return m_tableName; }


### PR DESCRIPTION
- By default, the pop batch size is 128. It could be set to other
  values when necessary. If a value large enough is set here, the
  behavior will be to pop out all existing items in the table.