### PR TITLE
[MacAddress]: Remove code from stackoverflow

### DIFF
--- a/common/macaddress.cpp
+++ b/common/macaddress.cpp
@@ -64,7 +64,11 @@ bool MacAddress::parseMacString(const string& str_mac, uint8_t* bin_mac)
     const char* ptr_mac = str_mac.c_str();
 
     // first check that all mac address separators are equal to each other
-    if (!allequal(ptr_mac[2], ptr_mac[5], ptr_mac[8], ptr_mac[11], ptr_mac[14]))
+    // 2, 5, 8, 11, and 14 are MAC address separator positions
+    if (!(ptr_mac[2]  == ptr_mac[5]
+       && ptr_mac[5]  == ptr_mac[8]
+       && ptr_mac[8]  == ptr_mac[11]
+       && ptr_mac[11] == ptr_mac[14]))
     {
         return false;
     }

--- a/common/macaddress.h
+++ b/common/macaddress.h
@@ -8,16 +8,6 @@
 
 namespace swss {
 
-template <typename T>
-bool allequal(const T &t, const T &u) {
-    return t == u;
-}
-
-template <typename T, typename... Others>
-bool allequal(const T &t, const T &u, Others const &... args) {
-    return (t == u) && allequal(u, args...);
-}
-
 class MacAddress
 {
 public:

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -10,7 +10,7 @@ endif
 
 CFLAGS_GTEST = -I $(top_srcdir)/googletest/googletest/include
 LDADD_GTEST = $(top_srcdir)/googletest/build/googlemock/gtest/libgtest_main.a \
-        $(top_srcdir)/googletest/build/googlemock/gtest/libgtest.a
+              $(top_srcdir)/googletest/build/googlemock/gtest/libgtest.a
 
 tests_SOURCES = redis_ut.cpp                \
                 redis_piped_ut.cpp          \
@@ -24,7 +24,7 @@ tests_SOURCES = redis_ut.cpp                \
                 macaddress_ut.cpp           \
                 converter_ut.cpp            \
                 exec_ut.cpp                 \
-				redis_subscriber_state_ut.cpp
+                redis_subscriber_state_ut.cpp
 
 tests_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST)
 tests_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST)


### PR DESCRIPTION
1. Remove code from stackoverflow which was introduces by https://github.com/Azure/sonic-swss-common/pull/171
2. Convert tabs to spaces