### PR TITLE
Fix a bug which caused SAI use unintialized log levels

### DIFF
--- a/common/logger.cpp
+++ b/common/logger.cpp
@@ -118,8 +118,8 @@ void Logger::linkToDbWithOutput(const std::string dbName, const PriorityChangeNo
 
     logger.m_currentPrios[dbName] = prio;
     logger.m_currentOutputs[dbName] = output;
-    prioNotify(key, prio);
-    outputNotify(key, output);
+    prioNotify(dbName, prio);
+    outputNotify(dbName, output);
 }
 
 void Logger::linkToDb(const std::string dbName, const PriorityChangeNotify& prioNotify, const std::string& defPrio)


### PR DESCRIPTION
Fix a bug introduced by https://github.com/Azure/sonic-swss-common/pull/186
Without the patch you can see following output. The SAI subsystem log levels weren't initialized:
```
ERR syncd: :- get_enum_value_from_name: not found SAI_API_SWITCH:SAI_API_SWITCH
ERR syncd: :- get_enum_value_from_name: not found SAI_API_PORT:SAI_API_PORT
ERR syncd: :- get_enum_value_from_name: not found SAI_API_FDB:SAI_API_FDB
ERR syncd: :- get_enum_value_from_name: not found SAI_API_VLAN:SAI_API_VLAN
ERR syncd: :- get_enum_value_from_name: not found SAI_API_VIRTUAL_ROUTER:SAI_API_VIRTUAL_ROUTER
ERR syncd: :- get_enum_value_from_name: not found SAI_API_ROUTE:SAI_API_ROUTE
ERR syncd: :- get_enum_value_from_name: not found SAI_API_NEXT_HOP:SAI_API_NEXT_HOP
ERR syncd: :- get_enum_value_from_name: not found SAI_API_NEXT_HOP_GROUP:SAI_API_NEXT_HOP_GROUP
ERR syncd: :- get_enum_value_from_name: not found SAI_API_ROUTER_INTERFACE:SAI_API_ROUTER_INTERFACE
ERR syncd: :- get_enum_value_from_name: not found SAI_API_NEIGHBOR:SAI_API_NEIGHBOR
ERR syncd: :- get_enum_value_from_name: not found SAI_API_ACL:SAI_API_ACL
ERR syncd: :- get_enum_value_from_name: not found SAI_API_HOSTIF:SAI_API_HOSTIF
ERR syncd: :- get_enum_value_from_name: not found SAI_API_MIRROR:SAI_API_MIRROR
ERR syncd: :- get_enum_value_from_name: not found SAI_API_SAMPLEPACKET:SAI_API_SAMPLEPACKET
ERR syncd: :- get_enum_value_from_name: not found SAI_API_STP:SAI_API_STP
ERR syncd: :- get_enum_value_from_name: not found SAI_API_LAG:SAI_API_LAG
ERR syncd: :- get_enum_value_from_name: not found SAI_API_POLICER:SAI_API_POLICER
ERR syncd: :- get_enum_value_from_name: not found SAI_API_WRED:SAI_API_WRED
ERR syncd: :- get_enum_value_from_name: not found SAI_API_QOS_MAP:SAI_API_QOS_MAP
ERR syncd: :- get_enum_value_from_name: not found SAI_API_QUEUE:SAI_API_QUEUE
ERR syncd: :- get_enum_value_from_name: not found SAI_API_SCHEDULER:SAI_API_SCHEDULER
ERR syncd: :- get_enum_value_from_name: not found SAI_API_SCHEDULER_GROUP:SAI_API_SCHEDULER_GROUP
ERR syncd: :- get_enum_value_from_name: not found SAI_API_BUFFER:SAI_API_BUFFER
ERR syncd: :- get_enum_value_from_name: not found SAI_API_HASH:SAI_API_HASH
ERR syncd: :- get_enum_value_from_name: not found SAI_API_UDF:SAI_API_UDF
ERR syncd: :- get_enum_value_from_name: not found SAI_API_TUNNEL:SAI_API_TUNNEL
ERR syncd: :- get_enum_value_from_name: not found SAI_API_L2MC:SAI_API_L2MC
ERR syncd: :- get_enum_value_from_name: not found SAI_API_IPMC:SAI_API_IPMC
ERR syncd: :- get_enum_value_from_name: not found SAI_API_RPF_GROUP:SAI_API_RPF_GROUP
ERR syncd: :- get_enum_value_from_name: not found SAI_API_L2MC_GROUP:SAI_API_L2MC_GROUP
ERR syncd: :- get_enum_value_from_name: not found SAI_API_IPMC_GROUP:SAI_API_IPMC_GROUP
ERR syncd: :- get_enum_value_from_name: not found SAI_API_MCAST_FDB:SAI_API_MCAST_FDB
ERR syncd: :- get_enum_value_from_name: not found SAI_API_BRIDGE:SAI_API_BRIDGE
ERR syncd: :- get_enum_value_from_name: not found SAI_API_TAM:SAI_API_TAM
ERR syncd: :- get_enum_value_from_name: not found SAI_API_SEGMENTROUTE:SAI_API_SEGMENTROUTE
ERR syncd: :- get_enum_value_from_name: not found SAI_API_MPLS:SAI_API_MPLS
ERR syncd: :- get_enum_value_from_name: not found SAI_API_UBURST:SAI_API_UBURST

```