### PR TITLE
[Selectable]: EINTR error handling

### DIFF
--- a/common/select.cpp
+++ b/common/select.cpp
@@ -74,7 +74,12 @@ int Select::select(Selectable **c, int *fd, unsigned int timeout)
         FD_SET(fdn, &fs);
     }
 
-    err = ::select(FD_SETSIZE, &fs, NULL, NULL, pTimeout);
+    do
+    {
+        err = ::select(FD_SETSIZE, &fs, NULL, NULL, pTimeout);
+    }
+    while(err == -1 && errno == EINTR); // Retry the select if the process was interrupted by a signal
+
     if (err < 0)
         return Select::ERROR;
     if (err == 0)

--- a/common/selectableevent.cpp
+++ b/common/selectableevent.cpp
@@ -26,7 +26,13 @@ SelectableEvent::SelectableEvent() :
 
 SelectableEvent::~SelectableEvent()
 {
-    close(m_efd);
+    int err;
+
+    do
+    {
+        err = close(m_efd);
+    }
+    while(err == -1 && errno == EINTR);
 }
 
 void SelectableEvent::addFd(fd_set *fd)
@@ -42,7 +48,12 @@ int SelectableEvent::readCache()
 void SelectableEvent::readMe()
 {
     uint64_t r;
-    ssize_t s = read(m_efd, &r, sizeof(uint64_t));
+
+    do
+    {
+        ssize_t s = read(m_efd, &r, sizeof(uint64_t));
+    }
+    while(s == -1 && errno == EINTR);
 
     if (s != sizeof(uint64_t))
     {
@@ -62,7 +73,11 @@ void SelectableEvent::notify()
     SWSS_LOG_ENTER();
 
     uint64_t value = 1;
-    ssize_t s = write(m_efd, &value, sizeof(uint64_t));
+    do
+    {
+        ssize_t s = write(m_efd, &value, sizeof(uint64_t));
+    }
+    while(s == -1 && errno == EINTR);
 
     if (s != sizeof(uint64_t))
     {

--- a/common/selectableevent.cpp
+++ b/common/selectableevent.cpp
@@ -49,9 +49,10 @@ void SelectableEvent::readMe()
 {
     uint64_t r;
 
+    ssize_t s;
     do
     {
-        ssize_t s = read(m_efd, &r, sizeof(uint64_t));
+        s = read(m_efd, &r, sizeof(uint64_t));
     }
     while(s == -1 && errno == EINTR);
 
@@ -73,9 +74,10 @@ void SelectableEvent::notify()
     SWSS_LOG_ENTER();
 
     uint64_t value = 1;
+    ssize_t s;
     do
     {
-        ssize_t s = write(m_efd, &value, sizeof(uint64_t));
+        s = write(m_efd, &value, sizeof(uint64_t));
     }
     while(s == -1 && errno == EINTR);
 


### PR DESCRIPTION
We need to handle EINTR error returning from UNIX API calls.
When we receive a signal a UNIX API call can return EINTR which is not error.
We have to restart an UNIX API call when it returns EINTR.
Otherwise we see this in our log and orchagent crashes.
"NOTICE orchagent: :- start: Error: Interrupted system call!"

We also can solve the issue with a MACRO:
```
#define HANDLE_EINTR(x) ({ \
	typeof(x) __eintr_result__; \
	do { \
	__eintr_result__ = (x); \
	} while (__eintr_result__ == -1 && errno == EINTR); \
	__eintr_result__;\

```