### PR TITLE
Extending IpAddress class with method to return the scope of any given ip-address

### DIFF
--- a/common/ipaddress.cpp
+++ b/common/ipaddress.cpp
@@ -5,12 +5,6 @@
 
 using namespace swss;
 
-/* Auxiliary prefixes used to determine the scope of any given address */
-static IpAddress ipv4LinkScopeAddress("169.254.0.0");
-static IpAddress ipv6LinkScopeAddress("fe80::0");
-static IpAddress ipv4HostScopeAddress("127.0.0.1");
-static IpAddress ipv6HostScopeAddress("::1");
-
 IpAddress::IpAddress(uint32_t ip)
 {
     m_ip.family = AF_INET;
@@ -46,6 +40,12 @@ std::string IpAddress::to_string() const
 
 IpAddress::AddrScope IpAddress::getAddrScope() const
 {
+    /* Auxiliary prefixes used to determine the scope of any given address */
+    static const IpAddress ipv4LinkScopeAddress = IpAddress("169.254.0.0");
+    static const IpAddress ipv6LinkScopeAddress = IpAddress("FE80::0");
+    static const IpAddress ipv4HostScopeAddress = IpAddress("127.0.0.1");
+    static const IpAddress ipv6HostScopeAddress = IpAddress("::1");
+
     if (isV4())
     {
         const uint32_t ip1 = htonl(getV4Addr());

--- a/common/ipaddress.h
+++ b/common/ipaddress.h
@@ -74,6 +74,14 @@ public:
 
     std::string to_string() const;
 
+    enum AddrScope {
+        GLOBAL_SCOPE,
+        LINK_SCOPE,
+        HOST_SCOPE
+    };
+
+    IpAddress::AddrScope getAddrScope() const;
+
 private:
     struct ip_addr_t m_ip;
 };

--- a/tests/ipaddress_ut.cpp
+++ b/tests/ipaddress_ut.cpp
@@ -33,3 +33,42 @@ TEST(IpAddresses, contains)
     EXPECT_TRUE(ips.contains(ips_1));
     EXPECT_FALSE(ips.contains(ips_2));
 }
+
+TEST(IpAddress, getAddrScope)
+{
+    // IPv4 prefixes
+    IpAddress ip1("0.0.0.0");
+    IpAddress ip2("169.1.1.1");
+    IpAddress ip3("169.254.0.1");
+    IpAddress ip4("169.254.255.255");
+    IpAddress ip5("169.253.1.1");
+    IpAddress ip6("169.255.1.1");
+    IpAddress ip7("127.0.0.1");
+
+    // IPv6 prefixes
+    IpAddress ip11("2001:4898:f0:f153:357c:77b2:49c9:627c");
+    IpAddress ip12("fe80::1");
+    IpAddress ip13("fe80:1:1:1:1:1:1:1");
+    IpAddress ip14("fe99::1");
+    IpAddress ip15("feb0:1::1");
+    IpAddress ip16("febf:1::1");
+    IpAddress ip17("fec0:1::1");
+    IpAddress ip18("::1");
+
+    EXPECT_EQ(IpAddress::AddrScope::GLOBAL_SCOPE, ip1.getAddrScope());
+    EXPECT_EQ(IpAddress::AddrScope::GLOBAL_SCOPE, ip2.getAddrScope());
+    EXPECT_EQ(IpAddress::AddrScope::LINK_SCOPE,   ip3.getAddrScope());
+    EXPECT_EQ(IpAddress::AddrScope::LINK_SCOPE,   ip4.getAddrScope());
+    EXPECT_EQ(IpAddress::AddrScope::GLOBAL_SCOPE, ip5.getAddrScope());
+    EXPECT_EQ(IpAddress::AddrScope::GLOBAL_SCOPE, ip6.getAddrScope());
+    EXPECT_EQ(IpAddress::AddrScope::HOST_SCOPE,   ip7.getAddrScope());
+
+    EXPECT_EQ(IpAddress::AddrScope::GLOBAL_SCOPE, ip11.getAddrScope());
+    EXPECT_EQ(IpAddress::AddrScope::LINK_SCOPE,   ip12.getAddrScope());
+    EXPECT_EQ(IpAddress::AddrScope::LINK_SCOPE,   ip13.getAddrScope());
+    EXPECT_EQ(IpAddress::AddrScope::LINK_SCOPE,   ip14.getAddrScope());
+    EXPECT_EQ(IpAddress::AddrScope::LINK_SCOPE,   ip15.getAddrScope());
+    EXPECT_EQ(IpAddress::AddrScope::LINK_SCOPE,   ip16.getAddrScope());
+    EXPECT_EQ(IpAddress::AddrScope::GLOBAL_SCOPE, ip17.getAddrScope());
+    EXPECT_EQ(IpAddress::AddrScope::HOST_SCOPE,   ip18.getAddrScope());
+}


### PR DESCRIPTION

This code is required by link-local functionality (sonic-swss PR/437).

UTs execution:

rmolina@6175c07b92ba:/sonic/src/sonic-swss-common$ sudo ./tests/tests
...
[----------] 2 tests from IpAddresses
[ RUN      ] IpAddresses.empty
[       OK ] IpAddresses.empty (0 ms)
[ RUN      ] IpAddresses.contains
[       OK ] IpAddresses.contains (1 ms)
[----------] 2 tests from IpAddresses (1 ms total)

[----------] 1 test from IpAddress
[ RUN      ] IpAddress.getAddrScope
[       OK ] IpAddress.getAddrScope (0 ms)
[----------] 1 test from IpAddress (0 ms total)
...