### PR TITLE
Add map of database ID -> table name separator; No longer pass table name separator when constructing Table objects

### DIFF
--- a/common/consumertablebase.cpp
+++ b/common/consumertablebase.cpp
@@ -3,7 +3,7 @@
 namespace swss {
 
 ConsumerTableBase::ConsumerTableBase(DBConnector *db, std::string tableName, int popBatchSize):
-        TableConsumable(tableName),
+        TableConsumable(db, tableName),
         RedisTransactioner(db),
         POP_BATCH_SIZE(popBatchSize)
 {

--- a/common/consumertablebase.cpp
+++ b/common/consumertablebase.cpp
@@ -3,7 +3,7 @@
 namespace swss {
 
 ConsumerTableBase::ConsumerTableBase(DBConnector *db, std::string tableName, int popBatchSize):
-        TableConsumable(db, tableName),
+        TableConsumable(db->getDbId(), tableName),
         RedisTransactioner(db),
         POP_BATCH_SIZE(popBatchSize)
 {

--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -30,7 +30,7 @@ DBConnector::~DBConnector()
 
 DBConnector::DBConnector(int dbId, string hostname, int port,
                          unsigned int timeout) :
-    m_id(dbId)
+    m_dbId(dbId)
 {
     struct timeval tv = {0, (suseconds_t)timeout * 1000};
 
@@ -47,7 +47,7 @@ DBConnector::DBConnector(int dbId, string hostname, int port,
 }
 
 DBConnector::DBConnector(int dbId, string unixPath, unsigned int timeout) :
-    m_id(dbId)
+    m_dbId(dbId)
 {
     struct timeval tv = {0, (suseconds_t)timeout * 1000};
 
@@ -70,7 +70,7 @@ redisContext *DBConnector::getContext()
 
 int DBConnector::getDbId()
 {
-    return m_id;
+    return m_dbId;
 }
 
 DBConnector *DBConnector::newConnector(unsigned int timeout)

--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -17,7 +17,7 @@ constexpr const char *DBConnector::DEFAULT_UNIXSOCKET;
 void DBConnector::select(DBConnector *db)
 {
     string select("SELECT ");
-    select += to_string(db->getDB());
+    select += to_string(db->getDbId());
 
     RedisReply r(db, select, REDIS_REPLY_STATUS);
     r.checkStatusOK();
@@ -28,9 +28,9 @@ DBConnector::~DBConnector()
     redisFree(m_conn);
 }
 
-DBConnector::DBConnector(int db, string hostname, int port,
+DBConnector::DBConnector(int dbId, string hostname, int port,
                          unsigned int timeout) :
-    m_db(db)
+    m_id(dbId)
 {
     struct timeval tv = {0, (suseconds_t)timeout * 1000};
 
@@ -46,8 +46,8 @@ DBConnector::DBConnector(int db, string hostname, int port,
     select(this);
 }
 
-DBConnector::DBConnector(int db, string unixPath, unsigned int timeout) :
-    m_db(db)
+DBConnector::DBConnector(int dbId, string unixPath, unsigned int timeout) :
+    m_id(dbId)
 {
     struct timeval tv = {0, (suseconds_t)timeout * 1000};
 
@@ -68,20 +68,20 @@ redisContext *DBConnector::getContext()
     return m_conn;
 }
 
-int DBConnector::getDB()
+int DBConnector::getDbId()
 {
-    return m_db;
+    return m_id;
 }
 
 DBConnector *DBConnector::newConnector(unsigned int timeout)
 {
     if (getContext()->connection_type == REDIS_CONN_TCP)
-        return new DBConnector(getDB(),
+        return new DBConnector(getDbId(),
                                getContext()->tcp.host,
                                getContext()->tcp.port,
                                timeout);
     else
-        return new DBConnector(getDB(),
+        return new DBConnector(getDbId(),
                                getContext()->unix_sock.path,
                                timeout);
 }

--- a/common/dbconnector.h
+++ b/common/dbconnector.h
@@ -20,13 +20,13 @@ public:
      * Timeout - The time in milisecond until exception is been thrown. For
      *           infinite wait, set this value to 0
      */
-    DBConnector(int db, std::string hostname, int port, unsigned int timeout);
-    DBConnector(int db, std::string unixPath, unsigned int timeout);
+    DBConnector(int dbId, std::string hostname, int port, unsigned int timeout);
+    DBConnector(int dbId, std::string unixPath, unsigned int timeout);
 
     ~DBConnector();
 
     redisContext *getContext();
-    int getDB();
+    int getDbId();
 
     static void select(DBConnector *db);
 
@@ -35,7 +35,7 @@ public:
 
 private:
     redisContext *m_conn;
-    int m_db;
+    int m_id;
 };
 
 }

--- a/common/dbconnector.h
+++ b/common/dbconnector.h
@@ -35,7 +35,7 @@ public:
 
 private:
     redisContext *m_conn;
-    int m_id;
+    int m_dbId;
 };
 
 }

--- a/common/notificationconsumer.cpp
+++ b/common/notificationconsumer.cpp
@@ -40,12 +40,12 @@ void swss::NotificationConsumer::subscribe()
 
     /* Create new new context to DB */
     if (m_db->getContext()->connection_type == REDIS_CONN_TCP)
-        m_subscribe = new DBConnector(m_db->getDB(),
+        m_subscribe = new DBConnector(m_db->getDbId(),
                                       m_db->getContext()->tcp.host,
                                       m_db->getContext()->tcp.port,
                                       NOTIFICATION_SUBSCRIBE_TIMEOUT);
     else
-        m_subscribe = new DBConnector(m_db->getDB(),
+        m_subscribe = new DBConnector(m_db->getDbId(),
                                       m_db->getContext()->unix_sock.path,
                                       NOTIFICATION_SUBSCRIBE_TIMEOUT);
 

--- a/common/producerstatetable.cpp
+++ b/common/producerstatetable.cpp
@@ -20,7 +20,7 @@ ProducerStateTable::ProducerStateTable(DBConnector *db, string tableName)
 }
 
 ProducerStateTable::ProducerStateTable(RedisPipeline *pipeline, string tableName, bool buffered)
-    : TableBase(pipeline->getDbConnector(), tableName)
+    : TableBase(pipeline->getDbId(), tableName)
     , TableName_KeySet(tableName)
     , m_buffered(buffered)
     , m_pipeowned(false)

--- a/common/producerstatetable.cpp
+++ b/common/producerstatetable.cpp
@@ -20,7 +20,7 @@ ProducerStateTable::ProducerStateTable(DBConnector *db, string tableName)
 }
 
 ProducerStateTable::ProducerStateTable(RedisPipeline *pipeline, string tableName, bool buffered)
-    : TableBase(tableName)
+    : TableBase(pipeline->getDbConnector(), tableName)
     , TableName_KeySet(tableName)
     , m_buffered(buffered)
     , m_pipeowned(false)

--- a/common/producertable.cpp
+++ b/common/producertable.cpp
@@ -19,7 +19,7 @@ ProducerTable::ProducerTable(DBConnector *db, string tableName)
 }
 
 ProducerTable::ProducerTable(RedisPipeline *pipeline, string tableName, bool buffered)
-    : TableBase(pipeline->getDbConnector(), tableName)
+    : TableBase(pipeline->getDbId(), tableName)
     , TableName_KeyValueOpQueues(tableName)
     , m_buffered(buffered)
     , m_pipeowned(false)

--- a/common/producertable.cpp
+++ b/common/producertable.cpp
@@ -19,7 +19,7 @@ ProducerTable::ProducerTable(DBConnector *db, string tableName)
 }
 
 ProducerTable::ProducerTable(RedisPipeline *pipeline, string tableName, bool buffered)
-    : TableBase(tableName)
+    : TableBase(pipeline->getDbConnector(), tableName)
     , TableName_KeyValueOpQueues(tableName)
     , m_buffered(buffered)
     , m_pipeowned(false)

--- a/common/redispipeline.h
+++ b/common/redispipeline.h
@@ -94,7 +94,7 @@ public:
 
     int getDbId()
     {
-        return m_db == NULL ? -1 : m_db->getDbId();
+        return m_db->getDbId();
     }
 
 private:

--- a/common/redispipeline.h
+++ b/common/redispipeline.h
@@ -92,6 +92,11 @@ public:
         return m_remaining;
     }
 
+    DBConnector *getDbConnector()
+    {
+        return m_db;
+    }
+
 private:
     DBConnector *m_db;
     std::queue<int> m_expectedTypes;

--- a/common/redispipeline.h
+++ b/common/redispipeline.h
@@ -92,9 +92,9 @@ public:
         return m_remaining;
     }
 
-    DBConnector *getDbConnector()
+    int getDbId()
     {
-        return m_db;
+        return m_db == NULL ? -1 : m_db->getDbId();
     }
 
 private:

--- a/common/schema.h
+++ b/common/schema.h
@@ -13,6 +13,7 @@ namespace swss {
 #define PFC_WD_DB       5
 #define FLEX_COUNTER_DB 5
 #define STATE_DB        6
+#define TEST_DB         15
 
 /***** APPLICATION DATABASE *****/
 

--- a/common/schema.h
+++ b/common/schema.h
@@ -13,7 +13,6 @@ namespace swss {
 #define PFC_WD_DB       5
 #define FLEX_COUNTER_DB 5
 #define STATE_DB        6
-#define TEST_DB         15
 
 /***** APPLICATION DATABASE *****/
 

--- a/common/subscriberstatetable.cpp
+++ b/common/subscriberstatetable.cpp
@@ -15,11 +15,11 @@ using namespace std;
 namespace swss {
 
 SubscriberStateTable::SubscriberStateTable(DBConnector *db, string tableName)
-    : ConsumerTableBase(db, tableName), m_table(db, tableName, CONFIGDB_TABLE_NAME_SEPARATOR)
+    : ConsumerTableBase(db, tableName), m_table(db, tableName)
 {
     m_keyspace = "__keyspace@";
 
-    m_keyspace += to_string(db->getDB()) + "__:" + tableName + CONFIGDB_TABLE_NAME_SEPARATOR + "*";
+    m_keyspace += to_string(db->getDB()) + "__:" + tableName + m_table.getTableNameSeparator() + "*";
 
     psubscribe(m_db, m_keyspace);
 
@@ -134,7 +134,7 @@ void SubscriberStateTable::pops(deque<KeyOpFieldsValuesTuple> &vkco, string /*pr
         }
 
         string table_entry = msg.substr(pos + 1);
-        pos = table_entry.find(CONFIGDB_TABLE_NAME_SEPARATOR);
+        pos = table_entry.find(m_table.getTableNameSeparator());
         if (pos == table_entry.npos)
         {
             SWSS_LOG_ERROR("invalid key %s returned for pmessage of %s", ctx->str, m_keyspace.c_str());

--- a/common/subscriberstatetable.cpp
+++ b/common/subscriberstatetable.cpp
@@ -19,7 +19,7 @@ SubscriberStateTable::SubscriberStateTable(DBConnector *db, string tableName)
 {
     m_keyspace = "__keyspace@";
 
-    m_keyspace += to_string(db->getDB()) + "__:" + tableName + m_table.getTableNameSeparator() + "*";
+    m_keyspace += to_string(db->getDbId()) + "__:" + tableName + m_table.getTableNameSeparator() + "*";
 
     psubscribe(m_db, m_keyspace);
 

--- a/common/table.cpp
+++ b/common/table.cpp
@@ -20,7 +20,8 @@ const TableNameSeparatorMap TableBase::tableNameSeparatorMap = {
    { CONFIG_DB,       NEW_TABLE_NAME_SEPARATOR },
    { PFC_WD_DB,       LEGACY_TABLE_NAME_SEPARATOR },
    { FLEX_COUNTER_DB, LEGACY_TABLE_NAME_SEPARATOR },
-   { STATE_DB,        NEW_TABLE_NAME_SEPARATOR }
+   { STATE_DB,        NEW_TABLE_NAME_SEPARATOR },
+   { TEST_DB,         LEGACY_TABLE_NAME_SEPARATOR }
 };
 
 Table::Table(DBConnector *db, string tableName)

--- a/common/table.cpp
+++ b/common/table.cpp
@@ -12,6 +12,9 @@ using namespace std;
 using namespace swss;
 using json = nlohmann::json;
 
+const std::string TableBase::LEGACY_TABLE_NAME_SEPARATOR = ":";
+const std::string TableBase::NEW_TABLE_NAME_SEPARATOR = "|";
+
 const TableNameSeparatorMap TableBase::tableNameSeparatorMap = {
    { APPL_DB,         LEGACY_TABLE_NAME_SEPARATOR },
    { ASIC_DB,         LEGACY_TABLE_NAME_SEPARATOR },
@@ -20,8 +23,7 @@ const TableNameSeparatorMap TableBase::tableNameSeparatorMap = {
    { CONFIG_DB,       NEW_TABLE_NAME_SEPARATOR },
    { PFC_WD_DB,       LEGACY_TABLE_NAME_SEPARATOR },
    { FLEX_COUNTER_DB, LEGACY_TABLE_NAME_SEPARATOR },
-   { STATE_DB,        NEW_TABLE_NAME_SEPARATOR },
-   { TEST_DB,         LEGACY_TABLE_NAME_SEPARATOR }
+   { STATE_DB,        NEW_TABLE_NAME_SEPARATOR }
 };
 
 Table::Table(DBConnector *db, string tableName)

--- a/common/table.cpp
+++ b/common/table.cpp
@@ -31,7 +31,7 @@ Table::Table(DBConnector *db, string tableName)
 }
 
 Table::Table(RedisPipeline *pipeline, string tableName, bool buffered)
-    : TableBase(pipeline->getDbConnector(), tableName)
+    : TableBase(pipeline->getDbId(), tableName)
     , m_buffered(buffered)
     , m_pipeowned(false)
     , m_pipe(pipeline)

--- a/common/table.cpp
+++ b/common/table.cpp
@@ -12,14 +12,25 @@ using namespace std;
 using namespace swss;
 using json = nlohmann::json;
 
-Table::Table(DBConnector *db, string tableName, string tableSeparator)
-    : Table(new RedisPipeline(db, 1), tableName, tableSeparator, false)
+const TableNameSeparatorMap TableBase::tableNameSeparatorMap = {
+   { APPL_DB,         LEGACY_TABLE_NAME_SEPARATOR },
+   { ASIC_DB,         LEGACY_TABLE_NAME_SEPARATOR },
+   { COUNTERS_DB,     LEGACY_TABLE_NAME_SEPARATOR },
+   { LOGLEVEL_DB,     LEGACY_TABLE_NAME_SEPARATOR },
+   { CONFIG_DB,       NEW_TABLE_NAME_SEPARATOR },
+   { PFC_WD_DB,       LEGACY_TABLE_NAME_SEPARATOR },
+   { FLEX_COUNTER_DB, LEGACY_TABLE_NAME_SEPARATOR },
+   { STATE_DB,        NEW_TABLE_NAME_SEPARATOR }
+};
+
+Table::Table(DBConnector *db, string tableName)
+    : Table(new RedisPipeline(db, 1), tableName, false)
 {
     m_pipeowned = true;
 }
 
-Table::Table(RedisPipeline *pipeline, string tableName, string tableSeparator, bool buffered)
-    : TableBase(tableName, tableSeparator)
+Table::Table(RedisPipeline *pipeline, string tableName, bool buffered)
+    : TableBase(pipeline->getDbConnector(), tableName)
     , m_buffered(buffered)
     , m_pipeowned(false)
     , m_pipe(pipeline)

--- a/common/table.cpp
+++ b/common/table.cpp
@@ -12,18 +12,21 @@ using namespace std;
 using namespace swss;
 using json = nlohmann::json;
 
-const std::string TableBase::LEGACY_TABLE_NAME_SEPARATOR = ":";
-const std::string TableBase::NEW_TABLE_NAME_SEPARATOR = "|";
+// NOTE: Vertical bar ('|') is the new standard for table name separator
+// moving forward. We plan to eventually deprecate the colon separator
+// and transition all databases to use the vertical bar.
+const std::string TableBase::TABLE_NAME_SEPARATOR_COLON = ":";
+const std::string TableBase::TABLE_NAME_SEPARATOR_VBAR = "|";
 
 const TableNameSeparatorMap TableBase::tableNameSeparatorMap = {
-   { APPL_DB,         LEGACY_TABLE_NAME_SEPARATOR },
-   { ASIC_DB,         LEGACY_TABLE_NAME_SEPARATOR },
-   { COUNTERS_DB,     LEGACY_TABLE_NAME_SEPARATOR },
-   { LOGLEVEL_DB,     LEGACY_TABLE_NAME_SEPARATOR },
-   { CONFIG_DB,       NEW_TABLE_NAME_SEPARATOR },
-   { PFC_WD_DB,       LEGACY_TABLE_NAME_SEPARATOR },
-   { FLEX_COUNTER_DB, LEGACY_TABLE_NAME_SEPARATOR },
-   { STATE_DB,        NEW_TABLE_NAME_SEPARATOR }
+   { APPL_DB,         TABLE_NAME_SEPARATOR_COLON },
+   { ASIC_DB,         TABLE_NAME_SEPARATOR_COLON },
+   { COUNTERS_DB,     TABLE_NAME_SEPARATOR_COLON },
+   { LOGLEVEL_DB,     TABLE_NAME_SEPARATOR_COLON },
+   { CONFIG_DB,       TABLE_NAME_SEPARATOR_VBAR  },
+   { PFC_WD_DB,       TABLE_NAME_SEPARATOR_COLON },
+   { FLEX_COUNTER_DB, TABLE_NAME_SEPARATOR_COLON },
+   { STATE_DB,        TABLE_NAME_SEPARATOR_VBAR  }
 };
 
 Table::Table(DBConnector *db, string tableName)

--- a/common/table.h
+++ b/common/table.h
@@ -46,8 +46,8 @@ public:
         }
         else
         {
-            SWSS_LOG_NOTICE("Unrecognized database ID. Using default table name separator ('%s')", NEW_TABLE_NAME_SEPARATOR.c_str());
-            m_tableSeparator = NEW_TABLE_NAME_SEPARATOR;
+            SWSS_LOG_NOTICE("Unrecognized database ID. Using default table name separator ('%s')", TABLE_NAME_SEPARATOR_VBAR.c_str());
+            m_tableSeparator = TABLE_NAME_SEPARATOR_VBAR;
         }
     }
 
@@ -68,8 +68,8 @@ public:
 
     std::string getChannelName() { return m_tableName + "_CHANNEL"; }
 private:
-    static const std::string LEGACY_TABLE_NAME_SEPARATOR;
-    static const std::string NEW_TABLE_NAME_SEPARATOR;
+    static const std::string TABLE_NAME_SEPARATOR_COLON;
+    static const std::string TABLE_NAME_SEPARATOR_VBAR;
     static const TableNameSeparatorMap tableNameSeparatorMap;
 
     std::string m_tableName;

--- a/common/table.h
+++ b/common/table.h
@@ -18,9 +18,6 @@
 
 namespace swss {
 
-#define LEGACY_TABLE_NAME_SEPARATOR  ":"
-#define NEW_TABLE_NAME_SEPARATOR     "|"
-
 // Mapping of DB ID to table name separator string
 typedef std::map<int, std::string> TableNameSeparatorMap;
 
@@ -43,10 +40,15 @@ public:
         /* Look up table separator for the provided DB */
         auto it = tableNameSeparatorMap.find(dbId);
 
-        if (it == tableNameSeparatorMap.end())
-            throw std::invalid_argument("Unable to find table separator for DB " + std::to_string(dbId));
-
-        m_tableSeparator = it->second;
+        if (it != tableNameSeparatorMap.end())
+        {
+            m_tableSeparator = it->second;
+        }
+        else
+        {
+            SWSS_LOG_NOTICE("Unrecognized database ID. Using default table name separator ('%s')", NEW_TABLE_NAME_SEPARATOR.c_str());
+            m_tableSeparator = NEW_TABLE_NAME_SEPARATOR;
+        }
     }
 
     std::string getTableName() const { return m_tableName; }
@@ -66,6 +68,8 @@ public:
 
     std::string getChannelName() { return m_tableName + "_CHANNEL"; }
 private:
+    static const std::string LEGACY_TABLE_NAME_SEPARATOR;
+    static const std::string NEW_TABLE_NAME_SEPARATOR;
     static const TableNameSeparatorMap tableNameSeparatorMap;
 
     std::string m_tableName;

--- a/common/table.h
+++ b/common/table.h
@@ -37,14 +37,14 @@ typedef std::map<std::string,TableMap> TableDump;
 
 class TableBase {
 public:
-    TableBase(DBConnector *db, std::string tableName)
+    TableBase(int dbId, std::string tableName)
         : m_tableName(tableName)
     {
         /* Look up table separator for the provided DB */
-        auto it = tableNameSeparatorMap.find(db->getDB());
+        auto it = tableNameSeparatorMap.find(dbId);
 
         if (it == tableNameSeparatorMap.end())
-            throw std::invalid_argument("Unable to find table separator for DB " + std::to_string(db->getDB()));
+            throw std::invalid_argument("Unable to find table separator for DB " + std::to_string(dbId));
 
         m_tableSeparator = it->second;
     }
@@ -104,7 +104,7 @@ public:
     /* The default value of pop batch size is 128 */
     static constexpr int DEFAULT_POP_BATCH_SIZE = 128;
 
-    TableConsumable(DBConnector *db, std::string tableName) : TableBase(db, tableName) { }
+    TableConsumable(int dbId, std::string tableName) : TableBase(dbId, tableName) { }
 };
 
 class TableEntryEnumerable {

--- a/tests/redis_piped_ut.cpp
+++ b/tests/redis_piped_ut.cpp
@@ -327,7 +327,7 @@ TEST(Table, piped_test)
     string tableName = "TABLE_UT_TEST";
     DBConnector db(TEST_VIEW, "localhost", 6379, 0);
     RedisPipeline pipeline(&db);
-    Table t(&pipeline, tableName, DEFAULT_TABLE_NAME_SEPARATOR, true);
+    Table t(&pipeline, tableName, true);
 
     clearDB();
     cout << "Starting table manipulations" << endl;

--- a/tests/redis_subscriber_state_ut.cpp
+++ b/tests/redis_subscriber_state_ut.cpp
@@ -95,7 +95,7 @@ static inline void clearDB()
 static void producerWorker(int index)
 {
     DBConnector db(TEST_VIEW, dbhost, dbport, 0);
-    Table p(&db, testTableName, CONFIGDB_TABLE_NAME_SEPARATOR);
+    Table p(&db, testTableName);
 
     for (int i = 0; i < NUMBER_OF_OPS; i++)
     {
@@ -179,7 +179,7 @@ TEST(SubscriberStateTable, set)
     /* Prepare producer */
     int index = 0;
     DBConnector db(TEST_VIEW, dbhost, dbport, 0);
-    Table p(&db, testTableName, CONFIGDB_TABLE_NAME_SEPARATOR);
+    Table p(&db, testTableName);
     string key = "TheKey";
     int maxNumOfFields = 2;
 
@@ -234,7 +234,7 @@ TEST(SubscriberStateTable, del)
     /* Prepare producer */
     int index = 0;
     DBConnector db(TEST_VIEW, dbhost, dbport, 0);
-    Table p(&db, testTableName, CONFIGDB_TABLE_NAME_SEPARATOR);
+    Table p(&db, testTableName);
     string key = "TheKey";
     int maxNumOfFields = 2;
 
@@ -287,7 +287,7 @@ TEST(SubscriberStateTable, table_state)
     /* Prepare producer */
     int index = 0;
     DBConnector db(TEST_VIEW, dbhost, dbport, 0);
-    Table p(&db, testTableName, CONFIGDB_TABLE_NAME_SEPARATOR);
+    Table p(&db, testTableName);
 
     for (int i = 0; i < NUMBER_OF_OPS; i++)
    {

--- a/tests/redis_ut.cpp
+++ b/tests/redis_ut.cpp
@@ -16,7 +16,6 @@
 using namespace std;
 using namespace swss;
 
-#define TEST_VIEW            (7)
 #define NUMBER_OF_THREADS   (64) // Spawning more than 256 threads causes libc++ to except
 #define NUMBER_OF_OPS     (1000)
 #define MAX_FIELDS_DIV      (30) // Testing up to 30 fields objects
@@ -74,7 +73,7 @@ void validateFields(const string& key, const vector<FieldValueTuple>& f)
 void producerWorker(int index)
 {
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
-    DBConnector db(TEST_VIEW, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, "localhost", 6379, 0);
     ProducerTable p(&db, tableName);
 
     for (int i = 0; i < NUMBER_OF_OPS; i++)
@@ -102,7 +101,7 @@ void producerWorker(int index)
 void consumerWorker(int index)
 {
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
-    DBConnector db(TEST_VIEW, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, "localhost", 6379, 0);
     ConsumerTable c(&db, tableName);
     Select cs;
     Selectable *selectcs;
@@ -138,14 +137,14 @@ void consumerWorker(int index)
 
 void clearDB()
 {
-    DBConnector db(TEST_VIEW, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, "localhost", 6379, 0);
     RedisReply r(&db, "FLUSHALL", REDIS_REPLY_STATUS);
     r.checkStatusOK();
 }
 
 void TableBasicTest(string tableName, string separator)
 {
-    DBConnector db(TEST_VIEW, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, "localhost", 6379, 0);
 
     Table t(&db, tableName);
     string tableNameSeparator = t.getTableNameSeparator();
@@ -263,7 +262,7 @@ TEST(DBConnector, test)
 
 TEST(DBConnector, multitable)
 {
-    DBConnector db(TEST_VIEW, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, "localhost", 6379, 0);
     ConsumerTable *consumers[NUMBER_OF_THREADS];
     thread *producerThreads[NUMBER_OF_THREADS];
     KeyOpFieldsValuesTuple kco;
@@ -328,7 +327,7 @@ void notificationProducer()
 {
     sleep(1);
 
-    DBConnector db(TEST_VIEW, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, "localhost", 6379, 0);
     NotificationProducer np(&db, "UT_REDIS_CHANNEL");
 
     vector<FieldValueTuple> values;
@@ -341,7 +340,7 @@ void notificationProducer()
 
 TEST(DBConnector, notifications)
 {
-    DBConnector db(TEST_VIEW, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, "localhost", 6379, 0);
     NotificationConsumer nc(&db, "UT_REDIS_CHANNEL");
     Select s;
     s.addSelectable(&nc);
@@ -470,7 +469,7 @@ TEST(ProducerConsumer, Prefix)
 {
     std::string tableName = "tableName";
 
-    DBConnector db(TEST_VIEW, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, "localhost", 6379, 0);
     ProducerTable p(&db, tableName);
 
     std::vector<FieldValueTuple> values;
@@ -499,7 +498,7 @@ TEST(ProducerConsumer, Pop)
 {
     std::string tableName = "tableName";
 
-    DBConnector db(TEST_VIEW, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, "localhost", 6379, 0);
     ProducerTable p(&db, tableName);
 
     std::vector<FieldValueTuple> values;
@@ -527,7 +526,7 @@ TEST(ProducerConsumer, Pop2)
 {
     std::string tableName = "tableName";
 
-    DBConnector db(TEST_VIEW, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, "localhost", 6379, 0);
     ProducerTable p(&db, tableName);
 
     std::vector<FieldValueTuple> values;
@@ -566,7 +565,7 @@ TEST(ProducerConsumer, PopEmpty)
 {
     std::string tableName = "tableName";
 
-    DBConnector db(TEST_VIEW, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, "localhost", 6379, 0);
 
     ConsumerTable c(&db, tableName);
 

--- a/tests/redis_ut.cpp
+++ b/tests/redis_ut.cpp
@@ -16,6 +16,7 @@
 using namespace std;
 using namespace swss;
 
+#define TEST_DB             (15) // Default Redis config supports 16 databases, max DB ID is 15
 #define NUMBER_OF_THREADS   (64) // Spawning more than 256 threads causes libc++ to except
 #define NUMBER_OF_OPS     (1000)
 #define MAX_FIELDS_DIV      (30) // Testing up to 30 fields objects
@@ -142,16 +143,14 @@ void clearDB()
     r.checkStatusOK();
 }
 
-void TableBasicTest(string tableName, string separator)
+void TableBasicTest(string tableName)
 {
     DBConnector db(TEST_DB, "localhost", 6379, 0);
 
     Table t(&db, tableName);
-    string tableNameSeparator = t.getTableNameSeparator();
-    ASSERT_STREQ(tableNameSeparator.c_str(), separator.c_str());
 
     clearDB();
-    cout << "Starting table manipulations, table name separator is " << separator << endl;
+    cout << "Starting table manipulations" << endl;
 
     string key_1 = "a";
     string key_2 = "b";
@@ -450,19 +449,19 @@ TEST(DBConnector, selectabletimer)
 
 TEST(Table, basic)
 {
-    TableBasicTest("TABLE_UT_TEST", LEGACY_TABLE_NAME_SEPARATOR);
+    TableBasicTest("TABLE_UT_TEST");
 }
 
 TEST(Table, separator_in_table_name)
 {
-    std::string tableName = "TABLE_UT" + std::string(LEGACY_TABLE_NAME_SEPARATOR) + "TEST";
+    std::string tableName = "TABLE_UT|TEST";
 
-    TableBasicTest(tableName, LEGACY_TABLE_NAME_SEPARATOR);
+    TableBasicTest(tableName);
 }
 
 TEST(Table, table_separator_test)
 {
-    TableBasicTest("TABLE_UT_TEST", NEW_TABLE_NAME_SEPARATOR);
+    TableBasicTest("TABLE_UT_TEST");
 }
 
 TEST(ProducerConsumer, Prefix)

--- a/tests/redis_ut.cpp
+++ b/tests/redis_ut.cpp
@@ -147,7 +147,7 @@ void TableBasicTest(string tableName, string separator)
 {
     DBConnector db(TEST_VIEW, "localhost", 6379, 0);
 
-    Table t(&db, tableName, separator);
+    Table t(&db, tableName);
     string tableNameSeparator = t.getTableNameSeparator();
     ASSERT_STREQ(tableNameSeparator.c_str(), separator.c_str());
 
@@ -451,17 +451,19 @@ TEST(DBConnector, selectabletimer)
 
 TEST(Table, basic)
 {
-    TableBasicTest("TABLE_UT_TEST", ":");
+    TableBasicTest("TABLE_UT_TEST", LEGACY_TABLE_NAME_SEPARATOR);
 }
 
 TEST(Table, separator_in_table_name)
 {
-    TableBasicTest("TABLE_UT:TEST", ":");
+    std::string tableName = "TABLE_UT" + std::string(LEGACY_TABLE_NAME_SEPARATOR) + "TEST";
+
+    TableBasicTest(tableName, LEGACY_TABLE_NAME_SEPARATOR);
 }
 
 TEST(Table, table_separator_test)
 {
-    TableBasicTest("TABLE_UT_TEST", CONFIGDB_TABLE_NAME_SEPARATOR);
+    TableBasicTest("TABLE_UT_TEST", NEW_TABLE_NAME_SEPARATOR);
 }
 
 TEST(ProducerConsumer, Prefix)

--- a/tests/test_redis_ut.py
+++ b/tests/test_redis_ut.py
@@ -28,7 +28,7 @@ def test_Table():
 
 def test_SubscriberStateTable():
     db = swsscommon.DBConnector(0, "localhost", 6379, 0)
-    t = swsscommon.Table(db, "testsst", '|')
+    t = swsscommon.Table(db, "testsst")
     sel = swsscommon.Select()
     cst = swsscommon.SubscriberStateTable(db, "testsst")
     sel.addSelectable(cst)


### PR DESCRIPTION
Previously, SubscriberStateTable was hardcoded to use `CONFIGDB_TABLE_NAME_SEPARATOR`, which meant that one could only subscribe to notifications from databases which used "|" as a table name separator. If you subscribed to a database which used ":" as a table name separator, you would never receive notifications.

This change creates a constant map of database ID to table name separator, and chooses the appropriate table name separator for a table based on the DB one is connecting to. While fixing the above problem, I also simplified the method calls for instantiating Table objects, as one no longer needs to pass in the table separator. This will also prevent table name separator mismatches in the future.

Also changed name of `DEFAULT_TABLE_NAME_SEPARATOR` to `LEGACY_TABLE_NAME_SEPARATOR` and `CONFIGDB_TABLE_NAME_SEPARATOR` to `NEW_TABLE_NAME_SEPARATOR`

Also define `TEST_DB` at index 15, the largest index supported by default Redis config, for use in unit tests.

NOTE: This PR will require related changes in sonic-swss, sonic-sairedis and sonic-buildimage repos. I will submit those PRs shortly.