### PR TITLE
Pass arguments by references for constructors and methods

### DIFF
--- a/common/consumerstatetable.cpp
+++ b/common/consumerstatetable.cpp
@@ -11,7 +11,7 @@
 
 namespace swss {
 
-ConsumerStateTable::ConsumerStateTable(DBConnector *db, std::string tableName, int popBatchSize, int pri)
+ConsumerStateTable::ConsumerStateTable(DBConnector *db, const std::string &tableName, int popBatchSize, int pri)
     : ConsumerTableBase(db, tableName, popBatchSize, pri)
     , TableName_KeySet(tableName)
 {
@@ -30,7 +30,7 @@ ConsumerStateTable::ConsumerStateTable(DBConnector *db, std::string tableName, i
     setQueueLength(r.getReply<long long int>());
 }
 
-void ConsumerStateTable::pops(std::deque<KeyOpFieldsValuesTuple> &vkco, std::string /*prefix*/)
+void ConsumerStateTable::pops(std::deque<KeyOpFieldsValuesTuple> &vkco, const std::string& /*prefix*/)
 {
     static std::string luaScript = loadLuaScript("consumer_state_table_pops.lua");
 

--- a/common/consumerstatetable.h
+++ b/common/consumerstatetable.h
@@ -10,10 +10,10 @@ namespace swss {
 class ConsumerStateTable : public ConsumerTableBase, public TableName_KeySet
 {
 public:
-    ConsumerStateTable(DBConnector *db, std::string tableName, int popBatchSize = DEFAULT_POP_BATCH_SIZE, int pri = 0);
+    ConsumerStateTable(DBConnector *db, const std::string &tableName, int popBatchSize = DEFAULT_POP_BATCH_SIZE, int pri = 0);
 
     /* Get multiple pop elements */
-    void pops(std::deque<KeyOpFieldsValuesTuple> &vkco, std::string prefix = EMPTY_PREFIX);
+    void pops(std::deque<KeyOpFieldsValuesTuple> &vkco, const std::string &prefix = EMPTY_PREFIX);
 };
 
 }

--- a/common/consumertable.cpp
+++ b/common/consumertable.cpp
@@ -14,7 +14,7 @@ using namespace std;
 
 namespace swss {
 
-ConsumerTable::ConsumerTable(DBConnector *db, string tableName, int popBatchSize, int pri)
+ConsumerTable::ConsumerTable(DBConnector *db, const string &tableName, int popBatchSize, int pri)
     : ConsumerTableBase(db, tableName, popBatchSize, pri)
     , TableName_KeyValueOpQueues(tableName)
 {
@@ -34,7 +34,7 @@ ConsumerTable::ConsumerTable(DBConnector *db, string tableName, int popBatchSize
     setQueueLength(r.getReply<long long int>());
 }
 
-void ConsumerTable::pops(deque<KeyOpFieldsValuesTuple> &vkco, string prefix)
+void ConsumerTable::pops(deque<KeyOpFieldsValuesTuple> &vkco, const string &prefix)
 {
     static std::string luaScript = loadLuaScript("consumer_table_pops.lua");
 

--- a/common/consumertable.h
+++ b/common/consumertable.h
@@ -13,10 +13,10 @@ namespace swss {
 class ConsumerTable : public ConsumerTableBase, public TableName_KeyValueOpQueues
 {
 public:
-    ConsumerTable(DBConnector *db, std::string tableName, int popBatchSize = DEFAULT_POP_BATCH_SIZE, int pri = 0);
+    ConsumerTable(DBConnector *db, const std::string &tableName, int popBatchSize = DEFAULT_POP_BATCH_SIZE, int pri = 0);
 
     /* Get multiple pop elements */
-    void pops(std::deque<KeyOpFieldsValuesTuple> &vkco, std::string prefix = EMPTY_PREFIX);
+    void pops(std::deque<KeyOpFieldsValuesTuple> &vkco, const std::string &prefix = EMPTY_PREFIX);
 };
 
 }

--- a/common/consumertablebase.cpp
+++ b/common/consumertablebase.cpp
@@ -2,7 +2,7 @@
 
 namespace swss {
 
-ConsumerTableBase::ConsumerTableBase(DBConnector *db, std::string tableName, int popBatchSize, int pri):
+ConsumerTableBase::ConsumerTableBase(DBConnector *db, const std::string &tableName, int popBatchSize, int pri):
         TableConsumable(db->getDbId(), tableName, pri),
         RedisTransactioner(db),
         POP_BATCH_SIZE(popBatchSize)
@@ -13,12 +13,12 @@ ConsumerTableBase::~ConsumerTableBase()
 {
 }
 
-void ConsumerTableBase::pop(KeyOpFieldsValuesTuple &kco, std::string prefix)
+void ConsumerTableBase::pop(KeyOpFieldsValuesTuple &kco, const std::string &prefix)
 {
     pop(kfvKey(kco), kfvOp(kco), kfvFieldsValues(kco), prefix);
 }
 
-void ConsumerTableBase::pop(std::string &key, std::string &op, std::vector<FieldValueTuple> &fvs, std::string prefix)
+void ConsumerTableBase::pop(std::string &key, std::string &op, std::vector<FieldValueTuple> &fvs, const std::string &prefix)
 {
     if (m_buffer.empty())
     {

--- a/common/consumertablebase.h
+++ b/common/consumertablebase.h
@@ -10,13 +10,13 @@ class ConsumerTableBase: public TableConsumable, public RedisTransactioner
 public:
     const int POP_BATCH_SIZE;
 
-    ConsumerTableBase(DBConnector *db, std::string tableName, int popBatchSize = DEFAULT_POP_BATCH_SIZE, int pri = 0);
+    ConsumerTableBase(DBConnector *db, const std::string &tableName, int popBatchSize = DEFAULT_POP_BATCH_SIZE, int pri = 0);
 
     virtual ~ConsumerTableBase();
 
-    void pop(KeyOpFieldsValuesTuple &kco, std::string prefix = EMPTY_PREFIX);
+    void pop(KeyOpFieldsValuesTuple &kco, const std::string &prefix = EMPTY_PREFIX);
 
-    void pop(std::string &key, std::string &op, std::vector<FieldValueTuple> &fvs, std::string prefix = EMPTY_PREFIX);
+    void pop(std::string &key, std::string &op, std::vector<FieldValueTuple> &fvs, const std::string &prefix = EMPTY_PREFIX);
 
 protected:
 

--- a/common/converter.h
+++ b/common/converter.h
@@ -10,7 +10,7 @@
 
 namespace swss {
 
-static inline uint64_t __to_uint64(std::string str, uint64_t min = std::numeric_limits<uint64_t>::min(), uint64_t max = std::numeric_limits<uint64_t>::max())
+static inline uint64_t __to_uint64(const std::string &str, uint64_t min = std::numeric_limits<uint64_t>::min(), uint64_t max = std::numeric_limits<uint64_t>::max())
 {
     size_t idx = 0;
     uint64_t ret = stoul(str, &idx, 0);
@@ -27,7 +27,7 @@ static inline uint64_t __to_uint64(std::string str, uint64_t min = std::numeric_
     return ret;
 }
 
-static inline int64_t __to_int64(std::string str, int64_t min = std::numeric_limits<int64_t>::min(), int64_t max = std::numeric_limits<int64_t>::max())
+static inline int64_t __to_int64(const std::string &str, int64_t min = std::numeric_limits<int64_t>::min(), int64_t max = std::numeric_limits<int64_t>::max())
 {
     size_t idx = 0;
     int64_t ret = stol(str, &idx, 0);
@@ -45,7 +45,7 @@ static inline int64_t __to_int64(std::string str, int64_t min = std::numeric_lim
 }
 
 template <typename T>
-T to_int(std::string str, T min = std::numeric_limits<T>::min(), T max = std::numeric_limits<T>::max())
+T to_int(const std::string &str, T min = std::numeric_limits<T>::min(), T max = std::numeric_limits<T>::max())
 {
     static_assert(std::is_signed<T>::value, "Signed integer is expected");
     static_assert(std::numeric_limits<T>::max() <= std::numeric_limits<int64_t>::max(), "Type is too big");
@@ -54,7 +54,7 @@ T to_int(std::string str, T min = std::numeric_limits<T>::min(), T max = std::nu
 }
 
 template <typename T>
-T to_uint(std::string str, T min = std::numeric_limits<T>::min(), T max = std::numeric_limits<T>::max())
+T to_uint(const std::string &str, T min = std::numeric_limits<T>::min(), T max = std::numeric_limits<T>::max())
 {
     static_assert(std::is_unsigned<T>::value, "Unsigned integer is expected");
     static_assert(std::numeric_limits<T>::max() <= std::numeric_limits<uint64_t>::max(), "Type is too big");

--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -28,7 +28,7 @@ DBConnector::~DBConnector()
     redisFree(m_conn);
 }
 
-DBConnector::DBConnector(int dbId, string hostname, int port,
+DBConnector::DBConnector(int dbId, const string& hostname, int port,
                          unsigned int timeout) :
     m_dbId(dbId)
 {
@@ -46,7 +46,7 @@ DBConnector::DBConnector(int dbId, string hostname, int port,
     select(this);
 }
 
-DBConnector::DBConnector(int dbId, string unixPath, unsigned int timeout) :
+DBConnector::DBConnector(int dbId, const string& unixPath, unsigned int timeout) :
     m_dbId(dbId)
 {
     struct timeval tv = {0, (suseconds_t)timeout * 1000};

--- a/common/dbconnector.h
+++ b/common/dbconnector.h
@@ -20,8 +20,8 @@ public:
      * Timeout - The time in milisecond until exception is been thrown. For
      *           infinite wait, set this value to 0
      */
-    DBConnector(int dbId, std::string hostname, int port, unsigned int timeout);
-    DBConnector(int dbId, std::string unixPath, unsigned int timeout);
+    DBConnector(int dbId, const std::string &hostname, int port, unsigned int timeout);
+    DBConnector(int dbId, const std::string &unixPath, unsigned int timeout);
 
     ~DBConnector();
 

--- a/common/ipaddress.cpp
+++ b/common/ipaddress.cpp
@@ -13,7 +13,7 @@ IpAddress::IpAddress(uint32_t ip)
 
 IpAddress::IpAddress(const std::string &ipStr)
 {
-    if (ipStr.find(":") != std::string::npos)
+    if (ipStr.find(':') != std::string::npos)
     {
         m_ip.family = AF_INET6;
     }

--- a/common/ipaddresses.cpp
+++ b/common/ipaddresses.cpp
@@ -11,7 +11,7 @@ using namespace swss;
 IpAddresses::IpAddresses(const string &ipsStr)
 {
     auto ips = tokenize(ipsStr, IP_DELIMITER);
-    for (auto ip : ips)
+    for (const auto &ip : ips)
         m_ips.insert(ip);
 }
 

--- a/common/logger.cpp
+++ b/common/logger.cpp
@@ -8,12 +8,12 @@
 #include <sstream>
 #include <iomanip>
 #include <stdexcept>
-#include <schema.h>
-#include <select.h>
-#include <dbconnector.h>
-#include <redisclient.h>
-#include <consumerstatetable.h>
-#include <producerstatetable.h>
+#include "schema.h"
+#include "select.h"
+#include "dbconnector.h"
+#include "redisclient.h"
+#include "consumerstatetable.h"
+#include "producerstatetable.h"
 
 namespace swss {
 
@@ -34,7 +34,7 @@ const Logger::PriorityStringMap Logger::priorityStringMap = {
     { "DEBUG", SWSS_DEBUG }
 };
 
-void Logger::swssPrioNotify(std::string component, std::string prioStr)
+void Logger::swssPrioNotify(const std::string &component, const std::string &prioStr)
 {
     auto& logger = getInstance();
 
@@ -55,7 +55,7 @@ const Logger::OutputStringMap Logger::outputStringMap = {
     { "STDERR", SWSS_STDERR }
 };
 
-void Logger::swssOutputNotify(std::string component, std::string outputStr)
+void Logger::swssOutputNotify(const std::string &component, const std::string &outputStr)
 {
     auto& logger = getInstance();
 
@@ -70,7 +70,7 @@ void Logger::swssOutputNotify(std::string component, std::string outputStr)
     }
 }
 
-void Logger::linkToDbWithOutput(const std::string dbName, const PriorityChangeNotify& prioNotify, const std::string& defPrio, const OutputChangeNotify& outputNotify, const std::string& defOutput)
+void Logger::linkToDbWithOutput(const std::string &dbName, const PriorityChangeNotify& prioNotify, const std::string& defPrio, const OutputChangeNotify& outputNotify, const std::string& defOutput)
 {
     auto& logger = getInstance();
 
@@ -122,12 +122,12 @@ void Logger::linkToDbWithOutput(const std::string dbName, const PriorityChangeNo
     outputNotify(dbName, output);
 }
 
-void Logger::linkToDb(const std::string dbName, const PriorityChangeNotify& prioNotify, const std::string& defPrio)
+void Logger::linkToDb(const std::string &dbName, const PriorityChangeNotify& prioNotify, const std::string& defPrio)
 {
     linkToDbWithOutput(dbName, prioNotify, defPrio, swssOutputNotify, "SYSLOG");
 }
 
-void Logger::linkToDbNative(const std::string dbName)
+void Logger::linkToDbNative(const std::string &dbName)
 {
     auto& logger = getInstance();
 
@@ -188,7 +188,7 @@ Logger::Priority Logger::getMinPrio()
         auto values = kfvFieldsValues(koValues);
         for (const auto& i : values)
         {
-            std::string field = fvField(i), value = fvValue(i);
+            const std::string &field = fvField(i), &value = fvValue(i);
             if ((field == DAEMON_LOGLEVEL) && (value != m_currentPrios[key]))
             {
                 m_currentPrios[key] = value;

--- a/common/logger.h
+++ b/common/logger.h
@@ -55,10 +55,10 @@ public:
     static Logger &getInstance();
     static void setMinPrio(Priority prio);
     static Priority getMinPrio();
-    static void linkToDbWithOutput(const std::string dbName, const PriorityChangeNotify& prioNotify, const std::string& defPrio, const OutputChangeNotify& outputNotify, const std::string& defOutput);
-    static void linkToDb(const std::string dbName, const PriorityChangeNotify& notify, const std::string& defPrio);
+    static void linkToDbWithOutput(const std::string &dbName, const PriorityChangeNotify& prioNotify, const std::string& defPrio, const OutputChangeNotify& outputNotify, const std::string& defOutput);
+    static void linkToDb(const std::string &dbName, const PriorityChangeNotify& notify, const std::string& defPrio);
     // Must be called after all linkToDb to start select from DB
-    static void linkToDbNative(const std::string dbName);
+    static void linkToDbNative(const std::string &dbName);
     void write(Priority prio, const char *fmt, ...)
 #ifdef __GNUC__
         __attribute__ ((format (printf, 3, 4)))
@@ -112,9 +112,9 @@ private:
     Logger(const Logger&);
     Logger &operator=(const Logger&);
 
-    static void swssPrioNotify(std::string component, std::string prioStr);
-    static void swssOutputNotify(std::string component, std::string outputStr);
-    void settingThread();
+    static void swssPrioNotify(const std::string &component, const std::string &prioStr);
+    static void swssOutputNotify(const std::string &component, const std::string &outputStr);
+    [[ noreturn ]] void settingThread();
 
     LogSettingChangeObservers m_settingChangeObservers;
     std::map<std::string, std::string> m_currentPrios;

--- a/common/loglevel.cpp
+++ b/common/loglevel.cpp
@@ -12,7 +12,7 @@
 
 using namespace swss;
 
-[[ noreturn ]] void usage(std::string program, int status, std::string message)
+[[ noreturn ]] void usage(const std::string &program, int status, const std::string &message)
 {
     if (message.size() != 0)
     {
@@ -44,7 +44,7 @@ void setLoglevel(DBConnector& db, const std::string& component, const std::strin
     table.set(component, fieldValues);
 }
 
-bool validateSaiLoglevel(std::string prioStr)
+bool validateSaiLoglevel(const std::string &prioStr)
 {
     static const std::vector<std::string> saiPrios = {
         "SAI_LOG_LEVEL_CRITICAL",
@@ -112,7 +112,7 @@ int main(int argc, char **argv)
     auto keys = redisClient.keys("*");
     for (auto& key : keys)
     {
-        size_t colonPos = key.find(":");
+        size_t colonPos = key.find(':');
         if (colonPos == std::string::npos)
         {
             continue;
@@ -133,7 +133,8 @@ int main(int argc, char **argv)
         std::sort(keys.begin(), keys.end());
         for (const auto& key : keys)
         {
-            auto level = redisClient.hget(key + ":" + key, DAEMON_LOGLEVEL);
+            const auto redis_key = std::string(key).append(":").append(key);
+            auto level = redisClient.hget(redis_key, DAEMON_LOGLEVEL);
             std::cout << std::left << std::setw(30) << key << *level << std::endl;
         }
         return (EXIT_SUCCESS);

--- a/common/notificationconsumer.cpp
+++ b/common/notificationconsumer.cpp
@@ -6,7 +6,7 @@
 #define REDIS_PUBLISH_MESSAGE_INDEX (2)
 #define REDIS_PUBLISH_MESSAGE_ELEMNTS (3)
 
-swss::NotificationConsumer::NotificationConsumer(swss::DBConnector *db, std::string channel, int pri):
+swss::NotificationConsumer::NotificationConsumer(swss::DBConnector *db, const std::string &channel, int pri):
     Selectable(pri),
     m_db(db),
     m_subscribe(NULL),

--- a/common/notificationconsumer.h
+++ b/common/notificationconsumer.h
@@ -19,7 +19,7 @@ namespace swss {
 class NotificationConsumer : public Selectable
 {
 public:
-    NotificationConsumer(swss::DBConnector *db, std::string channel, int pri = 100);
+    NotificationConsumer(swss::DBConnector *db, const std::string &channel, int pri = 100);
 
     void pop(std::string &op, std::string &data, std::vector<FieldValueTuple> &values);
 

--- a/common/notificationproducer.cpp
+++ b/common/notificationproducer.cpp
@@ -1,11 +1,11 @@
 #include "notificationproducer.h"
 
-swss::NotificationProducer::NotificationProducer(swss::DBConnector *db, std::string channel):
+swss::NotificationProducer::NotificationProducer(swss::DBConnector *db, const std::string &channel):
     m_db(db), m_channel(channel)
 {
 }
 
-void swss::NotificationProducer::send(std::string op, std::string data, std::vector<FieldValueTuple> &values)
+void swss::NotificationProducer::send(const std::string &op, const std::string &data, std::vector<FieldValueTuple> &values)
 {
     SWSS_LOG_ENTER();
 

--- a/common/notificationproducer.h
+++ b/common/notificationproducer.h
@@ -16,9 +16,9 @@ namespace swss {
 class NotificationProducer
 {
 public:
-    NotificationProducer(swss::DBConnector *db, std::string channel);
+    NotificationProducer(swss::DBConnector *db, const std::string &channel);
 
-    void send(std::string op, std::string data, std::vector<FieldValueTuple> &values);
+    void send(const std::string &op, const std::string &data, std::vector<FieldValueTuple> &values);
 
 private:
 

--- a/common/portmap.cpp
+++ b/common/portmap.cpp
@@ -4,7 +4,7 @@ using namespace std;
 
 namespace swss {
 
-map<set<int>, string> handlePortMap(string file)
+map<set<int>, string> handlePortMap(const string &file)
 {
     map<set<int>, string> port_map;
 

--- a/common/portmap.h
+++ b/common/portmap.h
@@ -8,7 +8,7 @@
 
 namespace swss {
 
-std::map<std::set<int>, std::string> handlePortMap(std::string file);
+std::map<std::set<int>, std::string> handlePortMap(const std::string &file);
 
 }
 

--- a/common/producerstatetable.cpp
+++ b/common/producerstatetable.cpp
@@ -13,13 +13,13 @@ using namespace std;
 
 namespace swss {
 
-ProducerStateTable::ProducerStateTable(DBConnector *db, string tableName)
+ProducerStateTable::ProducerStateTable(DBConnector *db, const string &tableName)
     : ProducerStateTable(new RedisPipeline(db, 1), tableName, false)
 {
     m_pipeowned = true;
 }
 
-ProducerStateTable::ProducerStateTable(RedisPipeline *pipeline, string tableName, bool buffered)
+ProducerStateTable::ProducerStateTable(RedisPipeline *pipeline, const string &tableName, bool buffered)
     : TableBase(pipeline->getDbId(), tableName)
     , TableName_KeySet(tableName)
     , m_buffered(buffered)
@@ -54,8 +54,8 @@ void ProducerStateTable::setBuffered(bool buffered)
     m_buffered = buffered;
 }
 
-void ProducerStateTable::set(string key, vector<FieldValueTuple> &values,
-                 string op /*= SET_COMMAND*/, string prefix)
+void ProducerStateTable::set(const string &key, const vector<FieldValueTuple> &values,
+                 const string &op /*= SET_COMMAND*/, const string &prefix)
 {
     // Assembly redis command args into a string vector
     vector<string> args;
@@ -89,7 +89,7 @@ void ProducerStateTable::set(string key, vector<FieldValueTuple> &values,
     }
 }
 
-void ProducerStateTable::del(string key, string op /*= DEL_COMMAND*/, string prefix)
+void ProducerStateTable::del(const string &key, const string &op /*= DEL_COMMAND*/, const string &prefix)
 {
     // Assembly redis command args into a string vector
     vector<string> args;

--- a/common/producerstatetable.h
+++ b/common/producerstatetable.h
@@ -9,20 +9,20 @@ namespace swss {
 class ProducerStateTable : public TableBase, public TableName_KeySet
 {
 public:
-    ProducerStateTable(DBConnector *db, std::string tableName);
-    ProducerStateTable(RedisPipeline *pipeline, std::string tableName, bool buffered = false);
+    ProducerStateTable(DBConnector *db, const std::string &tableName);
+    ProducerStateTable(RedisPipeline *pipeline, const std::string &tableName, bool buffered = false);
     ~ProducerStateTable();
 
     void setBuffered(bool buffered);
     /* Implements set() and del() commands using notification messages */
-    virtual void set(std::string key,
-                     std::vector<FieldValueTuple> &values,
-                     std::string op = SET_COMMAND,
-                     std::string prefix = EMPTY_PREFIX);
+    virtual void set(const std::string &key,
+                     const std::vector<FieldValueTuple> &values,
+                     const std::string &op = SET_COMMAND,
+                     const std::string &prefix = EMPTY_PREFIX);
 
-    virtual void del(std::string key,
-                     std::string op = DEL_COMMAND,
-                     std::string prefix = EMPTY_PREFIX);
+    virtual void del(const std::string &key,
+                     const std::string &op = DEL_COMMAND,
+                     const std::string &prefix = EMPTY_PREFIX);
 
     void flush();
 

--- a/common/producertable.cpp
+++ b/common/producertable.cpp
@@ -12,13 +12,13 @@ using json = nlohmann::json;
 
 namespace swss {
 
-ProducerTable::ProducerTable(DBConnector *db, string tableName)
+ProducerTable::ProducerTable(DBConnector *db, const string &tableName)
     : ProducerTable(new RedisPipeline(db, 1), tableName, false)
 {
     m_pipeowned = true;
 }
 
-ProducerTable::ProducerTable(RedisPipeline *pipeline, string tableName, bool buffered)
+ProducerTable::ProducerTable(RedisPipeline *pipeline, const string &tableName, bool buffered)
     : TableBase(pipeline->getDbId(), tableName)
     , TableName_KeyValueOpQueues(tableName)
     , m_buffered(buffered)
@@ -34,7 +34,7 @@ ProducerTable::ProducerTable(RedisPipeline *pipeline, string tableName, bool buf
     m_shaEnque = m_pipe->loadRedisScript(luaEnque);
 }
 
-ProducerTable::ProducerTable(DBConnector *db, string tableName, string dumpFile)
+ProducerTable::ProducerTable(DBConnector *db, const string &tableName, const string &dumpFile)
     : ProducerTable(db, tableName)
 {
     m_dumpFile.open(dumpFile, fstream::out | fstream::trunc);
@@ -59,7 +59,7 @@ void ProducerTable::setBuffered(bool buffered)
     m_buffered = buffered;
 }
 
-void ProducerTable::enqueueDbChange(string key, string value, string op, string /* prefix */)
+void ProducerTable::enqueueDbChange(const string &key, const string &value, const string &op, const string& /* prefix */)
 {
     RedisCommand command;
     command.format(
@@ -77,7 +77,7 @@ void ProducerTable::enqueueDbChange(string key, string value, string op, string 
     m_pipe->push(command, REDIS_REPLY_NIL);
 }
 
-void ProducerTable::set(string key, vector<FieldValueTuple> &values, string op, string prefix)
+void ProducerTable::set(const string &key, const vector<FieldValueTuple> &values, const string &op, const string &prefix)
 {
     if (m_dumpFile.is_open())
     {
@@ -103,7 +103,7 @@ void ProducerTable::set(string key, vector<FieldValueTuple> &values, string op, 
     }
 }
 
-void ProducerTable::del(string key, string op, string prefix)
+void ProducerTable::del(const string &key, const string &op, const string &prefix)
 {
     if (m_dumpFile.is_open())
     {

--- a/common/producertable.h
+++ b/common/producertable.h
@@ -17,23 +17,23 @@ namespace swss {
 class ProducerTable : public TableBase, public TableName_KeyValueOpQueues
 {
 public:
-    ProducerTable(DBConnector *db, std::string tableName);
-    ProducerTable(RedisPipeline *pipeline, std::string tableName, bool buffered = false);
-    ProducerTable(DBConnector *db, std::string tableName, std::string dumpFile);
+    ProducerTable(DBConnector *db, const std::string &tableName);
+    ProducerTable(RedisPipeline *pipeline, const std::string &tableName, bool buffered = false);
+    ProducerTable(DBConnector *db, const std::string &tableName, const std::string &dumpFile);
     virtual ~ProducerTable();
 
     void setBuffered(bool buffered);
 
     /* Implements set() and del() commands using notification messages */
 
-    virtual void set(std::string key,
-                     std::vector<FieldValueTuple> &values,
-                     std::string op = SET_COMMAND,
-                     std::string prefix = EMPTY_PREFIX);
+    virtual void set(const std::string &key,
+                     const std::vector<FieldValueTuple> &values,
+                     const std::string &op = SET_COMMAND,
+                     const std::string &prefix = EMPTY_PREFIX);
 
-    virtual void del(std::string key,
-                     std::string op = DEL_COMMAND,
-                     std::string prefix = EMPTY_PREFIX);
+    virtual void del(const std::string &key,
+                     const std::string &op = DEL_COMMAND,
+                     const std::string &prefix = EMPTY_PREFIX);
 
     void flush();
 
@@ -49,7 +49,7 @@ private:
     RedisPipeline *m_pipe;
     std::string m_shaEnque;
 
-    void enqueueDbChange(std::string key, std::string value, std::string op, std::string prefix);
+    void enqueueDbChange(const std::string &key, const std::string &value, const std::string &op, const std::string &prefix);
 };
 
 }

--- a/common/redisclient.cpp
+++ b/common/redisclient.cpp
@@ -12,7 +12,7 @@ RedisClient::RedisClient(swss::DBConnector *db):
 {
 }
 
-int64_t RedisClient::del(string key)
+int64_t RedisClient::del(const string &key)
 {
     RedisCommand sdel;
     sdel.format("DEL %s", key.c_str());
@@ -20,7 +20,7 @@ int64_t RedisClient::del(string key)
     return r.getContext()->integer;
 }
 
-int64_t RedisClient::hdel(string key, string field)
+int64_t RedisClient::hdel(const string &key, const string &field)
 {
     RedisCommand shdel;
     shdel.format("HDEL %s %s", key.c_str(), field.c_str());
@@ -28,21 +28,21 @@ int64_t RedisClient::hdel(string key, string field)
     return r.getContext()->integer;
 }
 
-void RedisClient::hset(string key, string field, string value)
+void RedisClient::hset(const string &key, const string &field, const string &value)
 {
     RedisCommand shset;
     shset.format("HSET %s %s %s", key.c_str(), field.c_str(), value.c_str());
     RedisReply r(m_db, shset, REDIS_REPLY_INTEGER);
 }
 
-void RedisClient::set(string key, string value)
+void RedisClient::set(const string &key, const string &value)
 {
     RedisCommand sset;
     sset.format("SET %s %s", key.c_str(), value.c_str());
     RedisReply r(m_db, sset, REDIS_REPLY_STATUS);
 }
 
-unordered_map<string, string> RedisClient::hgetall(string key)
+unordered_map<string, string> RedisClient::hgetall(const string &key)
 {
     RedisCommand sincr;
     sincr.format("HGETALL %s", key.c_str());
@@ -57,7 +57,7 @@ unordered_map<string, string> RedisClient::hgetall(string key)
     return map;
 }
 
-vector<string> RedisClient::keys(string key)
+vector<string> RedisClient::keys(const string &key)
 {
     RedisCommand skeys;
     skeys.format("KEYS %s", key.c_str());
@@ -72,7 +72,7 @@ vector<string> RedisClient::keys(string key)
     return list;
 }
 
-int64_t RedisClient::incr(string key)
+int64_t RedisClient::incr(const string &key)
 {
     RedisCommand sincr;
     sincr.format("INCR %s", key.c_str());
@@ -80,7 +80,7 @@ int64_t RedisClient::incr(string key)
     return r.getContext()->integer;
 }
 
-int64_t RedisClient::decr(string key)
+int64_t RedisClient::decr(const string &key)
 {
     RedisCommand sdecr;
     sdecr.format("DECR %s", key.c_str());
@@ -88,7 +88,7 @@ int64_t RedisClient::decr(string key)
     return r.getContext()->integer;
 }
 
-shared_ptr<string> RedisClient::get(string key)
+shared_ptr<string> RedisClient::get(const string &key)
 {
     RedisCommand sget;
     sget.format("GET %s", key.c_str());
@@ -109,7 +109,7 @@ shared_ptr<string> RedisClient::get(string key)
     throw runtime_error("GET failed, memory exception");
 }
 
-shared_ptr<string> RedisClient::hget(string key, string field)
+shared_ptr<string> RedisClient::hget(const string &key, const string &field)
 {
     RedisCommand shget;
     shget.format("HGET %s %s", key.c_str(), field.c_str());
@@ -131,7 +131,7 @@ shared_ptr<string> RedisClient::hget(string key, string field)
     throw runtime_error("HGET failed, unexpected reply type, memory exception");
 }
 
-int64_t RedisClient::rpush(string list, string item)
+int64_t RedisClient::rpush(const string &list, const string &item)
 {
     RedisCommand srpush;
     srpush.format("RPUSH %s %s", list.c_str(), item.c_str());
@@ -139,7 +139,7 @@ int64_t RedisClient::rpush(string list, string item)
     return r.getContext()->integer;
 }
 
-shared_ptr<string> RedisClient::blpop(string list, int timeout)
+shared_ptr<string> RedisClient::blpop(const string &list, int timeout)
 {
     RedisCommand sblpop;
     sblpop.format("BLPOP %s %d", list.c_str(), timeout);

--- a/common/redisclient.h
+++ b/common/redisclient.h
@@ -24,39 +24,39 @@ class RedisClient
 
         RedisClient(swss::DBConnector *db);
 
-        int64_t del(std::string key);
+        int64_t del(const std::string &key);
 
-        int64_t hdel(std::string key, std::string field);
+        int64_t hdel(const std::string &key, const std::string &field);
 
-        std::unordered_map<std::string, std::string> hgetall(std::string key);
+        std::unordered_map<std::string, std::string> hgetall(const std::string &key);
 
-        std::vector<std::string> keys(std::string key);
+        std::vector<std::string> keys(const std::string &key);
 
-        std::vector<std::string> hkeys(std::string key);
+        std::vector<std::string> hkeys(const std::string &key);
 
-        void set(std::string key, std::string value);
+        void set(const std::string &key, const std::string &value);
 
-        void hset(std::string key, std::string field, std::string value);
+        void hset(const std::string &key, const std::string &field, const std::string &value);
 
-        void mset(std::unordered_map<std::string, std::string> map);
+        void mset(const std::unordered_map<std::string, std::string> &map);
 
-        void hmset(std::string key, std::unordered_map<std::string, std::string> map);
+        void hmset(const std::string &key, const std::unordered_map<std::string, std::string> &map);
 
-        std::shared_ptr<std::string> get(std::string key);
+        std::shared_ptr<std::string> get(const std::string &key);
 
-        std::shared_ptr<std::string> hget(std::string key, std::string field);
+        std::shared_ptr<std::string> hget(const std::string &key, const std::string &field);
 
-        std::vector<std::shared_ptr<std::string>> mget(std::vector<std::string> keys);
+        std::vector<std::shared_ptr<std::string>> mget(const std::vector<std::string> &keys);
 
-        std::vector<std::shared_ptr<std::string>> hmget(std::string key, std::vector<std::string> fields);
+        std::vector<std::shared_ptr<std::string>> hmget(const std::string &key, const std::vector<std::string> &fields);
 
-        int64_t incr(std::string key);
+        int64_t incr(const std::string &key);
 
-        int64_t decr(std::string key);
+        int64_t decr(const std::string &key);
 
-        int64_t rpush(std::string list, std::string item);
+        int64_t rpush(const std::string &list, const std::string &item);
 
-        std::shared_ptr<std::string> blpop(std::string list, int timeout);
+        std::shared_ptr<std::string> blpop(const std::string &list, int timeout);
 
     private:
         swss::DBConnector *m_db;

--- a/common/redisreply.cpp
+++ b/common/redisreply.cpp
@@ -34,7 +34,7 @@ RedisReply::RedisReply(DBConnector *db, const RedisCommand& command)
     guard([&]{checkReply();}, command.c_str());
 }
 
-RedisReply::RedisReply(DBConnector *db, string command)
+RedisReply::RedisReply(DBConnector *db, const string &command)
 {
     redisAppendCommand(db->getContext(), command.c_str());
     redisGetReply(db->getContext(), (void**)&m_reply);
@@ -47,7 +47,7 @@ RedisReply::RedisReply(DBConnector *db, const RedisCommand& command, int expecte
     guard([&]{checkReplyType(expectedType);}, command.c_str());
 }
 
-RedisReply::RedisReply(DBConnector *db, string command, int expectedType)
+RedisReply::RedisReply(DBConnector *db, const string &command, int expectedType)
     : RedisReply(db, command)
 {
     guard([&]{checkReplyType(expectedType);}, command.c_str());
@@ -85,7 +85,7 @@ redisReply *RedisReply::getChild(size_t index)
     return m_reply->element[index];
 }
 
-void RedisReply::checkStatus(char *status)
+void RedisReply::checkStatus(const char *status)
 {
     if (strcmp(m_reply->str, status) != 0)
     {

--- a/common/redisreply.h
+++ b/common/redisreply.h
@@ -16,7 +16,7 @@ public:
      * No reply type specified.
      */
     RedisReply(DBConnector *db, const RedisCommand& command);
-    RedisReply(DBConnector *db, std::string command);
+    RedisReply(DBConnector *db, const std::string &command);
     /*
      * Send a new command to redis and waits for reply
      * The reply must be one of REDIS_REPLY_* format (e.g. REDIS_REPLY_STATUS,
@@ -25,7 +25,7 @@ public:
      *               protocol
      */
     RedisReply(DBConnector *db, const RedisCommand& command, int expectedType);
-    RedisReply(DBConnector *db, std::string command, int expectedType);
+    RedisReply(DBConnector *db, const std::string &command, int expectedType);
 
     /* auto_ptr for native structue (Free the memory on destructor) */
     RedisReply(redisReply *reply);
@@ -53,7 +53,7 @@ public:
     void checkStatusQueued();
 
 private:
-    void checkStatus(char *status);
+    void checkStatus(const char *status);
     void checkReply();
 
     redisReply *m_reply;

--- a/common/redisselect.cpp
+++ b/common/redisselect.cpp
@@ -62,7 +62,7 @@ void RedisSelect::updateAfterRead()
 }
 
 /* Create a new redisContext, SELECT DB and SUBSCRIBE */
-void RedisSelect::subscribe(DBConnector* db, std::string channelName)
+void RedisSelect::subscribe(DBConnector* db, const std::string &channelName)
 {
     m_subscribe.reset(db->newConnector(SUBSCRIBE_TIMEOUT));
 
@@ -73,7 +73,7 @@ void RedisSelect::subscribe(DBConnector* db, std::string channelName)
 }
 
 /* PSUBSCRIBE */
-void RedisSelect::psubscribe(DBConnector* db, std::string channelName)
+void RedisSelect::psubscribe(DBConnector* db, const std::string &channelName)
 {
     m_subscribe.reset(db->newConnector(SUBSCRIBE_TIMEOUT));
 

--- a/common/redisselect.h
+++ b/common/redisselect.h
@@ -21,10 +21,10 @@ public:
     void updateAfterRead() override;
 
     /* Create a new redisContext, SELECT DB and SUBSCRIBE */
-    void subscribe(DBConnector* db, std::string channelName);
+    void subscribe(DBConnector* db, const std::string &channelName);
 
     /* PSUBSCRIBE */
-    void psubscribe(DBConnector* db, std::string channelName);
+    void psubscribe(DBConnector* db, const std::string &channelName);
 
     void setQueueLength(long long int queueLength);
 

--- a/common/redistran.cpp
+++ b/common/redistran.cpp
@@ -63,7 +63,7 @@ bool RedisTransactioner::exec()
 }
 
 /* Send a command within a transaction */
-void RedisTransactioner::enqueue(std::string command, int expectedType)
+void RedisTransactioner::enqueue(const std::string &command, int expectedType)
 {
     RedisReply r(m_db, command, REDIS_REPLY_STATUS);
     r.checkStatusQueued();

--- a/common/redistran.h
+++ b/common/redistran.h
@@ -21,7 +21,7 @@ public:
     bool exec();
 
     /* Send a command within a transaction */
-    void enqueue(std::string command, int expectedType);
+    void enqueue(const std::string &command, int expectedType);
 
     redisReply *dequeueReply();
 

--- a/common/subscriberstatetable.cpp
+++ b/common/subscriberstatetable.cpp
@@ -14,7 +14,7 @@ using namespace std;
 
 namespace swss {
 
-SubscriberStateTable::SubscriberStateTable(DBConnector *db, string tableName, int popBatchSize, int pri)
+SubscriberStateTable::SubscriberStateTable(DBConnector *db, const string &tableName, int popBatchSize, int pri)
     : ConsumerTableBase(db, tableName, popBatchSize, pri), m_table(db, tableName)
 {
     m_keyspace = "__keyspace@";
@@ -86,7 +86,7 @@ bool SubscriberStateTable::hasCachedData()
     return m_buffer.size() > 1 || m_keyspace_event_buffer.size() > 1;
 }
 
-void SubscriberStateTable::pops(deque<KeyOpFieldsValuesTuple> &vkco, string /*prefix*/)
+void SubscriberStateTable::pops(deque<KeyOpFieldsValuesTuple> &vkco, const string& /*prefix*/)
 {
     vkco.clear();
 
@@ -125,7 +125,7 @@ void SubscriberStateTable::pops(deque<KeyOpFieldsValuesTuple> &vkco, string /*pr
 
         ctx = event->getContext()->element[2];
         string msg(ctx->str);
-        size_t pos = msg.find(":");
+        size_t pos = msg.find(':');
         if (pos == msg.npos)
         {
             SWSS_LOG_ERROR("invalid format %s returned for pmessage of %s", ctx->str, m_keyspace.c_str());

--- a/common/subscriberstatetable.h
+++ b/common/subscriberstatetable.h
@@ -11,10 +11,10 @@ namespace swss {
 class SubscriberStateTable : public ConsumerTableBase
 {
 public:
-    SubscriberStateTable(DBConnector *db, std::string tableName, int popBatchSize = DEFAULT_POP_BATCH_SIZE, int pri = 0);
+    SubscriberStateTable(DBConnector *db, const std::string &tableName, int popBatchSize = DEFAULT_POP_BATCH_SIZE, int pri = 0);
 
     /* Get all elements available */
-    void pops(std::deque<KeyOpFieldsValuesTuple> &vkco, std::string prefix = EMPTY_PREFIX);
+    void pops(std::deque<KeyOpFieldsValuesTuple> &vkco, const std::string &prefix = EMPTY_PREFIX);
 
     /* Read keyspace event from redis */
     void readData() override;

--- a/common/table.cpp
+++ b/common/table.cpp
@@ -29,13 +29,13 @@ const TableNameSeparatorMap TableBase::tableNameSeparatorMap = {
    { STATE_DB,        TABLE_NAME_SEPARATOR_VBAR  }
 };
 
-Table::Table(DBConnector *db, string tableName)
+Table::Table(DBConnector *db, const string &tableName)
     : Table(new RedisPipeline(db, 1), tableName, false)
 {
     m_pipeowned = true;
 }
 
-Table::Table(RedisPipeline *pipeline, string tableName, bool buffered)
+Table::Table(RedisPipeline *pipeline, const string &tableName, bool buffered)
     : TableBase(pipeline->getDbId(), tableName)
     , m_buffered(buffered)
     , m_pipeowned(false)
@@ -61,7 +61,7 @@ void Table::flush()
     m_pipe->flush();
 }
 
-bool Table::get(string key, vector<FieldValueTuple> &values)
+bool Table::get(const string &key, vector<FieldValueTuple> &values)
 {
     RedisCommand hgetall_key;
     hgetall_key.format("HGETALL %s", getKeyName(key).c_str());
@@ -85,8 +85,8 @@ bool Table::get(string key, vector<FieldValueTuple> &values)
     return true;
 }
 
-void Table::set(string key, vector<FieldValueTuple> &values,
-                string /*op*/, string /*prefix*/)
+void Table::set(const string &key, const vector<FieldValueTuple> &values,
+                const string& /*op*/, const string& /*prefix*/)
 {
     if (values.size() == 0)
         return;
@@ -101,7 +101,7 @@ void Table::set(string key, vector<FieldValueTuple> &values,
     }
 }
 
-void Table::del(string key, string /* op */, string /*prefix*/)
+void Table::del(const string &key, const string& /* op */, const string& /*prefix*/)
 {
     RedisCommand del_key;
     del_key.format("DEL %s", getKeyName(key).c_str());
@@ -192,7 +192,7 @@ void Table::dump(TableDump& tableDump)
     }
 }
 
-string Table::stripSpecialSym(string key)
+string Table::stripSpecialSym(const string &key)
 {
     size_t pos = key.find('@');
     if (pos != key.npos)

--- a/common/table.h
+++ b/common/table.h
@@ -34,7 +34,7 @@ typedef std::map<std::string,TableMap> TableDump;
 
 class TableBase {
 public:
-    TableBase(int dbId, std::string tableName)
+    TableBase(int dbId, const std::string &tableName)
         : m_tableName(tableName)
     {
         /* Look up table separator for the provided DB */
@@ -54,7 +54,7 @@ public:
     std::string getTableName() const { return m_tableName; }
 
     /* Return the actual key name as a combination of tableName<table_separator>key */
-    std::string getKeyName(std::string key)
+    std::string getKeyName(const std::string &key)
     {
         if (key == "") return m_tableName;
         else return m_tableName + m_tableSeparator + key;
@@ -81,14 +81,14 @@ public:
     virtual ~TableEntryWritable() { }
 
     /* Set an entry in the table */
-    virtual void set(std::string key,
-                     std::vector<FieldValueTuple> &values,
-                     std::string op = "",
-                     std::string prefix = EMPTY_PREFIX) = 0;
+    virtual void set(const std::string &key,
+                     const std::vector<FieldValueTuple> &values,
+                     const std::string &op = "",
+                     const std::string &prefix = EMPTY_PREFIX) = 0;
     /* Delete an entry in the table */
-    virtual void del(std::string key,
-                     std::string op = "",
-                     std::string prefix = EMPTY_PREFIX) = 0;
+    virtual void del(const std::string &key,
+                     const std::string &op = "",
+                     const std::string &prefix = EMPTY_PREFIX) = 0;
 
 };
 
@@ -97,10 +97,10 @@ public:
     virtual ~TableEntryPoppable() { }
 
     /* Pop an action (set or del) on the table */
-    virtual void pop(KeyOpFieldsValuesTuple &kco, std::string prefix = EMPTY_PREFIX) = 0;
+    virtual void pop(KeyOpFieldsValuesTuple &kco, const std::string &prefix = EMPTY_PREFIX) = 0;
 
     /* Get multiple pop elements */
-    virtual void pops(std::deque<KeyOpFieldsValuesTuple> &vkco, std::string prefix = EMPTY_PREFIX) = 0;
+    virtual void pops(std::deque<KeyOpFieldsValuesTuple> &vkco, const std::string &prefix = EMPTY_PREFIX) = 0;
 };
 
 class TableConsumable : public TableBase, public TableEntryPoppable, public RedisSelect {
@@ -108,7 +108,7 @@ public:
     /* The default value of pop batch size is 128 */
     static constexpr int DEFAULT_POP_BATCH_SIZE = 128;
 
-    TableConsumable(int dbId, std::string tableName, int pri) : TableBase(dbId, tableName), RedisSelect(pri) { }
+    TableConsumable(int dbId, const std::string &tableName, int pri) : TableBase(dbId, tableName), RedisSelect(pri) { }
 };
 
 class TableEntryEnumerable {
@@ -116,7 +116,7 @@ public:
     virtual ~TableEntryEnumerable() { }
 
     /* Get all the field-value tuple of the table entry with the key */
-    virtual bool get(std::string key, std::vector<FieldValueTuple> &values) = 0;
+    virtual bool get(const std::string &key, std::vector<FieldValueTuple> &values) = 0;
 
     /* get all the keys in the table */
     virtual void getKeys(std::vector<std::string> &keys) = 0;
@@ -128,23 +128,23 @@ public:
 
 class Table : public TableBase, public TableEntryEnumerable {
 public:
-    Table(DBConnector *db, std::string tableName);
-    Table(RedisPipeline *pipeline, std::string tableName, bool buffered);
+    Table(DBConnector *db, const std::string &tableName);
+    Table(RedisPipeline *pipeline, const std::string &tableName, bool buffered);
     virtual ~Table();
 
     /* Set an entry in the DB directly (op not in use) */
-    virtual void set(std::string key,
-                     std::vector<FieldValueTuple> &values,
-                     std::string op = "",
-                     std::string prefix = EMPTY_PREFIX);
+    virtual void set(const std::string &key,
+                     const std::vector<FieldValueTuple> &values,
+                     const std::string &op = "",
+                     const std::string &prefix = EMPTY_PREFIX);
     /* Delete an entry in the table */
-    virtual void del(std::string key,
-                     std::string op = "",
-                     std::string prefix = EMPTY_PREFIX);
+    virtual void del(const std::string &key,
+                     const std::string &op = "",
+                     const std::string &prefix = EMPTY_PREFIX);
 
     /* Read a value from the DB directly */
     /* Returns false if the key doesn't exists */
-    virtual bool get(std::string key, std::vector<FieldValueTuple> &ovalues);
+    virtual bool get(const std::string &key, std::vector<FieldValueTuple> &ovalues);
 
     void getKeys(std::vector<std::string> &keys);
 
@@ -167,7 +167,7 @@ protected:
      * 1) "ports@"
      * 2) "Ethernet0,Ethernet4,...
      * */
-    std::string stripSpecialSym(std::string key);
+    std::string stripSpecialSym(const std::string &key);
 };
 
 class TableName_KeyValueOpQueues {
@@ -176,7 +176,7 @@ private:
     std::string m_value;
     std::string m_op;
 public:
-    TableName_KeyValueOpQueues(std::string tableName)
+    TableName_KeyValueOpQueues(const std::string &tableName)
         : m_key(tableName + "_KEY_QUEUE")
         , m_value(tableName + "_VALUE_QUEUE")
         , m_op(tableName + "_OP_QUEUE")
@@ -192,7 +192,7 @@ class TableName_KeySet {
 private:
     std::string m_key;
 public:
-    TableName_KeySet(std::string tableName)
+    TableName_KeySet(const std::string &tableName)
         : m_key(tableName + "_KEY_SET")
     {
     }


### PR DESCRIPTION
Pass complex arguments by references, don't copy them.

That will save us some time + reduce number of allocations/deallocations.

I've fixed also some #includes which were wrong, use find specially designed for characters

