### PR TITLE
use std::pair instead of std::tuple for FieldValueTuple

### DIFF
--- a/common/producerstatetable.cpp
+++ b/common/producerstatetable.cpp
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <tuple>
 #include <sstream>
+#include <utility>
 #include <algorithm>
 #include "redisreply.h"
 #include "table.h"

--- a/common/rediscommand.h
+++ b/common/rediscommand.h
@@ -1,10 +1,11 @@
 #pragma once
 #include <string.h>
+#include <utility>
 #include <tuple>
 
 namespace swss {
 
-typedef std::tuple<std::string, std::string> FieldValueTuple;
+typedef std::pair<std::string, std::string> FieldValueTuple;
 #define fvField std::get<0>
 #define fvValue std::get<1>
 typedef std::tuple<std::string, std::string, std::vector<FieldValueTuple> > KeyOpFieldsValuesTuple;

--- a/common/table.cpp
+++ b/common/table.cpp
@@ -35,7 +35,7 @@ bool Table::get(string key, vector<FieldValueTuple> &values)
 
     for (unsigned int i = 0; i < reply->elements; i += 2)
     {
-        values.push_back(make_tuple(stripSpecialSym(reply->element[i]->str),
+        values.push_back(make_pair(stripSpecialSym(reply->element[i]->str),
                                     reply->element[i + 1]->str));
     }
 

--- a/common/table.h
+++ b/common/table.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <queue>
 #include <tuple>
+#include <utility>
 #include <map>
 #include <deque>
 #include "hiredis/hiredis.h"
@@ -19,7 +20,7 @@ namespace swss {
 #define DEFAULT_TABLE_NAME_SEPARATOR    ":"
 #define CONFIGDB_TABLE_NAME_SEPARATOR   "|"
 
-typedef std::tuple<std::string, std::string> FieldValueTuple;
+typedef std::pair<std::string, std::string> FieldValueTuple;
 #define fvField std::get<0>
 #define fvValue std::get<1>
 typedef std::tuple<std::string, std::string, std::vector<FieldValueTuple> > KeyOpFieldsValuesTuple;


### PR DESCRIPTION
prepare to introduce swig support since swig does not support std::tuple