### PR TITLE
Fix compiler errors with gcc-7

### DIFF
--- a/common/logger.h
+++ b/common/logger.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <thread>
 #include <mutex>
+#include <functional>
 
 namespace swss {
 

--- a/tests/json_ut.cpp
+++ b/tests/json_ut.cpp
@@ -49,7 +49,9 @@ TEST(JSON, test)
         for (auto it = item.begin(); it != item.end(); it++)
         {
             if (it.key() == "OP")
+            {
                 EXPECT_TRUE(it.value() == "SET" || it.value() == "DEL");
+            }
             else
             {
                 EXPECT_TRUE(it.key() == "UT_REDIS" + separator + "test_key_1" || it.key() == "UT_REDIS" + separator + "test_key_2");
@@ -60,9 +62,13 @@ TEST(JSON, test)
                     for (auto subit = subitem.begin(); subit != subitem.end(); subit++)
                     {
                         if (subit.key() == "test_field_1")
+                        {
                             EXPECT_EQ(subit.value(), "test_value_1");
+                        }
                         if (subit.key() == "test_field_2")
+                        {
                             EXPECT_EQ(subit.value(), "test_value_2");
+                        }
                     }
                 }
             }

--- a/tests/redis_piped_ut.cpp
+++ b/tests/redis_piped_ut.cpp
@@ -364,8 +364,14 @@ TEST(Table, piped_test)
         {
             string value_1 = "1", value_2 = "2";
             cout << " " << fvField(fv) << ":" << fvValue(fv) << flush;
-            if (fvField(fv) == "field_1") EXPECT_EQ(fvValue(fv), value_1);
-            if (fvField(fv) == "field_2") EXPECT_EQ(fvValue(fv), value_2);
+            if (fvField(fv) == "field_1")
+            {
+                EXPECT_EQ(fvValue(fv), value_1);
+            }
+            if (fvField(fv) == "field_2")
+            {
+                EXPECT_EQ(fvValue(fv), value_2);
+            }
         }
         cout << endl;
     }
@@ -384,8 +390,14 @@ TEST(Table, piped_test)
     {
         string value_1 = "1", value_2 = "2";
         cout << " " << fvField(fv) << ":" << fvValue(fv) << flush;
-        if (fvField(fv) == "field_1") EXPECT_EQ(fvValue(fv), value_1);
-        if (fvField(fv) == "field_2") EXPECT_EQ(fvValue(fv), value_2);
+        if (fvField(fv) == "field_1")
+        {
+            EXPECT_EQ(fvValue(fv), value_1);
+        }
+        if (fvField(fv) == "field_2")
+        {
+            EXPECT_EQ(fvValue(fv), value_2);
+        }
     }
     cout << endl;
 

--- a/tests/redis_ut.cpp
+++ b/tests/redis_ut.cpp
@@ -196,8 +196,14 @@ void TableBasicTest(string tableName)
         {
             string value_1 = "1", value_2 = "2";
             cout << " " << fvField(fv) << ":" << fvValue(fv) << flush;
-            if (fvField(fv) == "field_1") EXPECT_EQ(fvValue(fv), value_1);
-            if (fvField(fv) == "field_2") EXPECT_EQ(fvValue(fv), value_2);
+            if (fvField(fv) == "field_1")
+            {
+                EXPECT_EQ(fvValue(fv), value_1);
+            }
+            if (fvField(fv) == "field_2")
+            {
+                EXPECT_EQ(fvValue(fv), value_2);
+            }
         }
         cout << endl;
     }
@@ -216,8 +222,14 @@ void TableBasicTest(string tableName)
     {
         string value_1 = "1", value_2 = "2";
         cout << " " << fvField(fv) << ":" << fvValue(fv) << flush;
-        if (fvField(fv) == "field_1") EXPECT_EQ(fvValue(fv), value_1);
-        if (fvField(fv) == "field_2") EXPECT_EQ(fvValue(fv), value_2);
+        if (fvField(fv) == "field_1")
+        {
+            EXPECT_EQ(fvValue(fv), value_1);
+        }
+        if (fvField(fv) == "field_2")
+        {
+            EXPECT_EQ(fvValue(fv), value_2);
+        }
     }
     cout << endl;
 


### PR DESCRIPTION
Compiling with gcc-7, two errors occurred:
Firstly, an include was missing (commit 5127067) and secondly the compiler was complaining about dangling else ambiguity in tests (commit 0d407f0) when EXPECT_xx was used in if-conditions without surrounding brackets.
