### PR TITLE
Add exec library for executing shell commands

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -42,7 +42,8 @@ libswsscommon_la_SOURCES = \
     notificationproducer.cpp  \
     linkcache.cpp             \
     portmap.cpp               \
-    tokenize.cpp
+    tokenize.cpp              \
+    exec.cpp
 
 libswsscommon_la_CXXFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(LIBNL_CFLAGS)
 libswsscommon_la_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(LIBNL_CPPFLAGS)

--- a/common/exec.cpp
+++ b/common/exec.cpp
@@ -1,25 +1,24 @@
-#include <cstdio>
-#include <iostream>
-#include <stdexcept>
 #include <array>
 #include "exec.h"
 #include "common/logger.h"
 
+using namespace std;
+
 namespace swss {
 
-std::string exec(const char* cmd)
+string exec(const char* cmd)
 {
-    std::array<char, 128> buffer;
-    std::string result;
-    std::shared_ptr<FILE> pipe(popen(cmd, "r"), pclose);
+    array<char, 128> buffer;
+    string result;
+    shared_ptr<FILE> pipe(popen(cmd, "r"), pclose);
 
     if (!pipe)
     {
-        std::string errmsg(cmd);
+        string errmsg(cmd);
 
         errmsg = "popen(" + errmsg + ") failed!";
         SWSS_LOG_ERROR("exec: %s", errmsg.c_str());
-        throw std::runtime_error(errmsg);
+        throw runtime_error(errmsg);
     }
 
     while (!feof(pipe.get()))

--- a/common/exec.cpp
+++ b/common/exec.cpp
@@ -1,0 +1,35 @@
+#include <cstdio>
+#include <iostream>
+#include <stdexcept>
+#include <array>
+#include "exec.h"
+#include "common/logger.h"
+
+namespace swss {
+
+std::string exec(const char* cmd)
+{
+    std::array<char, 128> buffer;
+    std::string result;
+    std::shared_ptr<FILE> pipe(popen(cmd, "r"), pclose);
+
+    if (!pipe)
+    {
+        std::string errmsg(cmd);
+
+        errmsg = "popen(" + errmsg + ") failed!";
+        SWSS_LOG_ERROR("exec: %s", errmsg.c_str());
+        throw std::runtime_error(errmsg);
+    }
+
+    while (!feof(pipe.get()))
+    {
+        if (fgets(buffer.data(), 128, pipe.get()) != NULL)
+            result += buffer.data();
+    }
+
+    SWSS_LOG_DEBUG("%s : %s", cmd, result.c_str());
+    return result;
+}
+
+}

--- a/common/exec.h
+++ b/common/exec.h
@@ -4,6 +4,6 @@
 
 namespace swss {
 
-std::string exec(const char* cmd);
+int exec(const std::string &cmd, std::string &stdout);
 
 }

--- a/common/exec.h
+++ b/common/exec.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <string>
+
+namespace swss {
+
+std::string exec(const char* cmd);
+
+}

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -22,7 +22,8 @@ tests_SOURCES = redis_ut.cpp                \
                 ipaddress_ut.cpp            \
                 ipprefix_ut.cpp             \
                 macaddress_ut.cpp           \
-                converter_ut.cpp
+                converter_ut.cpp            \
+                exec_ut.cpp
 
 tests_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST)
 tests_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST)

--- a/tests/exec_ut.cpp
+++ b/tests/exec_ut.cpp
@@ -1,0 +1,20 @@
+#include "common/exec.h"
+#include "gtest/gtest.h"
+
+using namespace std;
+using namespace swss;
+
+TEST(EXEC, empty)
+{
+    string cmd1 = "cat /proc/cpuinfo  | grep processor | wc -l";
+    string cmd2 = "nproc --all";
+    string cmd3 = "lscpu | egrep '^CPU\\(' | rev | cut -d' ' -f1 | rev";
+
+    string result1 = exec(cmd1.c_str());
+    string result2 = exec(cmd2.c_str());
+    string result3 = exec(cmd3.c_str());
+
+    EXPECT_EQ(result1, result2);
+
+    EXPECT_EQ(result2, result3);
+}

--- a/tests/exec_ut.cpp
+++ b/tests/exec_ut.cpp
@@ -4,17 +4,33 @@
 using namespace std;
 using namespace swss;
 
-TEST(EXEC, empty)
+TEST(EXEC, result)
 {
     string cmd1 = "cat /proc/cpuinfo  | grep processor | wc -l";
     string cmd2 = "nproc --all";
     string cmd3 = "lscpu | egrep '^CPU\\(' | rev | cut -d' ' -f1 | rev";
 
-    string result1 = exec(cmd1.c_str());
-    string result2 = exec(cmd2.c_str());
-    string result3 = exec(cmd3.c_str());
+    string result1;
+    int ret = exec(cmd1, result1);
+    EXPECT_TRUE(ret == 0);
+
+    string result2;
+    ret = exec(cmd2, result2);
+    EXPECT_TRUE(ret == 0);
+
+    string result3;
+    ret = exec(cmd3, result3);
+    EXPECT_TRUE(ret == 0);
 
     EXPECT_EQ(result1, result2);
-
     EXPECT_EQ(result2, result3);
+}
+
+TEST(EXEC, error)
+{
+    string cmd = "nproc --aaall > /dev/null 2>&1";
+
+    string result;
+    int ret = exec(cmd, result);
+    EXPECT_FALSE(ret == 0);
 }


### PR DESCRIPTION
Add support for executing shell command in c++ code.

jipan@043cf76fe4fe:/sonic/src/sonic-swss-common/tests$ ./tests --gtest_filter=EXEC*
Running main() from gtest_main.cc
Note: Google Test filter = EXEC*
[==========] Running 2 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 2 tests from EXEC
[ RUN      ] EXEC.result
[       OK ] EXEC.result (6 ms)
[ RUN      ] EXEC.error
[       OK ] EXEC.error (2 ms)
[----------] 2 tests from EXEC (8 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test case ran. (8 ms total)
[  PASSED  ] 2 tests.
jipan@043cf76fe4fe:/sonic/src/sonic-swss-common/tests$ ./tests --gtest_filter=EXEC*
Running main() from gtest_main.cc
Note: Google Test filter = EXEC*
[==========] Running 2 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 2 tests from EXEC
[ RUN      ] EXEC.result
[       OK ] EXEC.result (5 ms)
[ RUN      ] EXEC.error
[       OK ] EXEC.error (1 ms)
[----------] 2 tests from EXEC (6 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test case ran. (6 ms total)
[  PASSED  ] 2 tests.

