### PR TITLE
Make C++ Unit Tests work with recent table name separator changes

### DIFF
--- a/tests/json_ut.cpp
+++ b/tests/json_ut.cpp
@@ -6,13 +6,13 @@ using namespace std;
 using namespace swss;
 using json = nlohmann::json;
 
-#define TEST_VIEW       (7)
+#define TEST_DB         (15) // Default Redis config supports 16 databases, max DB ID is 15
 #define TEST_DUMP_FILE  "ut_dump_file.txt"
 
 TEST(JSON, test)
 {
     /* Construct the file */
-    DBConnector db(TEST_VIEW, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, "localhost", 6379, 0);
     ProducerTable *p;
     p = new ProducerTable(&db, "UT_REDIS", TEST_DUMP_FILE);
 

--- a/tests/json_ut.cpp
+++ b/tests/json_ut.cpp
@@ -15,6 +15,7 @@ TEST(JSON, test)
     DBConnector db(TEST_DB, "localhost", 6379, 0);
     ProducerTable *p;
     p = new ProducerTable(&db, "UT_REDIS", TEST_DUMP_FILE);
+    string separator = p->getTableNameSeparator();
 
     vector<FieldValueTuple> fvTuples;
     FieldValueTuple fv1("test_field_1", "test_value_1");
@@ -51,7 +52,7 @@ TEST(JSON, test)
                 EXPECT_TRUE(it.value() == "SET" || it.value() == "DEL");
             else
             {
-                EXPECT_TRUE(it.key() == "UT_REDIS:test_key_1" || it.key() == "UT_REDIS:test_key_2");
+                EXPECT_TRUE(it.key() == "UT_REDIS" + separator + "test_key_1" || it.key() == "UT_REDIS" + separator + "test_key_2");
                 auto subitem = it.value();
                 EXPECT_TRUE(subitem.is_object());
                 if (subitem.size() > 0)

--- a/tests/redis_piped_state_ut.cpp
+++ b/tests/redis_piped_state_ut.cpp
@@ -16,11 +16,11 @@
 using namespace std;
 using namespace swss;
 
-#define TEST_DB             (15) // Default Redis config supports 16 databases, max DB ID is 15
-#define NUMBER_OF_THREADS   (64) // Spawning more than 256 threads causes libc++ to except
-#define NUMBER_OF_OPS     (1000)
-#define MAX_FIELDS_DIV      (30) // Testing up to 30 fields objects
-#define PRINT_SKIP          (10) // Print + for Producer and - for Consumer for every 100 ops
+#define TEST_DB           APPL_DB // Need to test against a DB which uses a colon table name separator due to hardcoding in consumer_table_pops.lua
+#define NUMBER_OF_THREADS    (64) // Spawning more than 256 threads causes libc++ to except
+#define NUMBER_OF_OPS      (1000)
+#define MAX_FIELDS_DIV       (30) // Testing up to 30 fields objects
+#define PRINT_SKIP           (10) // Print + for Producer and - for Consumer for every 100 ops
 
 static inline int getMaxFields(int i)
 {

--- a/tests/redis_piped_state_ut.cpp
+++ b/tests/redis_piped_state_ut.cpp
@@ -16,7 +16,7 @@
 using namespace std;
 using namespace swss;
 
-#define TEST_VIEW            (7)
+#define TEST_DB             (15) // Default Redis config supports 16 databases, max DB ID is 15
 #define NUMBER_OF_THREADS   (64) // Spawning more than 256 threads causes libc++ to except
 #define NUMBER_OF_OPS     (1000)
 #define MAX_FIELDS_DIV      (30) // Testing up to 30 fields objects
@@ -76,7 +76,7 @@ static inline void validateFields(const string& key, const vector<FieldValueTupl
 static void producerWorker(int index)
 {
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
-    DBConnector db(TEST_VIEW, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, "localhost", 6379, 0);
     RedisPipeline pipeline(&db);
     ProducerStateTable p(&pipeline, tableName, true);
 
@@ -104,7 +104,7 @@ static void producerWorker(int index)
 static void consumerWorker(int index)
 {
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
-    DBConnector db(TEST_VIEW, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, "localhost", 6379, 0);
     ConsumerStateTable c(&db, tableName);
     Select cs;
     Selectable *selectcs;
@@ -140,7 +140,7 @@ static void consumerWorker(int index)
 
 static inline void clearDB()
 {
-    DBConnector db(TEST_VIEW, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, "localhost", 6379, 0);
     RedisReply r(&db, "FLUSHALL", REDIS_REPLY_STATUS);
     r.checkStatusOK();
 }
@@ -152,7 +152,7 @@ TEST(ConsumerStateTable, async_double_set)
     /* Prepare producer */
     int index = 0;
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
-    DBConnector db(TEST_VIEW, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, "localhost", 6379, 0);
     RedisPipeline pipeline(&db);
     ProducerStateTable p(&pipeline, tableName, true);
     string key = "TheKey";
@@ -230,7 +230,7 @@ TEST(ConsumerStateTable, async_set_del)
     /* Prepare producer */
     int index = 0;
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
-    DBConnector db(TEST_VIEW, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, "localhost", 6379, 0);
     RedisPipeline pipeline(&db);
     ProducerStateTable p(&pipeline, tableName, true);
     string key = "TheKey";
@@ -285,7 +285,7 @@ TEST(ConsumerStateTable, async_set_del_set)
     /* Prepare producer */
     int index = 0;
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
-    DBConnector db(TEST_VIEW, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, "localhost", 6379, 0);
     RedisPipeline pipeline(&db);
     ProducerStateTable p(&pipeline, tableName, true);
     string key = "TheKey";
@@ -361,7 +361,7 @@ TEST(ConsumerStateTable, async_singlethread)
 
     int index = 0;
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
-    DBConnector db(TEST_VIEW, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, "localhost", 6379, 0);
     RedisPipeline pipeline(&db);
     ProducerStateTable p(&pipeline, tableName, true);
 
@@ -463,7 +463,7 @@ TEST(ConsumerStateTable, async_test)
 
 TEST(ConsumerStateTable, async_multitable)
 {
-    DBConnector db(TEST_VIEW, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, "localhost", 6379, 0);
     ConsumerStateTable *consumers[NUMBER_OF_THREADS];
     thread *producerThreads[NUMBER_OF_THREADS];
     KeyOpFieldsValuesTuple kco;

--- a/tests/redis_piped_ut.cpp
+++ b/tests/redis_piped_ut.cpp
@@ -15,7 +15,7 @@
 using namespace std;
 using namespace swss;
 
-#define TEST_VIEW            (7)
+#define TEST_DB             (15) // Default Redis config supports 16 databases, max DB ID is 15
 #define NUMBER_OF_THREADS   (64) // Spawning more than 256 threads causes libc++ to except
 #define NUMBER_OF_OPS     (1000)
 #define MAX_FIELDS_DIV      (30) // Testing up to 30 fields objects
@@ -73,7 +73,7 @@ static void validateFields(const string& key, const vector<FieldValueTuple>& f)
 static void producerWorker(int index)
 {
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
-    DBConnector db(TEST_VIEW, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, "localhost", 6379, 0);
     RedisPipeline pipeline(&db);
     ProducerTable p(&pipeline, tableName, true);
 
@@ -102,7 +102,7 @@ static void producerWorker(int index)
 static void consumerWorker(int index)
 {
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
-    DBConnector db(TEST_VIEW, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, "localhost", 6379, 0);
     ConsumerTable c(&db, tableName);
     Select cs;
     Selectable *selectcs;
@@ -138,7 +138,7 @@ static void consumerWorker(int index)
 
 static void clearDB()
 {
-    DBConnector db(TEST_VIEW, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, "localhost", 6379, 0);
     RedisReply r(&db, "FLUSHALL", REDIS_REPLY_STATUS);
     r.checkStatusOK();
 }
@@ -172,7 +172,7 @@ TEST(DBConnector, piped_test)
 
 TEST(DBConnector, piped_multitable)
 {
-    DBConnector db(TEST_VIEW, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, "localhost", 6379, 0);
     ConsumerTable *consumers[NUMBER_OF_THREADS];
     thread *producerThreads[NUMBER_OF_THREADS];
     KeyOpFieldsValuesTuple kco;
@@ -237,7 +237,7 @@ static void notificationProducer()
 {
     sleep(1);
 
-    DBConnector db(TEST_VIEW, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, "localhost", 6379, 0);
     NotificationProducer np(&db, "UT_REDIS_CHANNEL");
 
     vector<FieldValueTuple> values;
@@ -250,7 +250,7 @@ static void notificationProducer()
 
 TEST(DBConnector, piped_notifications)
 {
-    DBConnector db(TEST_VIEW, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, "localhost", 6379, 0);
     NotificationConsumer nc(&db, "UT_REDIS_CHANNEL");
     Select s;
     s.addSelectable(&nc);
@@ -325,7 +325,7 @@ TEST(DBConnector, piped_selectableevent)
 TEST(Table, piped_test)
 {
     string tableName = "TABLE_UT_TEST";
-    DBConnector db(TEST_VIEW, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, "localhost", 6379, 0);
     RedisPipeline pipeline(&db);
     Table t(&pipeline, tableName, true);
 
@@ -406,7 +406,7 @@ TEST(ProducerConsumer, piped_Prefix)
 {
     string tableName = "tableName";
 
-    DBConnector db(TEST_VIEW, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, "localhost", 6379, 0);
     RedisPipeline pipeline(&db);
     ProducerTable p(&pipeline, tableName, true);
 

--- a/tests/redis_state_ut.cpp
+++ b/tests/redis_state_ut.cpp
@@ -15,11 +15,11 @@
 using namespace std;
 using namespace swss;
 
-#define TEST_DB             (15) // Default Redis config supports 16 databases, max DB ID is 15
-#define NUMBER_OF_THREADS   (64) // Spawning more than 256 threads causes libc++ to except
-#define NUMBER_OF_OPS     (1000)
-#define MAX_FIELDS_DIV      (30) // Testing up to 30 fields objects
-#define PRINT_SKIP          (10) // Print + for Producer and - for Consumer for every 100 ops
+#define TEST_DB           APPL_DB // Need to test against a DB which uses a colon table name separator due to hardcoding in consumer_table_pops.lua
+#define NUMBER_OF_THREADS    (64) // Spawning more than 256 threads causes libc++ to except
+#define NUMBER_OF_OPS      (1000)
+#define MAX_FIELDS_DIV       (30) // Testing up to 30 fields objects
+#define PRINT_SKIP           (10) // Print + for Producer and - for Consumer for every 100 ops
 
 static inline int getMaxFields(int i)
 {

--- a/tests/redis_state_ut.cpp
+++ b/tests/redis_state_ut.cpp
@@ -15,7 +15,7 @@
 using namespace std;
 using namespace swss;
 
-#define TEST_VIEW            (7)
+#define TEST_DB             (15) // Default Redis config supports 16 databases, max DB ID is 15
 #define NUMBER_OF_THREADS   (64) // Spawning more than 256 threads causes libc++ to except
 #define NUMBER_OF_OPS     (1000)
 #define MAX_FIELDS_DIV      (30) // Testing up to 30 fields objects
@@ -75,7 +75,7 @@ static inline void validateFields(const string& key, const vector<FieldValueTupl
 static void producerWorker(int index)
 {
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
-    DBConnector db(TEST_VIEW, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, "localhost", 6379, 0);
     ProducerStateTable p(&db, tableName);
 
     for (int i = 0; i < NUMBER_OF_OPS; i++)
@@ -102,7 +102,7 @@ static void producerWorker(int index)
 static void consumerWorker(int index)
 {
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
-    DBConnector db(TEST_VIEW, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, "localhost", 6379, 0);
     ConsumerStateTable c(&db, tableName);
     Select cs;
     Selectable *selectcs;
@@ -138,7 +138,7 @@ static void consumerWorker(int index)
 
 static inline void clearDB()
 {
-    DBConnector db(TEST_VIEW, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, "localhost", 6379, 0);
     RedisReply r(&db, "FLUSHALL", REDIS_REPLY_STATUS);
     r.checkStatusOK();
 }
@@ -150,7 +150,7 @@ TEST(ConsumerStateTable, double_set)
     /* Prepare producer */
     int index = 0;
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
-    DBConnector db(TEST_VIEW, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, "localhost", 6379, 0);
     ProducerStateTable p(&db, tableName);
     string key = "TheKey";
     int maxNumOfFields = 2;
@@ -226,7 +226,7 @@ TEST(ConsumerStateTable, set_del)
     /* Prepare producer */
     int index = 0;
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
-    DBConnector db(TEST_VIEW, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, "localhost", 6379, 0);
     ProducerStateTable p(&db, tableName);
     string key = "TheKey";
     int maxNumOfFields = 2;
@@ -279,7 +279,7 @@ TEST(ConsumerStateTable, set_del_set)
     /* Prepare producer */
     int index = 0;
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
-    DBConnector db(TEST_VIEW, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, "localhost", 6379, 0);
     ProducerStateTable p(&db, tableName);
     string key = "TheKey";
     int maxNumOfFields = 2;
@@ -353,7 +353,7 @@ TEST(ConsumerStateTable, singlethread)
 
     int index = 0;
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
-    DBConnector db(TEST_VIEW, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, "localhost", 6379, 0);
     ProducerStateTable p(&db, tableName);
 
     for (int i = 0; i < NUMBER_OF_OPS; i++)
@@ -452,7 +452,7 @@ TEST(ConsumerStateTable, test)
 
 TEST(ConsumerStateTable, multitable)
 {
-    DBConnector db(TEST_VIEW, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, "localhost", 6379, 0);
     ConsumerStateTable *consumers[NUMBER_OF_THREADS];
     thread *producerThreads[NUMBER_OF_THREADS];
     KeyOpFieldsValuesTuple kco;

--- a/tests/redis_subscriber_state_ut.cpp
+++ b/tests/redis_subscriber_state_ut.cpp
@@ -12,7 +12,7 @@
 using namespace std;
 using namespace swss;
 
-#define TEST_VIEW            (7)
+#define TEST_DB             (15) // Default Redis config supports 16 databases, max DB ID is 15
 #define NUMBER_OF_THREADS   (64) // Spawning more than 256 threads causes libc++ to except
 #define NUMBER_OF_OPS     (1000)
 #define MAX_FIELDS_DIV      (30) // Testing up to 30 fields objects
@@ -87,14 +87,14 @@ static inline void validateFields(const string& key, const vector<FieldValueTupl
 
 static inline void clearDB()
 {
-    DBConnector db(TEST_VIEW, dbhost, dbport, 0);
+    DBConnector db(TEST_DB, dbhost, dbport, 0);
     RedisReply r(&db, "FLUSHALL", REDIS_REPLY_STATUS);
     r.checkStatusOK();
 }
 
 static void producerWorker(int index)
 {
-    DBConnector db(TEST_VIEW, dbhost, dbport, 0);
+    DBConnector db(TEST_DB, dbhost, dbport, 0);
     Table p(&db, testTableName);
 
     for (int i = 0; i < NUMBER_OF_OPS; i++)
@@ -124,7 +124,7 @@ static void producerWorker(int index)
 
 static void subscriberWorker(int index, int *status)
 {
-    DBConnector db(TEST_VIEW, dbhost, dbport, 0);
+    DBConnector db(TEST_DB, dbhost, dbport, 0);
     SubscriberStateTable c(&db, testTableName);
     Select cs;
     Selectable *selectcs;
@@ -178,7 +178,7 @@ TEST(SubscriberStateTable, set)
 
     /* Prepare producer */
     int index = 0;
-    DBConnector db(TEST_VIEW, dbhost, dbport, 0);
+    DBConnector db(TEST_DB, dbhost, dbport, 0);
     Table p(&db, testTableName);
     string key = "TheKey";
     int maxNumOfFields = 2;
@@ -233,7 +233,7 @@ TEST(SubscriberStateTable, del)
 
     /* Prepare producer */
     int index = 0;
-    DBConnector db(TEST_VIEW, dbhost, dbport, 0);
+    DBConnector db(TEST_DB, dbhost, dbport, 0);
     Table p(&db, testTableName);
     string key = "TheKey";
     int maxNumOfFields = 2;
@@ -286,7 +286,7 @@ TEST(SubscriberStateTable, table_state)
 
     /* Prepare producer */
     int index = 0;
-    DBConnector db(TEST_VIEW, dbhost, dbport, 0);
+    DBConnector db(TEST_DB, dbhost, dbport, 0);
     Table p(&db, testTableName);
 
     for (int i = 0; i < NUMBER_OF_OPS; i++)


### PR DESCRIPTION
- Align (almost) all unit tests with new definition of TEST_DB (ID 15). Exceptions include redis_state_ut.cpp and redis_piped_state_ut.cpp, which now test against APPL_DB (DB ID 0), because due to hardcoded colon (":") separators in consumer_table_pops.lua, ConsumerTable/ConsumerStateTable currently only work with tables which use the colon as a table name separator.

- Remove hard-coded table name separators from json_ut.cpp. Instead, fetch separator from Table object