### PR TITLE
Due to the missing of NLMSG_DONE flag in some netlink messages, netli…

### DIFF
--- a/common/netlink.cpp
+++ b/common/netlink.cpp
@@ -33,6 +33,7 @@ NetLink::NetLink() :
                            "Unable to connect netlink socket");
     }
 
+    nl_socket_set_nonblocking(m_socket);
     /* Set socket buffer size to 256KB */
     nl_socket_set_buffer_size(m_socket, 2097152, 0);
 }


### PR DESCRIPTION
Due to the missing of NLMSG_DONE flag in some netlink messages, netlink process got stuck in "static int recvmsgs(struct nl_sock *sk, struct nl_cb *cb)" function of libnl.

As recommended at http://www.infradead.org/~tgr/libnl/doc/core.html : If a socket is used to only receive notifications it usually is best to put the socket in non-blocking mode and periodically poll for new notifications.

4.x kernel has fix to the wrong use of NLM_F_MULTI problem: github.com/torvalds/linux/commit/46c264daaaa569e24f8aba877d0fd8167c42a9a4
but introducing the fix to 3.16 will break Debian Jessie ABI. Setting netlink socket to non-blocking mode gets around the problem without kernel change.