### PR TITLE
Add VLAN_MEMBER state table

### DIFF
--- a/common/schema.h
+++ b/common/schema.h
@@ -105,7 +105,9 @@ namespace swss {
 #define STATE_PORT_TABLE_NAME           "PORT_TABLE"
 #define STATE_LAG_TABLE_NAME            "LAG_TABLE"
 #define STATE_VLAN_TABLE_NAME           "VLAN_TABLE"
+#define STATE_VLAN_MEMBER_TABLE_NAME    "VLAN_MEMBER_TABLE"
 #define STATE_INTERFACE_TABLE_NAME      "INTERFACE_TABLE"
+#define STATE_FDB_TABLE_NAME            "FDB_TABLE"
 
 /***** MISC *****/
 

--- a/common/schema.h
+++ b/common/schema.h
@@ -107,7 +107,6 @@ namespace swss {
 #define STATE_VLAN_TABLE_NAME           "VLAN_TABLE"
 #define STATE_VLAN_MEMBER_TABLE_NAME    "VLAN_MEMBER_TABLE"
 #define STATE_INTERFACE_TABLE_NAME      "INTERFACE_TABLE"
-#define STATE_FDB_TABLE_NAME            "FDB_TABLE"
 
 /***** MISC *****/
 


### PR DESCRIPTION
I've added table identifier for one more state table: VLAN_MEMBER.
I need them to improve current Fast-Reboot procedure, by applying saved FDB and ARP entries right after a VLAN_MEMBER interface was added.