### PR TITLE
Clear stdout string before filling it with command output

### DIFF
--- a/common/exec.cpp
+++ b/common/exec.cpp
@@ -24,6 +24,7 @@ int exec(const string &cmd, string &stdout)
         throw runtime_error(errmsg);
     }
 
+    stdout.clear();
     while (!feof(pipe))
     {
         if (fgets(buffer.data(), buffsz, pipe) != NULL)


### PR DESCRIPTION

Clear stdout string before filling it with command output, so the stdout is guaranteed to hold clean result and doesn't reply on user to clean it explicitly.  It is convenient when application wants run exec multiple times in a function.

Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>


jipan@ea03d6710aec:/sonic/src/sonic-swss-common$ tests/tests --gtest_filter=EXEC 
Running main() from gtest_main.cc
Note: Google Test filter = EXEC*
[==========] Running 2 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 2 tests from EXEC
[ RUN      ] EXEC.result
[       OK ] EXEC.result (5 ms)
[ RUN      ] EXEC.error
[       OK ] EXEC.error (1 ms)
[----------] 2 tests from EXEC (6 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test case ran. (6 ms total)
[  PASSED  ] 2 tests.
