### PR TITLE
golang swig support for swss-common, unit test included

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ config.status
 configure
 libtool
 Makefile.in
+!goext/Makefile.in
 stamp-h1
 **/.deps/
 **/.libs/

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = common pyext
+SUBDIRS = common pyext goext
 
 ACLOCAL_AMFLAGS = -I m4
 

--- a/common/consumertablebase.cpp
+++ b/common/consumertablebase.cpp
@@ -18,6 +18,11 @@ void ConsumerTableBase::pop(KeyOpFieldsValuesTuple &kco, std::string prefix)
     pop(kfvKey(kco), kfvOp(kco), kfvFieldsValues(kco), prefix);
 }
 
+void ConsumerTableBase::pop(KeyOpTuple &ko, std::vector<FieldValueTuple> &fvs, std::string prefix)
+{
+    pop(koKey(ko), koOp(ko), fvs, prefix);
+}
+
 void ConsumerTableBase::pop(std::string &key, std::string &op, std::vector<FieldValueTuple> &fvs, std::string prefix)
 {
     if (m_buffer.empty())

--- a/common/consumertablebase.h
+++ b/common/consumertablebase.h
@@ -17,6 +17,7 @@ public:
     void pop(KeyOpFieldsValuesTuple &kco, std::string prefix = EMPTY_PREFIX);
 
     void pop(std::string &key, std::string &op, std::vector<FieldValueTuple> &fvs, std::string prefix = EMPTY_PREFIX);
+    void pop(KeyOpTuple &ko, std::vector<FieldValueTuple> &fvs, std::string prefix = EMPTY_PREFIX);
 
 protected:
 

--- a/common/select.cpp
+++ b/common/select.cpp
@@ -38,6 +38,11 @@ void Select::addFd(int fd)
     m_fds.push_back(fd);
 }
 
+bool Select::isSelected(Selectable *selectable)
+{
+    return (selectable == m_selected);
+}
+
 int Select::select(Selectable **c, int *fd, unsigned int timeout)
 {
     SWSS_LOG_ENTER();
@@ -49,6 +54,7 @@ int Select::select(Selectable **c, int *fd, unsigned int timeout)
 
     FD_ZERO(&fs);
     *c = NULL;
+    m_selected = NULL;
     *fd = 0;
     if (timeout != numeric_limits<unsigned int>::max())
         pTimeout = &t;
@@ -62,6 +68,7 @@ int Select::select(Selectable **c, int *fd, unsigned int timeout)
             return Select::ERROR;
         else if (err == Selectable::DATA) {
             *c = i;
+            m_selected = *c;
             return Select::OBJECT;
         }
         /* else, timeout = no data */
@@ -91,6 +98,7 @@ int Select::select(Selectable **c, int *fd, unsigned int timeout)
         {
             i->readMe();
             *c = i;
+            m_selected = *c;
             return Select::OBJECT;
         }
 

--- a/common/select.h
+++ b/common/select.h
@@ -32,9 +32,12 @@ public:
     };
     int select(Selectable **c, int *fd, unsigned int timeout = std::numeric_limits<unsigned int>::max());
 
+    /* Check whether the Selectable object is the one which has pending event */
+    bool isSelected(Selectable *selectable);
 private:
     std::vector<Selectable * > m_objects;
     std::vector<int> m_fds;
+    Selectable *m_selected;
 };
 
 }

--- a/common/table.h
+++ b/common/table.h
@@ -23,6 +23,9 @@ namespace swss {
 typedef std::pair<std::string, std::string> FieldValueTuple;
 #define fvField std::get<0>
 #define fvValue std::get<1>
+typedef std::pair<std::string, std::string> KeyOpTuple;
+#define koKey std::get<0>
+#define koOp std::get<1>
 typedef std::tuple<std::string, std::string, std::vector<FieldValueTuple> > KeyOpFieldsValuesTuple;
 #define kfvKey    std::get<0>
 #define kfvOp     std::get<1>

--- a/configure.ac
+++ b/configure.ac
@@ -89,6 +89,7 @@ AC_CONFIG_FILES([
     Makefile
     common/Makefile
     pyext/Makefile
+    goext/Makefile
     tests/Makefile
 ])
 

--- a/goext/Makefile.in
+++ b/goext/Makefile.in
@@ -1,0 +1,111 @@
+GOPATH = /sonic/go
+
+# SRCDIR is the relative path to the current source directory
+# - For in-source-tree builds, SRCDIR with be either '' or './', but
+#   '../' for the test suites that build in a subdir (e.g. C#, Java)
+# - For out-of-source-tree builds, SRCDIR will be a relative
+#   path ending with a '/'
+SRCDIR = ../common
+
+SRCDIR_CXXSRCS := $(wildcard $(SRC_DIR)/*.cpp) $(wildcard $(SRC_DIR)/*.h)
+
+
+ifeq (,$(DEBUG))
+DBGFLAGS = -ggdb -DDEBUG
+else
+DBGFLAGS = -g -DNDEBUG
+endif
+
+CC         = @CC@
+CXX        = @CXX@
+CPPFLAGS   = $(DBGFLAGS) @LIBNL_CFLAGS@
+CFLAGS     =
+CXXFLAGS   = $(DBGFLAGS) @CXXFLAGS@  @CFLAGS_COMMON@ \
+             -Wno-packed -Wno-cast-qual -Wno-unused-function -fpermissive -Wno-error
+LDFLAGS    = @LDFLAGS@
+SRCS       =
+INCLUDES   =
+LIBS       = @LIBS@ -lpthread $(LIBNL_LIBS)
+INTERFACE  = swsscommon.i
+INTERFACEDIR  =
+INTERFACEPATH = $(INTERFACEDIR)$(INTERFACE)
+SWIGOPT    =
+
+
+SWIG_LIB_DIR = ./swig/Lib
+SWIGEXE    = ./swig/swig
+SWIG_LIB_SET = env SWIG_LIB=$(SWIG_LIB_DIR)
+SWIGTOOL   =
+SWIG       = $(SWIG_LIB_SET) $(SWIGTOOL) $(SWIGEXE)
+
+
+IWRAP      = $(INTERFACE:.i=_wrap.i)
+ISRCS      = $(IWRAP:.i=.c)
+ICXXSRCS   = $(IWRAP:.i=.cxx)
+IOBJS      = $(IWRAP:.i=.o)
+
+GO = /usr/local/go/bin/go
+GOC = compile
+GOOPT = -intgosize 64
+GOVERSIONOPTION = version
+
+GOSRCS = $(INTERFACE:.i=.go)
+
+REPODIR := $(shell git remote -v | grep fetch | cut -f 3- -d / | cut -f 1 -d ' ')
+GOPATHDIR = $(GOPATH)/src/$(REPODIR)
+
+all: build
+
+build: $(SRCDIR_CXXSRCS)
+	# To use swig version 3.0.12 .
+	if [ ! -x $(SWIGEXE) ]; then \
+		git clone https://github.com/swig/swig.git; \
+		cd swig && git checkout rel-3.0.12 && ./autogen.sh && ./configure && make; cd - ; \
+	fi
+
+	$(SWIG) -go -c++ -cgo $(GOOPT) $(GOSWIGARG) $(SWIGOPT)  -I$(SRCDIR) -o $(ICXXSRCS) $(INTERFACEPATH)
+
+	mkdir -p $(GOPATH)/src/$(REPODIR) 2>/dev/null || true
+	rm -f -r $(GOPATHDIR)/*
+	cp $(ICXXSRCS) $(GOPATHDIR)/
+	if test -f $(IWRAP:.i=.h); then \
+	  cp $(IWRAP:.i=.h) $(GOPATHDIR)/; \
+	fi
+
+	rsync -av  --exclude '*.cpp' --exclude '*.o'  --exclude '*.lo' $(SRCDIR) $(GOPATHDIR)/;
+	rsync -av  --exclude 'loglevel.cpp' $(SRCDIR)/*.cpp $(GOPATHDIR)/;
+
+	cp $(GOSRCS) $(GOPATHDIR)/
+	export GOPATH; \
+	CGO_CPPFLAGS="$(CPPFLAGS) $(INCLUDES) -I $(GOPATHDIR) -I $(GOPATHDIR)/common"; \
+	export CGO_CPPFLAGS; \
+	CGO_CFLAGS="$(CFLAGS)"; \
+	export CGO_CFLAGS; \
+	CGO_CXXFLAGS="$(CXXFLAGS)"; \
+	export CGO_CXXFLAGS; \
+	CGO_LDFLAGS="$(LDFLAGS) -lm $(LIBS)"; \
+	export CGO_LDFLAGS; \
+	(cd $(GOPATHDIR) && GOPATH=$(GOPATH) $(GO) install -x)
+
+install:
+	@echo "install: Not doing anything!!"
+
+uninstall:
+	@echo "uninstall: Not doing anything!!"
+
+# -----------------------------------------------------------------
+# Version display
+# -----------------------------------------------------------------
+
+version:
+	$(GO) $(GOVERSIONOPTION)
+
+# -----------------------------------------------------------------
+# Cleaning the Go examples
+# -----------------------------------------------------------------
+
+clean:
+	rm -f *_wrap* *_gc* *.gox .~* $(GOSRCS)
+	rm -rf $(GOPATHDIR)
+	rm -f core
+	rm -f *.o *.[568] *.a *.so

--- a/goext/Makefile.in
+++ b/goext/Makefile.in
@@ -1,4 +1,4 @@
-GOPATH = /sonic/go
+GOPATH = /tmp/sonic/go
 
 # SRCDIR is the relative path to the current source directory
 # - For in-source-tree builds, SRCDIR with be either '' or './', but
@@ -72,8 +72,8 @@ build: $(SRCDIR_CXXSRCS)
 	  cp $(IWRAP:.i=.h) $(GOPATHDIR)/; \
 	fi
 
-	rsync -av  --exclude '*.cpp' --exclude '*.o'  --exclude '*.lo' $(SRCDIR) $(GOPATHDIR)/;
-	rsync -av  --exclude 'loglevel.cpp' $(SRCDIR)/*.cpp $(GOPATHDIR)/;
+	@rsync -av  --exclude '*.cpp' --exclude '*.o'  --exclude '*.lo' $(SRCDIR) $(GOPATHDIR)/;
+	@rsync -av  --exclude 'loglevel.cpp' $(SRCDIR)/*.cpp $(GOPATHDIR)/;
 
 	cp $(GOSRCS) $(GOPATHDIR)/
 	export GOPATH; \

--- a/goext/swsscommon.i
+++ b/goext/swsscommon.i
@@ -1,0 +1,78 @@
+%module swsscommon
+
+%{
+#include <string>
+#include "schema.h"
+#include "dbconnector.h"
+#include "select.h"
+#include "selectable.h"
+#include "rediscommand.h"
+#include "table.h"
+#include "redispipeline.h"
+#include "redisselect.h"
+#include "redistran.h"
+#include "producerstatetable.h"
+#include "consumertablebase.h"
+#include "consumerstatetable.h"
+#include "subscriberstatetable.h"
+#include "notificationconsumer.h"
+%}
+
+%include <typemaps.i>
+%include "std_string.i"
+%include "std_vector.i"
+%include <std_pair.i>
+
+namespace std {
+	%template(StringPair) std::pair<std::string, std::string>;
+	%template(FieldValuePairs) std::vector<std::pair<std::string, std::string>>;
+	%template(VectorString) std::vector<std::string>;
+}
+
+%apply int *OUTPUT {int *fd};
+
+/* Ignoring this input argument, but using local temp */
+%typemap(in, numinputs=0) swss::Selectable ** (swss::Selectable *temp) {
+    $1 = &temp;
+}
+
+/* Have not figured out a way to have the argout data returned in $result for golang */
+/*
+%typemap(argout) swss::Selectable ** {
+    PyObject* temp = NULL;
+    if (!PyList_Check($result)) {
+        temp = $result;
+        $result = PyList_New(1);
+        PyList_SetItem($result, 0, temp);
+    }
+    temp = SWIG_NewPointerObj(*$1, SWIGTYPE_p_swss__Selectable, SWIG_POINTER_OWN);
+    PyList_Append($result, temp);
+}
+*/
+
+%include "schema.h"
+%include "dbconnector.h"
+%include "selectable.h"
+%include "select.h"
+%include "rediscommand.h"
+%include "redispipeline.h"
+%include "redisselect.h"
+%include "redistran.h"
+
+%include "table.h"
+
+%include "producerstatetable.h"
+
+/*
+ * Not taking effect,  it crashes if non-const string reference is passed down.
+ */
+%apply std::string& OUTPUT {std::string &key};
+%apply std::string& OUTPUT {std::string &op};
+
+%include "consumertablebase.h"
+%clear std::string &key;
+%clear std::string &op;
+
+%include "consumerstatetable.h"
+%include "subscriberstatetable.h"
+%include "notificationconsumer.h"

--- a/tests/redis_ut_test.go
+++ b/tests/redis_ut_test.go
@@ -1,0 +1,169 @@
+package redis_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+
+	swsscommon "github.com/Azure/sonic-swss-common"
+)
+
+func Test_Table(t *testing.T) {
+	db := swsscommon.NewDBConnector(0, "localhost", 6379, uint(0))
+	defer swsscommon.DeleteDBConnector(db)
+	tbl := swsscommon.NewTable(db, "abc")
+	defer swsscommon.DeleteTable(tbl)
+	fvps := swsscommon.NewFieldValuePairs()
+	defer swsscommon.DeleteFieldValuePairs(fvps)
+	fvp1 := swsscommon.NewStringPair("a", "b")
+	defer swsscommon.DeleteStringPair(fvp1)
+	fvp2 := swsscommon.NewStringPair("c", "d")
+	defer swsscommon.DeleteStringPair(fvp2)
+
+	fvps.Add(fvp1)
+	fvps.Add(fvp2)
+
+	tbl.Set("aaa", fvps)
+
+	keys := swsscommon.NewVectorString()
+	defer swsscommon.DeleteVectorString(keys)
+	tbl.GetKeys(keys)
+	if keys.Size() != 1 {
+		t.Error("Wrong keys size: ", keys.Size())
+	}
+
+	if keys.Get(0) != "aaa" {
+		t.Error("Wrong keys: ", keys.Get(0))
+	}
+
+	vpsr := swsscommon.NewFieldValuePairs()
+	defer swsscommon.DeleteFieldValuePairs(vpsr)
+	ret := tbl.Get("aaa", vpsr)
+	if ret != true {
+		t.Error("table get failed")
+	}
+
+	if vpsr.Size() != 2 {
+		t.Error("Wrong FieldValuePairs size: ", vpsr.Size())
+	}
+
+	fp0 := vpsr.Get(0)
+	if fp0.GetFirst() != "a" || fp0.GetSecond() != "b" {
+		t.Error("Wrong First FieldValuePair ")
+	}
+
+	fp1 := vpsr.Get(1)
+	if fp1.GetFirst() != "c" || fp1.GetSecond() != "d" {
+		t.Error("Wrong First FieldValuePair ")
+	}
+	tbl.Del("aaa")
+}
+
+func Test_ProducerStateTable(t *testing.T) {
+	db := swsscommon.NewDBConnector(0, "localhost", 6379, uint(0))
+	defer swsscommon.DeleteDBConnector(db)
+	ps := swsscommon.NewProducerStateTable(db, "abc")
+	defer swsscommon.DeleteProducerStateTable(ps)
+	cs := swsscommon.NewConsumerStateTable(db, "abc")
+	defer swsscommon.DeleteConsumerStateTable(cs)
+
+	fvps := swsscommon.NewFieldValuePairs()
+	defer swsscommon.DeleteFieldValuePairs(fvps)
+	fvp1 := swsscommon.NewStringPair("a", "b")
+	defer swsscommon.DeleteStringPair(fvp1)
+	fvps.Add(fvp1)
+
+	ps.Set("aaa", fvps)
+
+	vpsr := swsscommon.NewFieldValuePairs()
+	defer swsscommon.DeleteFieldValuePairs(vpsr)
+	// Reusing FieldValuePair for KeyOpTuple as std::pair<std::string, std::string>
+	ko := swsscommon.NewStringPair()
+	defer swsscommon.DeleteStringPair(ko)
+	//var key, op string
+	cs.Pop(ko, vpsr)
+	if ko.GetFirst() != "aaa" {
+		t.Error("Wrong key: ", ko.GetFirst())
+	}
+
+	if ko.GetSecond() != "SET" {
+		t.Error("Wrong op: ", ko.GetSecond())
+	}
+
+	if vpsr.Size() != 1 {
+		t.Error("Wrong FieldValuePairs size: ", vpsr.Size())
+	}
+
+	fp0 := vpsr.Get(0)
+	if fp0.GetFirst() != "a" || fp0.GetSecond() != "b" {
+		t.Error("Wrong FieldValuePair ")
+	}
+}
+
+func Test_SubscriberStateTable(t *testing.T) {
+	os.Setenv("PATH", "/usr/bin:/sbin:/bin")
+	cmd := exec.Command("redis-cli", "config", "set", "notify-keyspace-events", "KEA")
+	output, err := cmd.Output()
+	if err != nil {
+		os.Stderr.WriteString(err.Error())
+		fmt.Println(string(output))
+	}
+
+	db := swsscommon.NewDBConnector(0, "localhost", 6379, uint(0))
+	defer swsscommon.DeleteDBConnector(db)
+	tbl := swsscommon.NewTable(db, "testsst", "|")
+	defer swsscommon.DeleteTable(tbl)
+
+	sel := swsscommon.NewSelect()
+	defer swsscommon.DeleteSelect(sel)
+
+	cst := swsscommon.NewSubscriberStateTable(db, "testsst")
+	defer swsscommon.DeleteSubscriberStateTable(cst)
+
+	sel.AddSelectable(cst.SwigGetSelectable())
+
+	fvs := swsscommon.NewFieldValuePairs()
+	defer swsscommon.DeleteFieldValuePairs(fvs)
+	fvp1 := swsscommon.NewStringPair("a", "b")
+	defer swsscommon.DeleteStringPair(fvp1)
+	fvs.Add(fvp1)
+
+	tbl.Set("aaa", fvs)
+
+	//const timout = 1000
+	// s := swsscommon.NewRedisSelect()
+	//defer swsscommon.DeleteRedisSelect(s)
+	fd := []int{0}
+	var timeout uint = 1000
+	//ret := sel.Xselect(s.SwigGetSelectable(), fd, timeout)
+	ret := sel.Xselect(fd, timeout)
+
+	if ret != swsscommon.SelectOBJECT {
+		t.Error("Expecting : ", swsscommon.SelectOBJECT)
+	}
+
+	vpsr := swsscommon.NewFieldValuePairs()
+	defer swsscommon.DeleteFieldValuePairs(vpsr)
+	// Reusing FieldValuePair for KeyOpTuple as std::pair<std::string, std::string>
+	ko := swsscommon.NewStringPair()
+	defer swsscommon.DeleteStringPair(ko)
+	cst.Pop(ko, vpsr)
+
+	if ko.GetFirst() != "aaa" {
+		t.Error("Wrong key: ", ko.GetFirst())
+	}
+
+	if ko.GetSecond() != "SET" {
+		t.Error("Wrong op: ", ko.GetSecond())
+	}
+
+	if vpsr.Size() != 1 {
+		t.Error("Wrong FieldValuePairs size: ", vpsr.Size())
+	}
+
+	fp0 := vpsr.Get(0)
+	if fp0.GetFirst() != "a" || fp0.GetSecond() != "b" {
+		t.Error("Wrong FieldValuePair ")
+	}
+}

--- a/tests/redis_ut_test.go
+++ b/tests/redis_ut_test.go
@@ -78,7 +78,7 @@ func Test_ProducerStateTable(t *testing.T) {
 
 	vpsr := swsscommon.NewFieldValuePairs()
 	defer swsscommon.DeleteFieldValuePairs(vpsr)
-	// Reusing FieldValuePair for KeyOpTuple as std::pair<std::string, std::string>
+
 	ko := swsscommon.NewStringPair()
 	defer swsscommon.DeleteStringPair(ko)
 	//var key, op string
@@ -131,21 +131,21 @@ func Test_SubscriberStateTable(t *testing.T) {
 
 	tbl.Set("aaa", fvs)
 
-	//const timout = 1000
-	// s := swsscommon.NewRedisSelect()
-	//defer swsscommon.DeleteRedisSelect(s)
 	fd := []int{0}
 	var timeout uint = 1000
-	//ret := sel.Xselect(s.SwigGetSelectable(), fd, timeout)
 	ret := sel.Xselect(fd, timeout)
 
 	if ret != swsscommon.SelectOBJECT {
 		t.Error("Expecting : ", swsscommon.SelectOBJECT)
 	}
 
+	if !sel.IsSelected(cst.SwigGetSelectable()) {
+		t.Error("Invalid Selectable object ")
+	}
+
 	vpsr := swsscommon.NewFieldValuePairs()
 	defer swsscommon.DeleteFieldValuePairs(vpsr)
-	// Reusing FieldValuePair for KeyOpTuple as std::pair<std::string, std::string>
+
 	ko := swsscommon.NewStringPair()
 	defer swsscommon.DeleteStringPair(ko)
 	cst.Pop(ko, vpsr)


### PR DESCRIPTION
Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>

jipan@e92e7f4f35e8:/sonic/src/sonic-swss-common/tests$ GOPATH=/tmp/sonic/go go test -v redis_ut_test.go
=== RUN   Test_Table
--- PASS: Test_Table (0.00s)
=== RUN   Test_ProducerStateTable
--- PASS: Test_ProducerStateTable (0.00s)
=== RUN   Test_SubscriberStateTable
--- PASS: Test_SubscriberStateTable (0.07s)
PASS
ok  	command-line-arguments	0.071s
