### PR TITLE
[Makefile.am]: Use full file names

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -9,10 +9,7 @@ EXTRA_DIST = \
 
 swssdir = $(datadir)/swss
 
-dist_swss_DATA = \
-    consumer_state_table_pops.lua \
-    consumer_table_pops.lua \
-    table_dump.lua
+dist_swss_DATA = $(EXTRA_DIST)
 
 bin_PROGRAMS = swssloglevel
 

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -2,11 +2,17 @@ INCLUDES = -I $(top_srcdir) -I/usr/include/libnl3
 
 lib_LTLIBRARIES = libswsscommon.la
 
-EXTRA_DIST = *.lua
+EXTRA_DIST = \
+    consumer_state_table_pops.lua \
+    consumer_table_pops.lua \
+    table_dump.lua
 
 swssdir = $(datadir)/swss
 
-dist_swss_DATA = *.lua
+dist_swss_DATA = \
+    consumer_state_table_pops.lua \
+    consumer_table_pops.lua \
+    table_dump.lua
 
 bin_PROGRAMS = swssloglevel
 


### PR DESCRIPTION
GNU Automake does not support wildcards, which makes the build fail on
some versions of Automake with error "No rule to make target *.lua".

Signed-off-by: marian-pritsak <marianp@mellanox.com>