### PR TITLE
[netlink]: Check return code from nl_recvmsgs_default to catch lost messages

### DIFF
--- a/common/netlink.cpp
+++ b/common/netlink.cpp
@@ -87,7 +87,14 @@ int NetLink::readCache()
 
 void NetLink::readMe()
 {
-    nl_recvmsgs_default(m_socket);
+    int err = nl_recvmsgs_default(m_socket);
+    if (err < 0)
+    {
+        if (err == -NLE_NOMEM)
+            SWSS_LOG_ERROR("netlink reports out of memory on reading a netlink socket. High possiblity of a lost message");
+        else
+            SWSS_LOG_ERROR("netlink reports an error=%d on reading a netlink socket", err);
+    }
 }
 
 int NetLink::onNetlinkMsg(struct nl_msg *msg, void *arg)


### PR DESCRIPTION
When our library is not fast enough in reading netlink messages we're loosing them.
Report about such cases in the log