### PR TITLE
[table]: return correct key when table name has separator

### DIFF
--- a/common/table.cpp
+++ b/common/table.cpp
@@ -88,8 +88,7 @@ void Table::getKeys(vector<string> &keys)
     for (unsigned int i = 0; i < reply->elements; i++)
     {
         string key = reply->element[i]->str;
-        auto pos = key.find(getTableNameSeparator());
-        keys.push_back(key.substr(pos+1));
+        keys.push_back(key.substr(getTableName().length()+1));
     }
 }
 


### PR DESCRIPTION
When table name has separator, e.g., ASIC_DB:ROUTE and
the table name separator is ':'. getKeys will return ROUTE:key
instead of key.