### PR TITLE
API to return broadcast IP

### DIFF
--- a/common/ipprefix.h
+++ b/common/ipprefix.h
@@ -24,6 +24,35 @@ public:
         return m_ip;
     }
 
+    inline IpAddress getBroadcastIp() const
+    {
+        switch (m_ip.getIp().family)
+        {
+            case AF_INET:
+            {
+                return IpAddress((m_ip.getV4Addr()) | ~(getMask().getV4Addr()));
+            }
+            case AF_INET6:
+            {
+                ip_addr_t ipa;
+                ipa.family = AF_INET6;
+                const uint8_t *prefix = m_ip.getV6Addr();
+                IpAddress ip6mask = getMask();
+                const uint8_t *mask = ip6mask.getV6Addr();
+
+                for (int i = 0; i < 16; ++i)
+                {
+                    ipa.ip_addr.ipv6_addr[i] = (uint8_t)(prefix[i] | ~mask[i]);
+                }
+                return IpAddress(ipa);
+            }
+            default:
+            {
+                throw std::logic_error("Invalid family");
+            }
+        }
+    }
+
     inline IpAddress getMask() const
     {
         switch (m_ip.getIp().family)

--- a/tests/ipprefix_ut.cpp
+++ b/tests/ipprefix_ut.cpp
@@ -13,6 +13,14 @@ TEST(IpPrefix, ipv4)
     IpPrefix ip2("1.1.1.1/32");
     IpAddress mask2("255.255.255.255");
     EXPECT_EQ(ip2.getMask(), mask2);
+
+    IpPrefix ip3("192.168.0.1/27");
+    IpAddress bcast3("192.168.0.31");
+    EXPECT_EQ(ip3.getBroadcastIp(), bcast3);
+
+    IpPrefix ip4("10.1.1.1/24");
+    IpAddress bcast4("10.1.1.255");
+    EXPECT_EQ(ip4.getBroadcastIp(), bcast4);
 }
 
 TEST(IpPrefix, ipv6)
@@ -36,14 +44,17 @@ TEST(IpPrefix, ipv6)
     IpPrefix ipp64("2001:4898:f0:f153:357c:77b2:49c9:627c/64");
     EXPECT_EQ(ipp64.getIp().to_string(), "2001:4898:f0:f153:357c:77b2:49c9:627c");
     EXPECT_EQ(ipp64.getMask().to_string(), "ffff:ffff:ffff:ffff::");
+    EXPECT_EQ(ipp64.getBroadcastIp().to_string(), "2001:4898:f0:f153:ffff:ffff:ffff:ffff");
     
     IpPrefix ipp65("2001:4898:f0:f153:357c:77b2:49c9:627c/65");
     EXPECT_EQ(ipp65.getIp().to_string(), "2001:4898:f0:f153:357c:77b2:49c9:627c");
     EXPECT_EQ(ipp65.getMask().to_string(), "ffff:ffff:ffff:ffff:8000::");
+    EXPECT_EQ(ipp65.getBroadcastIp().to_string(), "2001:4898:f0:f153:7fff:ffff:ffff:ffff");
     
     IpPrefix ipp127("2001:4898:f0:f153:357c:77b2:49c9:627c/127");
     EXPECT_EQ(ipp127.getIp().to_string(), "2001:4898:f0:f153:357c:77b2:49c9:627c");
     EXPECT_EQ(ipp127.getMask().to_string(), "ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe");
+    EXPECT_EQ(ipp127.getBroadcastIp().to_string(), "2001:4898:f0:f153:357c:77b2:49c9:627d");
     
     IpPrefix ipp128("2001:4898:f0:f153:357c:77b2:49c9:627c/128");
     EXPECT_EQ(ipp128.getIp().to_string(), "2001:4898:f0:f153:357c:77b2:49c9:627c");


### PR DESCRIPTION
API to return broadcast IP for any given subnet. 

Why I did this?
For subnet-directed IPv4 broadcast packets to be routed in data-plane, an entry has to be added in the layer 3 tables with the destination as the broadcast IP of the subnet. This feature is waiting on SAI support. 

**Note:** 
Subnet directed broadcast is not supported in IPv6 and hence this API is meaningful only for the IPv4 address family. However, the API to be in sync with the python class `ipaddress.IPv6Network.broadcast_address`, support is added to get broadcast address for IPv6 as well.

Please review the UT section for examples. 

