### PR TITLE
add support for SubscriberStateTable in python library

### DIFF
--- a/pyext/swsscommon.i
+++ b/pyext/swsscommon.i
@@ -3,6 +3,8 @@
 %include <std_string.i>
 %include <std_vector.i>
 %include <std_pair.i>
+%include <typemaps.i>
+
 %template(FieldValuePair) std::pair<std::string, std::string>;
 %template(FieldValuePairs) std::vector<std::pair<std::string, std::string>>;
 %apply std::string& OUTPUT {std::string &key};
@@ -25,6 +27,20 @@
 #include "notificationconsumer.h"
 %}
 
+%apply int *OUTPUT {int *fd};
+%typemap(in, numinputs=0) swss::Selectable ** (swss::Selectable *temp) {
+    $1 = &temp;
+}
+%typemap(argout) swss::Selectable ** {
+    PyObject* temp = NULL;
+    if (!PyList_Check($result)) {
+        temp = $result;
+        $result = PyList_New(1);
+        PyList_SetItem($result, 0, temp);
+    }
+    temp = SWIG_NewPointerObj(*$1, SWIGTYPE_p_swss__Selectable, SWIG_POINTER_OWN);
+    PyList_Append($result, temp);
+}
 %include "schema.h"
 %include "dbconnector.h"
 %include "selectable.h"

--- a/tests/test_redis_ut.py
+++ b/tests/test_redis_ut.py
@@ -12,3 +12,20 @@ def test_ProducerStateTable():
     assert op == "SET"
     assert len(cfvs) == 1
     assert cfvs[0] == ('a', 'b')
+
+def test_SubscriberStateTable():
+    db = swsscommon.DBConnector(0, "localhost", 6379, 0)
+    t = swsscommon.Table(db, "testsst", '|')
+    sel = swsscommon.Select()
+    cst = swsscommon.SubscriberStateTable(db, "testsst")
+    sel.addSelectable(cst)
+    fvs = swsscommon.FieldValuePairs([('a','b')])
+    t.set("aaa", fvs)
+    (state, c, fd) = sel.select()
+    assert state == swsscommon.Select.OBJECT
+    cfvs = swsscommon.FieldValuePairs([])
+    (key, op) = cst.pop(cfvs)
+    assert key == "aaa"
+    assert op == "SET"
+    assert len(cfvs) == 1
+    assert cfvs[0] == ('a', 'b')


### PR DESCRIPTION
```
lgh@ddf90f25c0d1:/data/sonic/sonic-swss-common$ py.test tests/
================================================== test session starts ===================================================
platform linux2 -- Python 2.7.9 -- py-1.4.25 -- pytest-2.6.3
plugins: cov
collected 2 items 

tests/test_redis_ut.py ..

================================================ 2 passed in 0.04 seconds ================================================
```