### PR TITLE
Increase netlink buffer. Otherwise we're loosing netlink messages

### DIFF
--- a/common/netlink.cpp
+++ b/common/netlink.cpp
@@ -34,7 +34,7 @@ NetLink::NetLink() :
     }
 
     /* Set socket buffer size to 256KB */
-    nl_socket_set_buffer_size(m_socket, 262144, 0);
+    nl_socket_set_buffer_size(m_socket, 2097152, 0);
 }
 
 NetLink::~NetLink()


### PR DESCRIPTION
When we're add many neighbors to our database, we can lose some netlink messages. In this case our app_db database doesn't have all neighbor entries in comparison with Linux kernel.

This pull request introduce a quick fix. It's better to have two threads for the code. One thread for reading data from the socket, another one for writing to database.