### PR TITLE
[MacAddress]: Optimize to_string() and parseMacString methods

### DIFF
--- a/common/macaddress.cpp
+++ b/common/macaddress.cpp
@@ -39,14 +39,18 @@ std::string MacAddress::to_string(const uint8_t* mac)
         if (left_half >= 0 && left_half <= 9)
         {
             str[left] = static_cast<char>(left_half + '0');
-        } else {
+        }
+        else
+        {
             str[left] = static_cast<char>(left_half + 'a' - 0x0a);
         }
 
         if (right_half >= 0 && right_half <= 9)
         {
             str[right] = static_cast<char>(right_half + '0');
-        } else {
+        }
+        else
+        {
             str[right] = static_cast<char>(right_half + 'a' - 0x0a);
         }
     }

--- a/common/macaddress.cpp
+++ b/common/macaddress.cpp
@@ -46,6 +46,9 @@ std::string MacAddress::to_string(const uint8_t* mac)
     return str;
 }
 
+// This function parses a string to a binary mac address (uint8_t[6])
+// The string should contain mac address only. No spaces are allowed.
+// The mac address separators could be either ':' or '-'
 bool MacAddress::parseMacString(const string& str_mac, uint8_t* bin_mac)
 {
     if (bin_mac == NULL)
@@ -60,8 +63,14 @@ bool MacAddress::parseMacString(const string& str_mac, uint8_t* bin_mac)
 
     const char* ptr_mac = str_mac.c_str();
 
-    if ((ptr_mac[2] != ':' || ptr_mac[5] != ':' || ptr_mac[8] != ':' || ptr_mac[11] != ':' || ptr_mac[14] != ':')
-     && (ptr_mac[2] != '-' || ptr_mac[5] != '-' || ptr_mac[8] != '-' || ptr_mac[11] != '-' || ptr_mac[14] != '-'))
+    // first check that all mac address separators are equal to each other
+    if (!allequal(ptr_mac[2], ptr_mac[5], ptr_mac[8], ptr_mac[11], ptr_mac[14]))
+    {
+        return false;
+    }
+
+    // then check that the first separator is equal to ':' or '-'
+    if (ptr_mac[2] != ':' && ptr_mac[2] != '-')
     {
         return false;
     }

--- a/common/macaddress.cpp
+++ b/common/macaddress.cpp
@@ -20,7 +20,7 @@ MacAddress::MacAddress(const uint8_t *mac)
 MacAddress::MacAddress(const std::string& macStr)
 {
     bool suc = MacAddress::parseMacString(macStr, m_mac);
-    if (!suc) throw invalid_argument("invalid mac address " + macStr);
+    if (!suc) throw invalid_argument("can't parse mac address '" + macStr + "'");
 }
 
 const std::string MacAddress::to_string() const
@@ -30,30 +30,17 @@ const std::string MacAddress::to_string() const
 
 std::string MacAddress::to_string(const uint8_t* mac)
 {
+    const static char char_table[] = "0123456789abcdef";
+
     std::string str(mac_address_str_length, ':');
     for(int i = 0; i < ETHER_ADDR_LEN; ++i) {
         int left = i * 3;      // left  digit position of hexadecimal number
         int right = left + 1;  // right digit position of hexadecimal number
-        char left_half = static_cast<char>(mac[i] >> 4);
-        char right_half = mac[i] & 0x0f;
+        int left_half  = mac[i] >> 4;
+        int right_half = mac[i] & 0x0f;
 
-        if (left_half >= 0 && left_half <= 9)
-        {
-            str[left] = static_cast<char>(left_half + '0');
-        }
-        else
-        {
-            str[left] = static_cast<char>(left_half + 'a' - 0x0a);
-        }
-
-        if (right_half >= 0 && right_half <= 9)
-        {
-            str[right] = static_cast<char>(right_half + '0');
-        }
-        else
-        {
-            str[right] = static_cast<char>(right_half + 'a' - 0x0a);
-        }
+        str[left]  = char_table[left_half];
+        str[right] = char_table[right_half];
     }
 
     return str;

--- a/common/macaddress.cpp
+++ b/common/macaddress.cpp
@@ -68,8 +68,8 @@ bool MacAddress::parseMacString(const string& str_mac, uint8_t* bin_mac)
 
     const char* ptr_mac = str_mac.c_str();
 
-    if ((ptr_mac[2]  != ':' || ptr_mac[5]  != ':' || ptr_mac[8] != ':' || ptr_mac[11] != ':' || ptr_mac[14] != ':')
-     && (ptr_mac[2]  != '-' || ptr_mac[5]  != '-' || ptr_mac[8] != '-' || ptr_mac[11] != '-' || ptr_mac[14] != '-'))
+    if ((ptr_mac[2] != ':' || ptr_mac[5] != ':' || ptr_mac[8] != ':' || ptr_mac[11] != ':' || ptr_mac[14] != ':')
+     && (ptr_mac[2] != '-' || ptr_mac[5] != '-' || ptr_mac[8] != '-' || ptr_mac[11] != '-' || ptr_mac[14] != '-'))
     {
         return false;
     }
@@ -79,15 +79,15 @@ bool MacAddress::parseMacString(const string& str_mac, uint8_t* bin_mac)
         int left  = i * 3;
         int right = left + 1;
 
-        if (ptr_mac[left] >= '0' &&  ptr_mac[left] <= '9')
+        if (ptr_mac[left] >= '0' && ptr_mac[left] <= '9')
         {
             bin_mac[i] = static_cast<uint8_t>(ptr_mac[left] - '0');
         }
-        else if (ptr_mac[left] >= 'A' &&  ptr_mac[left] <= 'F')
+        else if (ptr_mac[left] >= 'A' && ptr_mac[left] <= 'F')
         {
             bin_mac[i] = static_cast<uint8_t>(ptr_mac[left] - 'A' + 0x0a);
         }
-        else if (ptr_mac[left] >= 'a' &&  ptr_mac[left] <= 'f')
+        else if (ptr_mac[left] >= 'a' && ptr_mac[left] <= 'f')
         {
             bin_mac[i] = static_cast<uint8_t>(ptr_mac[left] - 'a' + 0x0a);
         }
@@ -98,15 +98,15 @@ bool MacAddress::parseMacString(const string& str_mac, uint8_t* bin_mac)
 
         bin_mac[i] = static_cast<uint8_t>(bin_mac[i] << 4);
 
-        if (ptr_mac[right] >= '0' &&  ptr_mac[right] <= '9')
+        if (ptr_mac[right] >= '0' && ptr_mac[right] <= '9')
         {
             bin_mac[i] |= static_cast<uint8_t>(ptr_mac[right] - '0');
         }
-        else if (ptr_mac[right] >= 'A' &&  ptr_mac[right] <= 'F')
+        else if (ptr_mac[right] >= 'A' && ptr_mac[right] <= 'F')
         {
             bin_mac[i] |= static_cast<uint8_t>(ptr_mac[right] - 'A' + 0x0a);
         }
-        else if (ptr_mac[right] >= 'a' &&  ptr_mac[right] <= 'f')
+        else if (ptr_mac[right] >= 'a' && ptr_mac[right] <= 'f')
         {
             bin_mac[i] |= static_cast<uint8_t>(ptr_mac[right] - 'a' + 0x0a);
         }

--- a/common/macaddress.cpp
+++ b/common/macaddress.cpp
@@ -1,25 +1,26 @@
-#include "macaddress.h"
-
-#include <sstream>
 #include <stdexcept>
+
+#include "macaddress.h"
 
 using namespace swss;
 using namespace std;
 
+const size_t mac_address_str_length = ETHER_ADDR_LEN*2 + 5; // 6 hexadecimal numbers (two digits each) + 5 delimiters
+
 MacAddress::MacAddress()
 {
-    memset(m_mac, 0, 6);
+    memset(m_mac, 0, ETHER_ADDR_LEN);
 }
 
 MacAddress::MacAddress(const uint8_t *mac)
 {
-    memcpy(m_mac, mac, 6);
+    memcpy(m_mac, mac, ETHER_ADDR_LEN);
 }
 
 MacAddress::MacAddress(const std::string& macStr)
 {
     bool suc = MacAddress::parseMacString(macStr, m_mac);
-    if (!suc) throw invalid_argument("macStr");
+    if (!suc) throw invalid_argument("invalid mac address " + macStr);
 }
 
 const std::string MacAddress::to_string() const
@@ -29,10 +30,10 @@ const std::string MacAddress::to_string() const
 
 std::string MacAddress::to_string(const uint8_t* mac)
 {
-    std::string str(17, ':');
-    for(int i = 0; i < 6; i++) {
-        int left = i * 3;
-        int right = left + 1;
+    std::string str(mac_address_str_length, ':');
+    for(int i = 0; i < ETHER_ADDR_LEN; ++i) {
+        int left = i * 3;      // left  digit position of hexadecimal number
+        int right = left + 1;  // right digit position of hexadecimal number
         char left_half = static_cast<char>(mac[i] >> 4);
         char right_half = mac[i] & 0x0f;
 
@@ -65,7 +66,7 @@ bool MacAddress::parseMacString(const string& str_mac, uint8_t* bin_mac)
         return false;
     }
 
-    if (str_mac.length() != 17)
+    if (str_mac.length() != mac_address_str_length)
     {
         return false;
     }
@@ -78,10 +79,10 @@ bool MacAddress::parseMacString(const string& str_mac, uint8_t* bin_mac)
         return false;
     }
 
-    for(int i = 0; i < 6; i++)
+    for(int i = 0; i < ETHER_ADDR_LEN; ++i)
     {
-        int left  = i * 3;
-        int right = left + 1;
+        int left  = i * 3;    // left  digit position of hexadecimal number
+        int right = left + 1; // right digit position of hexadecimal number
 
         if (ptr_mac[left] >= '0' && ptr_mac[left] <= '9')
         {

--- a/common/macaddress.h
+++ b/common/macaddress.h
@@ -8,6 +8,16 @@
 
 namespace swss {
 
+template <typename T>
+bool allequal(const T &t, const T &u) {
+    return t == u;
+}
+
+template <typename T, typename... Others>
+bool allequal(const T &t, const T &u, Others const &... args) {
+    return (t == u) && allequal(u, args...);
+}
+
 class MacAddress
 {
 public:

--- a/common/macaddress.h
+++ b/common/macaddress.h
@@ -1,6 +1,7 @@
 #ifndef __MACADDRESS__
 #define __MACADDRESS__
 
+#include <net/ethernet.h>
 #include <string.h>
 #include <stdint.h>
 #include <string>
@@ -19,7 +20,7 @@ public:
 
     inline void getMac(uint8_t *mac) const
     {
-        memcpy(mac, m_mac, 6);
+        memcpy(mac, m_mac, ETHER_ADDR_LEN);
     }
 
     inline const uint8_t *getMac() const
@@ -29,7 +30,7 @@ public:
 
     inline bool operator==(const MacAddress &o) const
     {
-        return !memcmp(m_mac, o.m_mac, 6);
+        return !memcmp(m_mac, o.m_mac, ETHER_ADDR_LEN);
     }
 
     inline bool operator!=(const MacAddress &o) const
@@ -60,7 +61,7 @@ public:
     static bool parseMacString(const std::string& strmac, uint8_t* mac);
 
 private:
-    uint8_t m_mac[6];
+    uint8_t m_mac[ETHER_ADDR_LEN];
 };
 
 }

--- a/tests/macaddress_ut.cpp
+++ b/tests/macaddress_ut.cpp
@@ -6,10 +6,12 @@ using namespace std;
 
 TEST(MacAddress, to_string)
 {
-    auto a = MacAddress("52:54:00:ac:3a:99");
-    auto b = MacAddress("02:09:87:65:43:21");
-
+    const uint8_t a_bin[] = {0x52, 0x54, 0x00, 0xac, 0x3a, 0x99};
+    auto a = MacAddress(a_bin);
     EXPECT_EQ(a.to_string(), "52:54:00:ac:3a:99");
+
+    const uint8_t b_bin[] = {0x02, 0x09, 0x87, 0x65, 0x43, 0x21};
+    auto b = MacAddress(b_bin);
     EXPECT_EQ(b.to_string(), "02:09:87:65:43:21");
 }
 
@@ -18,30 +20,36 @@ TEST(MacAddress, comparison)
     auto a = MacAddress("52:54:00:ac:3a:99");
     auto b = MacAddress("02:09:87:65:43:21");
 
-    EXPECT_EQ(a == a, true);
-    EXPECT_EQ(a != a, false);
-
-    EXPECT_EQ(a == b, false);
-    EXPECT_EQ(a != b, true);
-
+    EXPECT_EQ(a, a);
+    EXPECT_NE(a, b);
     EXPECT_LT(b, a);
 
-    EXPECT_EQ(a < b, false);
-    EXPECT_EQ(b < a, true);
-
-    EXPECT_EQ(!a, false);
-    EXPECT_EQ(!b, false);
+    EXPECT_FALSE(!a);
+    EXPECT_FALSE(!b);
 
     auto c = MacAddress("00:00:00:00:00:00");
 
-    EXPECT_EQ(!c, true);
+    EXPECT_TRUE(!c);
 }
 
 TEST(MacAddress, parse)
 {
     uint8_t mac[6];
-    bool suc = MacAddress::parseMacString("52:54:00:25::E9", mac);
-    EXPECT_FALSE(suc);
+
+    uint8_t ex_mac[] = {0xa0, 0xf9, 0xaa, 0xff, 0x0a, 0x9f};
+    EXPECT_TRUE(MacAddress::parseMacString("A0:F9:aA:fF:0a:9f", mac));   // correct mac address which uses all edge values
+    EXPECT_EQ(memcmp(mac, ex_mac, sizeof(mac)), 0);                      // check that we got correct result
+
+    EXPECT_FALSE(MacAddress::parseMacString("52:34:51:42:42:42", NULL)); // wrong destination parameter
+    EXPECT_FALSE(MacAddress::parseMacString("52:54:00:25::E9",    mac)); // wrong length 1
+    EXPECT_FALSE(MacAddress::parseMacString("52:54:00:25:12:E9 ", mac)); // wrong length 2
+    EXPECT_FALSE(MacAddress::parseMacString(" 52:54:00:25:12:E",  mac)); // wrong address
+    EXPECT_FALSE(MacAddress::parseMacString("52:54:00:25:Z9:E9",  mac)); // wrong hex number 1
+    EXPECT_FALSE(MacAddress::parseMacString("52:54:00:25:aZ:E9",  mac)); // wrong hex number 2
+    EXPECT_FALSE(MacAddress::parseMacString("52:54:00:25:z9:E9",  mac)); // wrong hex number 3
+    EXPECT_FALSE(MacAddress::parseMacString("52:54:00:25:az:E9",  mac)); // wrong hex number 4
+
+    EXPECT_FALSE(MacAddress::parseMacString("52:34:51:42:42_42",  mac)); // wrong delimiter
 
     EXPECT_THROW(MacAddress("52:54:00:25:E9"), invalid_argument);
 }

--- a/tests/macaddress_ut.cpp
+++ b/tests/macaddress_ut.cpp
@@ -9,10 +9,12 @@ TEST(MacAddress, to_string)
     const uint8_t a_bin[] = {0x52, 0x54, 0x00, 0xac, 0x3a, 0x99};
     auto a = MacAddress(a_bin);
     EXPECT_EQ(a.to_string(), "52:54:00:ac:3a:99");
+    EXPECT_EQ(MacAddress::to_string(a_bin), "52:54:00:ac:3a:99");
 
-    const uint8_t b_bin[] = {0x02, 0x09, 0x87, 0x65, 0x43, 0x21};
+    const uint8_t b_bin[] = {0xa0, 0xf9, 0x0a, 0x9f, 0x43, 0x21};
     auto b = MacAddress(b_bin);
-    EXPECT_EQ(b.to_string(), "02:09:87:65:43:21");
+    EXPECT_EQ(b.to_string(), "a0:f9:0a:9f:43:21");
+    EXPECT_EQ(MacAddress::to_string(b_bin), "a0:f9:0a:9f:43:21");
 }
 
 TEST(MacAddress, comparison)
@@ -40,6 +42,8 @@ TEST(MacAddress, parse)
     EXPECT_TRUE(MacAddress::parseMacString("A0:F9:aA:fF:0a:9f", mac));   // correct mac address which uses all edge values
     EXPECT_EQ(memcmp(mac, ex_mac, sizeof(mac)), 0);                      // check that we got correct result
 
+    EXPECT_TRUE(MacAddress::parseMacString("A0-F9-aA-fF-0a-9f", mac));   // correct mac address with '-' as delimiter
+
     EXPECT_FALSE(MacAddress::parseMacString("52:34:51:42:42:42", NULL)); // wrong destination parameter
     EXPECT_FALSE(MacAddress::parseMacString("52:54:00:25::E9",    mac)); // wrong length 1
     EXPECT_FALSE(MacAddress::parseMacString("52:54:00:25:12:E9 ", mac)); // wrong length 2
@@ -49,7 +53,11 @@ TEST(MacAddress, parse)
     EXPECT_FALSE(MacAddress::parseMacString("52:54:00:25:z9:E9",  mac)); // wrong hex number 3
     EXPECT_FALSE(MacAddress::parseMacString("52:54:00:25:az:E9",  mac)); // wrong hex number 4
 
-    EXPECT_FALSE(MacAddress::parseMacString("52:34:51:42:42_42",  mac)); // wrong delimiter
+    EXPECT_FALSE(MacAddress::parseMacString("52_34:51:42:42:42",  mac)); // wrong delimiter 1
+    EXPECT_FALSE(MacAddress::parseMacString("52:34_51:42:42:42",  mac)); // wrong delimiter 2
+    EXPECT_FALSE(MacAddress::parseMacString("52:34:51_42:42:42",  mac)); // wrong delimiter 3
+    EXPECT_FALSE(MacAddress::parseMacString("52:34:51:42_42:42",  mac)); // wrong delimiter 4
+    EXPECT_FALSE(MacAddress::parseMacString("52:34:51:42:42_42",  mac)); // wrong delimiter 5
 
     EXPECT_THROW(MacAddress("52:54:00:25:E9"), invalid_argument);
 }

--- a/tests/macaddress_ut.cpp
+++ b/tests/macaddress_ut.cpp
@@ -1,3 +1,4 @@
+#include <net/ethernet.h>
 #include <gtest/gtest.h>
 #include "common/macaddress.h"
 


### PR DESCRIPTION
MacAddress class instantiated many times from string. Also we parse mac addresses a lot. I did a benchmark and I found that our old version of to_string() and parseMacString() methods not so fast.

I've rewritten both of them. Now both methods faster (parseMacString - 76 times faster, almost 10 times faster) and parseMacString() catch more errors.

```
2018-01-03 23:01:53
Run on (16 X 2394.44 MHz CPU s)
CPU Caches:
  L1 Data 32K (x16)
  L1 Instruction 32K (x16)
  L2 Unified 256K (x16)
  L3 Unified 30720K (x16)
------------------------------------------------------------
Benchmark                     Time           CPU Iterations
------------------------------------------------------------
BM_ParseMacOld              840 ns        840 ns     842880
BM_ParseMac                  11 ns         11 ns   62703966
BM_MAC_to_string_old        496 ns        496 ns    1448299
BM_MAC_to_string             50 ns         50 ns   13564922
```