### PR TITLE
Add getTimestamp() common function

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -48,7 +48,8 @@ libswsscommon_la_SOURCES = \
     portmap.cpp               \
     tokenize.cpp              \
     exec.cpp                  \
-    subscriberstatetable.cpp
+    subscriberstatetable.cpp  \
+    timestamp.cpp
 
 libswsscommon_la_CXXFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(LIBNL_CFLAGS)
 libswsscommon_la_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(LIBNL_CPPFLAGS)

--- a/common/timestamp.cpp
+++ b/common/timestamp.cpp
@@ -1,0 +1,22 @@
+#include <unistd.h>
+#include <sys/time.h>
+#include <ctime>
+#include "timestamp.h"
+
+using namespace std;
+
+namespace swss {
+
+string getTimestamp()
+{
+    char buffer[64];
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+
+    size_t size = strftime(buffer, 32 ,"%Y-%m-%d.%T.", localtime(&tv.tv_sec));
+    snprintf(&buffer[size], 32, "%06ld", tv.tv_usec);
+
+    return string(buffer);
+}
+
+}

--- a/common/timestamp.h
+++ b/common/timestamp.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <string>
+
+namespace swss {
+
+std::string getTimestamp();
+
+}


### PR DESCRIPTION
Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>

This is to move the getTimestamp() function defined in swss saihelper.cpp and sai_redis_record.cpp to swss-common to avoid duplications.   No change to the function code itself.

Users of getTimestamp() also include Orch class in swss.

