### PR TITLE
Support specifying table name separator for table and tableBase class.

### DIFF
--- a/common/schema.h
+++ b/common/schema.h
@@ -72,9 +72,6 @@ namespace swss {
 
 /***** MISC *****/
 
-#define TABLE_NAME_SEPARATOR    "|"
-#define KEY_SEPARATOR           "|"
-
 #define IPV4_NAME "IPv4"
 #define IPV6_NAME "IPv6"
 

--- a/common/schema.h
+++ b/common/schema.h
@@ -72,6 +72,9 @@ namespace swss {
 
 /***** MISC *****/
 
+#define TABLE_NAME_SEPARATOR    "|"
+#define KEY_SEPARATOR           "|"
+
 #define IPV4_NAME "IPv4"
 #define IPV6_NAME "IPv6"
 

--- a/common/table.cpp
+++ b/common/table.cpp
@@ -12,7 +12,8 @@ using namespace std;
 using namespace swss;
 using json = nlohmann::json;
 
-Table::Table(DBConnector *db, string tableName) : RedisTransactioner(db), TableBase(tableName)
+Table::Table(DBConnector *db, string tableName, string tableSeparator)
+    : RedisTransactioner(db), TableBase(tableName, tableSeparator)
 {
 }
 
@@ -77,7 +78,7 @@ void TableEntryEnumerable::getTableContent(vector<KeyOpFieldsValuesTuple> &tuple
 
 void Table::getTableKeys(vector<string> &keys)
 {
-    string keys_cmd("KEYS " + getTableName() + ":*");
+    string keys_cmd("KEYS " + getTableName() + getTableNameSeparator() + "*");
     RedisReply r(m_db, keys_cmd, REDIS_REPLY_ARRAY);
     redisReply *reply = r.getContext();
     keys.clear();
@@ -85,7 +86,7 @@ void Table::getTableKeys(vector<string> &keys)
     for (unsigned int i = 0; i < reply->elements; i++)
     {
         string key = reply->element[i]->str;
-        auto pos = key.find(':');
+        auto pos = key.find(getTableNameSeparator());
         keys.push_back(key.substr(pos+1));
     }
 }

--- a/common/table.h
+++ b/common/table.h
@@ -29,7 +29,8 @@ typedef std::map<std::string,TableMap> TableDump;
 
 class TableBase {
 public:
-    TableBase(std::string tableName) : m_tableName(tableName) { }
+    TableBase(std::string tableName, std::string tableSeparator = ":")
+        : m_tableName(tableName), m_tableSeparator(tableSeparator) { }
 
     std::string getTableName() const { return m_tableName; }
 
@@ -37,12 +38,19 @@ public:
     std::string getKeyName(std::string key)
     {
         if (key == "") return m_tableName;
-        else return m_tableName + ':' + key;
+        else return m_tableName + m_tableSeparator + key;
+    }
+
+    /* Return the table name separator being used */
+    std::string getTableNameSeparator()
+    {
+        return m_tableSeparator;
     }
 
     std::string getChannelName() { return m_tableName + "_CHANNEL"; }
 private:
     std::string m_tableName;
+    std::string m_tableSeparator;
 };
 
 class TableEntryWritable {
@@ -97,7 +105,7 @@ public:
 
 class Table : public RedisTransactioner, public TableBase, public TableEntryEnumerable {
 public:
-    Table(DBConnector *db, std::string tableName);
+    Table(DBConnector *db, std::string tableName, std::string tableSeparator = ":");
     virtual ~Table() { }
 
     /* Set an entry in the DB directly (op not in use) */

--- a/common/table.h
+++ b/common/table.h
@@ -16,10 +16,8 @@
 
 namespace swss {
 
-#define DEFAULT_TABLE_NAME_SEPARATOR ":"
-#define DEFAULT_KEY_SEPARATOR        ":"
-#define TABLE_NAME_SEPARATOR         "|"
-#define KEY_SEPARATOR                "|"
+#define DEFAULT_TABLE_NAME_SEPARATOR    ":"
+#define CONFIGDB_TABLE_NAME_SEPARATOR   "|"
 
 typedef std::tuple<std::string, std::string> FieldValueTuple;
 #define fvField std::get<0>

--- a/common/table.h
+++ b/common/table.h
@@ -16,6 +16,11 @@
 
 namespace swss {
 
+#define DEFAULT_TABLE_NAME_SEPARATOR ":"
+#define DEFAULT_KEY_SEPARATOR        ":"
+#define TABLE_NAME_SEPARATOR         "|"
+#define KEY_SEPARATOR                "|"
+
 typedef std::tuple<std::string, std::string> FieldValueTuple;
 #define fvField std::get<0>
 #define fvValue std::get<1>
@@ -29,8 +34,13 @@ typedef std::map<std::string,TableMap> TableDump;
 
 class TableBase {
 public:
-    TableBase(std::string tableName, std::string tableSeparator = ":")
-        : m_tableName(tableName), m_tableSeparator(tableSeparator) { }
+    TableBase(std::string tableName, std::string tableSeparator = DEFAULT_TABLE_NAME_SEPARATOR)
+        : m_tableName(tableName), m_tableSeparator(tableSeparator)
+    {
+        const std::string legalSeparators = ":|";
+        if (legalSeparators.find(tableSeparator) == std::string::npos)
+            throw std::invalid_argument("Invalid table name separator");
+    }
 
     std::string getTableName() const { return m_tableName; }
 
@@ -42,7 +52,7 @@ public:
     }
 
     /* Return the table name separator being used */
-    std::string getTableNameSeparator()
+    std::string getTableNameSeparator() const
     {
         return m_tableSeparator;
     }
@@ -105,7 +115,7 @@ public:
 
 class Table : public RedisTransactioner, public TableBase, public TableEntryEnumerable {
 public:
-    Table(DBConnector *db, std::string tableName, std::string tableSeparator = ":");
+    Table(DBConnector *db, std::string tableName, std::string tableSeparator = DEFAULT_TABLE_NAME_SEPARATOR);
     virtual ~Table() { }
 
     /* Set an entry in the DB directly (op not in use) */

--- a/tests/redis_ut.cpp
+++ b/tests/redis_ut.cpp
@@ -399,6 +399,87 @@ TEST(Table, test)
     cout << "Done." << endl;
 }
 
+TEST(Table, table_separator_test)
+{
+    string tableName = "TABLE_UT_TEST";
+    DBConnector db(TEST_VIEW, "localhost", 6379, 0);
+    Table t(&db, tableName, TABLE_NAME_SEPARATOR);
+
+    string tableNameSeparator = t.getTableNameSeparator();
+    ASSERT_STREQ(tableNameSeparator.c_str(), TABLE_NAME_SEPARATOR);
+
+    clearDB();
+    cout << "Starting table manipulations, table name separator is " << TABLE_NAME_SEPARATOR << endl;
+
+    string key_1 = "a";
+    string key_2 = "b";
+    vector<FieldValueTuple> values;
+
+    for (int i = 1; i < 4; i++)
+    {
+        string field = "field_" + to_string(i);
+        string value = to_string(i);
+        values.push_back(make_pair(field, value));
+    }
+
+    cout << "- Step 1. SET" << endl;
+    cout << "Set key [a] field_1:1 field_2:2 field_3:3" << endl;
+    cout << "Set key [b] field_1:1 field_2:2 field_3:3" << endl;
+
+    t.set(key_1, values);
+    t.set(key_2, values);
+
+    cout << "- Step 2. GET_TABLE_CONTENT" << endl;
+    vector<KeyOpFieldsValuesTuple> tuples;
+    t.getTableContent(tuples);
+
+    cout << "Get total " << tuples.size() << " number of entries" << endl;
+    EXPECT_EQ(tuples.size(), (size_t)2);
+
+    for (auto tuple: tuples)
+    {
+        cout << "Get key [" << kfvKey(tuple) << "]" << flush;
+        unsigned int size_v = 3;
+        EXPECT_EQ(kfvFieldsValues(tuple).size(), size_v);
+        for (auto fv: kfvFieldsValues(tuple))
+        {
+            string value_1 = "1", value_2 = "2";
+            cout << " " << fvField(fv) << ":" << fvValue(fv) << flush;
+            if (fvField(fv) == "field_1") EXPECT_EQ(fvValue(fv), value_1);
+            if (fvField(fv) == "field_2") EXPECT_EQ(fvValue(fv), value_2);
+        }
+        cout << endl;
+    }
+
+    cout << "- Step 3. DEL" << endl;
+    cout << "Delete key [a]" << endl;
+    t.del(key_1);
+
+    cout << "- Step 4. GET" << endl;
+    cout << "Get key [a] and key [b]" << endl;
+    EXPECT_EQ(t.get(key_1, values), false);
+    t.get(key_2, values);
+
+    cout << "Get key [b]" << flush;
+    for (auto fv: values)
+    {
+        string value_1 = "1", value_2 = "2";
+        cout << " " << fvField(fv) << ":" << fvValue(fv) << flush;
+        if (fvField(fv) == "field_1") EXPECT_EQ(fvValue(fv), value_1);
+        if (fvField(fv) == "field_2") EXPECT_EQ(fvValue(fv), value_2);
+    }
+    cout << endl;
+
+    cout << "- Step 5. DEL and GET_TABLE_CONTENT" << endl;
+    cout << "Delete key [b]" << endl;
+    t.del(key_2);
+    t.getTableContent(tuples);
+
+    EXPECT_EQ(tuples.size(), unsigned(0));
+
+    cout << "Done." << endl;
+}
+
 TEST(ProducerConsumer, Prefix)
 {
     std::string tableName = "tableName";

--- a/tests/redis_ut.cpp
+++ b/tests/redis_ut.cpp
@@ -403,13 +403,13 @@ TEST(Table, table_separator_test)
 {
     string tableName = "TABLE_UT_TEST";
     DBConnector db(TEST_VIEW, "localhost", 6379, 0);
-    Table t(&db, tableName, TABLE_NAME_SEPARATOR);
+    Table t(&db, tableName, CONFIGDB_TABLE_NAME_SEPARATOR);
 
     string tableNameSeparator = t.getTableNameSeparator();
-    ASSERT_STREQ(tableNameSeparator.c_str(), TABLE_NAME_SEPARATOR);
+    ASSERT_STREQ(tableNameSeparator.c_str(), CONFIGDB_TABLE_NAME_SEPARATOR);
 
     clearDB();
-    cout << "Starting table manipulations, table name separator is " << TABLE_NAME_SEPARATOR << endl;
+    cout << "Starting table manipulations, table name separator is " << CONFIGDB_TABLE_NAME_SEPARATOR << endl;
 
     string key_1 = "a";
     string key_2 = "b";


### PR DESCRIPTION
Default separator is :
Application may choose different table separator like "|" when creating table or using tableBase 

Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>

jipan@ea03d6710aec:/sonic/src/sonic-swss-common$ tests/tests                     
Running main() from gtest_main.cc
[==========] Running 49 tests from 14 test cases.
[----------] Global test environment set-up.
[----------] 8 tests from DBConnector
[ RUN      ] DBConnector.test
Starting 128 producers and consumers on redis
+++++-+-+-++Done. Waiting for all job to finish 1000 jobs.
+++++--+++++++++++++-+++++++++++++---+++++---++++++++++++-++++++++++++-+-+-++++++-++++-++++++-+++++++++++-+-+++-+-+++-++++++++++++++++-++++-+++++++-+-+-++++++++++++-++++-+++++++++++-+++++++++++++--+-+-+++++-+-+++++++-+++++++-+-+-++++++++++++-+-+++-+++++++++++++-++++++++++++++---+++++--++++++++-++++++-+-+-++++++++++++--++++++++-++++-++++++++++++++-++++-++-++++-+-+++++-++++++++-+-+-++++++++++++-+++--+++++++++++++++++-+++++++-+-++++++--++-+++++-+++++++-++-+-+++++++++++++-+--+++++++++++++-++++++++++++++++++---+++--++++++-++++++-++-+-++++++++++-+++++++--++++++++-++++++++++++++-+++++-+++--+-+++-++++++++-+++--++++++++++-++++-+++++++-++++++++++++++++++++-+-+++++++---++-++-++++++++-+--++++++++++-+-++++++++++++++++++-++++++-+++++++++-+++-+++--+++-++-+++---+--+-+-------+-----+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Done.
[       OK ] DBConnector.test (7229 ms)
[ RUN      ] DBConnector.multitable
Starting 128 producers and consumers on redis, using single thread for consumers and thread per producer
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-+++++++++++++++++++++++-+++++++++++++++-+++++++++++++++++-+++++++++++-++++++++-++++++++++++++-+++++++++++++++++-+++++++++++++++++++++++++++--+++-+++++++++++-++++++++++++++-+++++++-+++-+++++-++-++-+-+-+++++++-++++++-++++++++--+++-++-+++++++++++++-++++-+++++-++++++++++++++++++++-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-+++++-++++++++-+--++--+-+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Done.
[       OK ] DBConnector.multitable (12544 ms)
[ RUN      ] DBConnector.notifications
Starting sending notification producer
Got notification from producer
[       OK ] DBConnector.notifications (1025 ms)
[ RUN      ] DBConnector.selectableevent
Starting listening ... 
Got notification
[       OK ] DBConnector.selectableevent (1000 ms)
[ RUN      ] DBConnector.piped_test
Starting 128 producers and consumers on redis
++++++Done. Waiting for all job to finish 1000 jobs.
+++-++++++---++++++-+++++-++-+-+--++++-++++-+++-++-++-++++++++++--++--+++++--+-+-+-----+-----++++++--+++++++++-++--+++-+-+++-++-+-+++-++++++++++-+--+----++++-+-+++--+--++++++---++--+-+-------+--+-++-++++-++-+--+-++++++--++--+++-++++--+-+++-++++++-+++++--++-+-+-+-++--+++--+++++---+--++--++++-+-+-++-++-++--++++-+-+-+-+-+-++++-+-+-++-++-++-+++++-++-++++++++----+++++-++++-+----+-++-+-++++--+-++--+++-++-++-++--++-+++-++---+++--+-+++++--+-+-+++++-+++++++-+++-+-+++++---+--+++-+-+-++-+-++++---++++--+-+++-+-++-++-+++++---+--+++-+++--+--++-++-+++++++-++++---++++-+++--++++--++-+--+++++--+-++-+++--++++-+--++-++-+-++-+++--+-+-++++-+-----+-+--+-+-+-++++-+-++++++-+-+-++-+++++--+-+++++---++++--++-++++---++--+-++-+-++-++-+-+-++-++-+++-+--++-++-++-+++--++-+++-+-+---+-++++-++++-++++++++++--+-+++-++-+-++-+--++---++-++-+-++-++-++-++++----+++++-++-++-+++-+-++++----+-++-+-+-+++--++++++++++-+++++--+-+-+++---+++-++---+-++-++-++--------+---++----+++---++++-+--+---+---+-----++-+------------------+-------+---++++---++++----+-----++-+------+++------+++--+--+-+-+++++++----+-+++-+--+-++--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Done.
[       OK ] DBConnector.piped_test (15115 ms)
[ RUN      ] DBConnector.piped_multitable
Starting 128 producers and consumers on redis, using single thread for consumers and thread per producer
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-++++++++++-+++-+++++++++-+-------+------------+-+-------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Done.
[       OK ] DBConnector.piped_multitable (12145 ms)
[ RUN      ] DBConnector.piped_notifications
Starting sending notification producer
Got notification from producer
[       OK ] DBConnector.piped_notifications (1003 ms)
[ RUN      ] DBConnector.piped_selectableevent
Starting listening ... 
Got notification
[       OK ] DBConnector.piped_selectableevent (1000 ms)
[----------] 8 tests from DBConnector (51061 ms total)

[----------] 3 tests from Table
[ RUN      ] Table.test
Starting table manipulations
- Step 1. SET
Set key [a] field_1:1 field_2:2 field_3:3
Set key [b] field_1:1 field_2:2 field_3:3
- Step 2. GET_TABLE_CONTENT
Get total 2 number of entries
Get key [b] field_1:1 field_2:2 field_3:3
Get key [a] field_1:1 field_2:2 field_3:3
- Step 3. DEL
Delete key [a]
- Step 4. GET
Get key [a] and key [b]
Get key [b] field_1:1 field_2:2 field_3:3
- Step 5. DEL and GET_TABLE_CONTENT
Delete key [b]
Done.
[       OK ] Table.test (2 ms)
[ RUN      ] Table.table_separator_test
Starting table manipulations, table name separator is |
- Step 1. SET
Set key [a] field_1:1 field_2:2 field_3:3
Set key [b] field_1:1 field_2:2 field_3:3
- Step 2. GET_TABLE_CONTENT
Get total 2 number of entries
Get key [b] field_1:1 field_2:2 field_3:3
Get key [a] field_1:1 field_2:2 field_3:3
- Step 3. DEL
Delete key [a]
- Step 4. GET
Get key [a] and key [b]
Get key [b] field_1:1 field_2:2 field_3:3
- Step 5. DEL and GET_TABLE_CONTENT
Delete key [b]
Done.
[       OK ] Table.table_separator_test (2 ms)
[ RUN      ] Table.piped_test
Starting table manipulations
- Step 1. SET
Set key [a] field_1:1 field_2:2 field_3:3
Set key [b] field_1:1 field_2:2 field_3:3
- Step 2. GET_TABLE_CONTENT
Get total 2 number of entries
Get key [b] field_1:1 field_2:2 field_3:3
Get key [a] field_1:1 field_2:2 field_3:3
- Step 3. DEL
Delete key [a]
- Step 4. GET
Get key [a] and key [b]
Get key [b] field_1:1 field_2:2 field_3:3
- Step 5. DEL and GET_TABLE_CONTENT
Delete key [b]
Done.
[       OK ] Table.piped_test (1 ms)
[----------] 3 tests from Table (5 ms total)

[----------] 2 tests from ProducerConsumer
[ RUN      ] ProducerConsumer.Prefix
[       OK ] ProducerConsumer.Prefix (1 ms)
[ RUN      ] ProducerConsumer.piped_Prefix
[       OK ] ProducerConsumer.piped_Prefix (1 ms)
[----------] 2 tests from ProducerConsumer (2 ms total)

[----------] 12 tests from ConsumerStateTable
[ RUN      ] ConsumerStateTable.double_set
[       OK ] ConsumerStateTable.double_set (1003 ms)
[ RUN      ] ConsumerStateTable.set_del
[       OK ] ConsumerStateTable.set_del (1003 ms)
[ RUN      ] ConsumerStateTable.set_del_set
[       OK ] ConsumerStateTable.set_del_set (1007 ms)
[ RUN      ] ConsumerStateTable.singlethread
++++++++++----------++++++++++----------Done. Waiting for all job to finish 1000 jobs.

Done.
[       OK ] ConsumerStateTable.singlethread (186 ms)
[ RUN      ] ConsumerStateTable.test
Starting 128 producers and consumers on redis
+++-++++Done. Waiting for all job to finish 1000 jobs.
++++++++++---+++++++++++-+++++++++-+++++--++-+++-+-+-+-+++++---+-++---------++++++++-------+-++++++++-+++++++--++++++++++++++-++++-++++++++++++-+++++-+-+++++---+-----+++------+---------------------------+-----------+---+-----+---+++++--+-++++++--++++-+++-+++++--+---+-++-+++----++---+-++---+++++-+-------+++-++--+++--+++++-++----+---+-+-+-+-++-+-++--+-+++++--++++++--+-+++----+-+++----++++-+++-+++++---+--+-++++-+--++--+---++---++++---+-++++-+--+--+-+-+-++-++--+-+++---+++++-+++-++-++----++++--++--++++++---+---+++-+++--++----+-+++--+++-++---+---+++-++++----+++--+-++-+-+-+-+-+-++--+++--++-++++-++--++++-++-+--+++--+-++++--+-+-++-+----+-+++--+++--+--++-+++--+-+++----+-++-+-+-++--+-++-+-+-++--+++-+--+-+-+-++++++-+-----++++-+-++-++++----++----++++-++++-++-++---++--+-+++-+-+-++----++-+-++-+-+-+-++--+-++++-+-+--+--++-++-+++----+++-+-+--+-++++-+---++++--+-++++++-++--+-----++-+++-+---++++---++-++++--++-+--++-++--+-++-+-+-+++--+--+++-++--+-+-+++----++-+-++--++++-+++-+-++---++++++++--------++++++-++++--++++-+++--++-++-+-----------+----+------------+-+-+-++-+-++--+++---++-+-+-+++---++++----++++++-+-+---++--+-++-+-++-+-+++-++++------++++-+--+-+-+-++-+-+-++-+---+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Done.
[       OK ] ConsumerStateTable.test (13829 ms)
[ RUN      ] ConsumerStateTable.multitable
Starting 128 producers and consumers on redis, using single thread for consumers and thread per producer
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-+++++++++++++-++++-++++++++-++++++--+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Done.
[       OK ] ConsumerStateTable.multitable (9917 ms)
[ RUN      ] ConsumerStateTable.async_double_set
[       OK ] ConsumerStateTable.async_double_set (1003 ms)
[ RUN      ] ConsumerStateTable.async_set_del
[       OK ] ConsumerStateTable.async_set_del (1004 ms)
[ RUN      ] ConsumerStateTable.async_set_del_set
[       OK ] ConsumerStateTable.async_set_del_set (1003 ms)
[ RUN      ] ConsumerStateTable.async_singlethread
++++++++++----------++++++++++----------Done. Waiting for all job to finish 1000 jobs.

Done.
[       OK ] ConsumerStateTable.async_singlethread (135 ms)
[ RUN      ] ConsumerStateTable.async_test
Starting 128 producers and consumers on redis
++++++++++++Done. Waiting for all job to finish 1000 jobs.
+++++++++++++++++++++-+++++-++++++++++++++++---++++++++++++-++-++++++++++++++++++++++++++++--++-+-+++-+++++++++--+-++++----+--+++----+--++++-+-++-+--+++++-++--+---+---+----+----+---+--------------+------+-++-++++++-----------+-----+++-+++++++++++++-+-+-+-+---+-+-++++-+---+++++-+-+-+++--++-++-+--+-++-++-----------+--------++-++-++------++++--++++-+-+++++-+--+++-++-+++++-+-+-+++-+-++-----------+++++++-----------+-------++++-+----------------------------+--------------+-------+----+-++---+++++++++++---+++++++++++++++++++++++++++++++++++++++++----+++++++++++++++++---++++-++++-+++++++--++++++++++++++++----+---++-+-+---------+-----+----------------------+---+++-------++++--+++++++++++++-+----+++-+-+-+--+---+++-----------------+----+-----+++++------------------+++++++-+++-++---++++++-+++++++++++++++-++----+++++--+---++------+-+++--++---++----+--+--++---+-+++---------------+--++++-++--+-++++++++----++-+++--+++--++-+++++++++---++-+++-+-++++++-+--+++++-+-------+----------++++--+++-+++------++++-+--+++----++----+-------------------------+++---++----++--+-+-+---+++++-+++++++++++++++++++++-+++-++++++++++++-+++++++++++++-++++++++++++-++-+--++----------------+----------------+---------------------------------------------------------+-------++--------+------++-----+--+++++++--+--++----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Done.
[       OK ] ConsumerStateTable.async_test (11339 ms)
[ RUN      ] ConsumerStateTable.async_multitable
Starting 128 producers and consumers on redis, using single thread for consumers and thread per producer
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-++---++-+++++-+--+++++++++++-+-+-++----+-+-----------------------+-------+--+----++--------++++++++-----+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Done.
[       OK ] ConsumerStateTable.async_multitable (7288 ms)
[----------] 12 tests from ConsumerStateTable (48717 ms total)

[----------] 3 tests from TOKENIZE
[ RUN      ] TOKENIZE.basic
[       OK ] TOKENIZE.basic (0 ms)
[ RUN      ] TOKENIZE.IP
[       OK ] TOKENIZE.IP (0 ms)
[ RUN      ] TOKENIZE.IP_2
[       OK ] TOKENIZE.IP_2 (0 ms)
[----------] 3 tests from TOKENIZE (0 ms total)

[----------] 5 tests from TOKENIZEFIRST
[ RUN      ] TOKENIZEFIRST.zero
[       OK ] TOKENIZEFIRST.zero (0 ms)
[ RUN      ] TOKENIZEFIRST.out_of_bound
[       OK ] TOKENIZEFIRST.out_of_bound (0 ms)
[ RUN      ] TOKENIZEFIRST.MAC
[       OK ] TOKENIZEFIRST.MAC (0 ms)
[ RUN      ] TOKENIZEFIRST.IPv6
[       OK ] TOKENIZEFIRST.IPv6 (0 ms)
[ RUN      ] TOKENIZEFIRST.IPv6_2
[       OK ] TOKENIZEFIRST.IPv6_2 (0 ms)
[----------] 5 tests from TOKENIZEFIRST (0 ms total)

[----------] 1 test from TOKENIZEFISRT
[ RUN      ] TOKENIZEFISRT.not_found
[       OK ] TOKENIZEFISRT.not_found (0 ms)
[----------] 1 test from TOKENIZEFISRT (0 ms total)

[----------] 1 test from JSON
[ RUN      ] JSON.test
[       OK ] JSON.test (1 ms)
[----------] 1 test from JSON (1 ms total)

[----------] 1 test from Notifications
[ RUN      ] Notifications.test
[       OK ] Notifications.test (1146 ms)
[----------] 1 test from Notifications (1146 ms total)

[----------] 2 tests from IpAddresses
[ RUN      ] IpAddresses.empty
[       OK ] IpAddresses.empty (0 ms)
[ RUN      ] IpAddresses.contains
[       OK ] IpAddresses.contains (0 ms)
[----------] 2 tests from IpAddresses (0 ms total)

[----------] 4 tests from IpPrefix
[ RUN      ] IpPrefix.ipv4
[       OK ] IpPrefix.ipv4 (0 ms)
[ RUN      ] IpPrefix.ipv6
[       OK ] IpPrefix.ipv6 (0 ms)
[ RUN      ] IpPrefix.compare
[       OK ] IpPrefix.compare (0 ms)
[ RUN      ] IpPrefix.subnet
[       OK ] IpPrefix.subnet (0 ms)
[----------] 4 tests from IpPrefix (0 ms total)

[----------] 3 tests from MacAddress
[ RUN      ] MacAddress.to_string
[       OK ] MacAddress.to_string (0 ms)
[ RUN      ] MacAddress.comparison
[       OK ] MacAddress.comparison (0 ms)
[ RUN      ] MacAddress.parse
[       OK ] MacAddress.parse (0 ms)
[----------] 3 tests from MacAddress (0 ms total)

[----------] 2 tests from CONVERTER
[ RUN      ] CONVERTER.positive
[       OK ] CONVERTER.positive (0 ms)
[ RUN      ] CONVERTER.negative
[       OK ] CONVERTER.negative (1 ms)
[----------] 2 tests from CONVERTER (1 ms total)

[----------] 2 tests from EXEC
[ RUN      ] EXEC.result
[       OK ] EXEC.result (8 ms)
[ RUN      ] EXEC.error
[       OK ] EXEC.error (2 ms)
[----------] 2 tests from EXEC (10 ms total)

[----------] Global test environment tear-down
[==========] 49 tests from 14 test cases ran. (100943 ms total)
[  PASSED  ] 49 tests.
jipan@ea03d6710aec:/sonic/src/sonic-swss-common$ 
