### PR TITLE
Reduce the number of LPUSH/LRANGE/LTRIM operations for producer/consumer

### DIFF
--- a/common/consumer_table_pops.lua
+++ b/common/consumer_table_pops.lua
@@ -1,7 +1,9 @@
 local rets = {}
-local keys   = redis.call('LRANGE', KEYS[1], -ARGV[1], -1)
+-- pop Key, Value and OP together.
+local popsize = ARGV[1] * 3
+local keys   = redis.call('LRANGE', KEYS[1], -popsize, -1)
 
-redis.call('LTRIM', KEYS[1], 0, -ARGV[1]-1)
+redis.call('LTRIM', KEYS[1], 0, -popsize-1)
 
 local n = table.getn(keys)
 for i = n, 1, -3 do

--- a/common/consumer_table_pops.lua
+++ b/common/consumer_table_pops.lua
@@ -1,17 +1,13 @@
 local rets = {}
 local keys   = redis.call('LRANGE', KEYS[1], -ARGV[1], -1)
-local ops    = redis.call('LRANGE', KEYS[2], -ARGV[1], -1)
-local values = redis.call('LRANGE', KEYS[3], -ARGV[1], -1)
 
 redis.call('LTRIM', KEYS[1], 0, -ARGV[1]-1)
-redis.call('LTRIM', KEYS[2], 0, -ARGV[1]-1)
-redis.call('LTRIM', KEYS[3], 0, -ARGV[1]-1)
 
 local n = table.getn(keys)
-for i = n, 1, -1 do
+for i = n, 1, -3 do
+   local op = keys[i-2]
+   local value = keys[i-1]
    local key = keys[i]
-   local op = ops[i]
-   local value = values[i]
    local dbop = op:sub(1,1)
    op = op:sub(2)
    local ret = {key, op}
@@ -35,7 +31,7 @@ for i = n, 1, -1 do
        while st <= len do
            local field = ret[st]
 -- keyname is ASIC_STATE : OBJECT_TYPE : OBJECT_ID
-           local keyname = KEYS[4] .. ':' .. key .. ':' .. field
+           local keyname = KEYS[2] .. ':' .. key .. ':' .. field
 
 -- value can be multiple a=v|a=v|... we need to split using gmatch
            local vars = ret[st+1]
@@ -49,9 +45,9 @@ for i = n, 1, -1 do
        end
 
    elseif op ~= 'flush' and op ~= 'flushresponse' and op ~= 'get' and op ~= 'getresponse' and op ~= 'notify' then
-       local keyname = KEYS[4] .. ':' .. key
+       local keyname = KEYS[2] .. ':' .. key
        if key == '' then
-           keyname = KEYS[4]
+           keyname = KEYS[2]
        end
 
        if dbop == 'D' then

--- a/common/consumertable.cpp
+++ b/common/consumertable.cpp
@@ -41,13 +41,11 @@ void ConsumerTable::pops(deque<KeyOpFieldsValuesTuple> &vkco, const string &pref
     static string sha = loadRedisScript(m_db, luaScript);
     RedisCommand command;
     command.format(
-        "EVALSHA %s 4 %s %s %s %s %d '' '' ''",
+        "EVALSHA %s 2 %s %s %d '' '' ''",
         sha.c_str(),
         getKeyQueueTableName().c_str(),
-        getOpQueueTableName().c_str(),
-        getValueQueueTableName().c_str(),
         (prefix+getTableName()).c_str(),
-        POP_BATCH_SIZE);
+        POP_BATCH_SIZE*3);
 
     RedisReply r(m_db, command, REDIS_REPLY_ARRAY);
 

--- a/common/consumertable.cpp
+++ b/common/consumertable.cpp
@@ -20,12 +20,12 @@ ConsumerTable::ConsumerTable(DBConnector *db, const string &tableName, int popBa
 {
     for (;;)
     {
-        RedisReply watch(m_db, string("WATCH ") + getKeyQueueTableName(), REDIS_REPLY_STATUS);
+        RedisReply watch(m_db, string("WATCH ") + getKeyValueOpQueueTableName(), REDIS_REPLY_STATUS);
         watch.checkStatusOK();
         multi();
-        enqueue(string("LLEN ") + getKeyQueueTableName(), REDIS_REPLY_INTEGER);
+        enqueue(string("LLEN ") + getKeyValueOpQueueTableName(), REDIS_REPLY_INTEGER);
         subscribe(m_db, getChannelName());
-        enqueue(string("LLEN ") + getKeyQueueTableName(), REDIS_REPLY_INTEGER);
+        enqueue(string("LLEN ") + getKeyValueOpQueueTableName(), REDIS_REPLY_INTEGER);
         bool succ = exec();
         if (succ) break;
     }
@@ -43,9 +43,9 @@ void ConsumerTable::pops(deque<KeyOpFieldsValuesTuple> &vkco, const string &pref
     command.format(
         "EVALSHA %s 2 %s %s %d '' '' ''",
         sha.c_str(),
-        getKeyQueueTableName().c_str(),
+        getKeyValueOpQueueTableName().c_str(),
         (prefix+getTableName()).c_str(),
-        POP_BATCH_SIZE*3);
+        POP_BATCH_SIZE);
 
     RedisReply r(m_db, command, REDIS_REPLY_ARRAY);
 

--- a/common/producertable.cpp
+++ b/common/producertable.cpp
@@ -25,6 +25,14 @@ ProducerTable::ProducerTable(RedisPipeline *pipeline, const string &tableName, b
     , m_pipeowned(false)
     , m_pipe(pipeline)
 {
+    /*
+     * KEYS[1] : tableName + "_KEY_VALUE_OP_QUEUE
+     * ARGV[1] : key
+     * ARGV[2] : value
+     * ARGV[3] : op
+     * KEYS[2] : tableName + "_CHANNEL"
+     * ARGV[4] : "G"
+     */
     string luaEnque =
         "redis.call('LPUSH', KEYS[1], ARGV[1], ARGV[2], ARGV[3]);"
         "redis.call('PUBLISH', KEYS[2], ARGV[4]);";
@@ -64,7 +72,7 @@ void ProducerTable::enqueueDbChange(const string &key, const string &value, cons
     command.format(
         "EVALSHA %s 2 %s %s %s %s %s %s",
         m_shaEnque.c_str(),
-        getKeyQueueTableName().c_str(),
+        getKeyValueOpQueueTableName().c_str(),
         getChannelName().c_str(),
         key.c_str(),
         value.c_str(),

--- a/common/producertable.cpp
+++ b/common/producertable.cpp
@@ -26,10 +26,8 @@ ProducerTable::ProducerTable(RedisPipeline *pipeline, const string &tableName, b
     , m_pipe(pipeline)
 {
     string luaEnque =
-        "redis.call('LPUSH', KEYS[1], ARGV[1]);"
-        "redis.call('LPUSH', KEYS[2], ARGV[2]);"
-        "redis.call('LPUSH', KEYS[3], ARGV[3]);"
-        "redis.call('PUBLISH', KEYS[4], ARGV[4]);";
+        "redis.call('LPUSH', KEYS[1], ARGV[1], ARGV[2], ARGV[3]);"
+        "redis.call('PUBLISH', KEYS[2], ARGV[4]);";
 
     m_shaEnque = m_pipe->loadRedisScript(luaEnque);
 }
@@ -62,12 +60,11 @@ void ProducerTable::setBuffered(bool buffered)
 void ProducerTable::enqueueDbChange(const string &key, const string &value, const string &op, const string& /* prefix */)
 {
     RedisCommand command;
+
     command.format(
-        "EVALSHA %s 4 %s %s %s %s %s %s %s %s",
+        "EVALSHA %s 2 %s %s %s %s %s %s",
         m_shaEnque.c_str(),
         getKeyQueueTableName().c_str(),
-        getValueQueueTableName().c_str(),
-        getOpQueueTableName().c_str(),
         getChannelName().c_str(),
         key.c_str(),
         value.c_str(),

--- a/common/table.h
+++ b/common/table.h
@@ -175,17 +175,20 @@ private:
     std::string m_key;
     std::string m_value;
     std::string m_op;
+    std::string m_keyvalueop;
 public:
     TableName_KeyValueOpQueues(const std::string &tableName)
         : m_key(tableName + "_KEY_QUEUE")
         , m_value(tableName + "_VALUE_QUEUE")
         , m_op(tableName + "_OP_QUEUE")
+        , m_keyvalueop(tableName + "_KEY_VALUE_OP_QUEUE")
     {
     }
 
     std::string getKeyQueueTableName() const { return m_key; }
     std::string getValueQueueTableName() const { return m_value; }
     std::string getOpQueueTableName() const { return m_op; }
+    std::string getKeyValueOpQueueTableName() const { return m_keyvalueop; }
 };
 
 class TableName_KeySet {

--- a/common/table.h
+++ b/common/table.h
@@ -172,22 +172,13 @@ protected:
 
 class TableName_KeyValueOpQueues {
 private:
-    std::string m_key;
-    std::string m_value;
-    std::string m_op;
     std::string m_keyvalueop;
 public:
     TableName_KeyValueOpQueues(const std::string &tableName)
-        : m_key(tableName + "_KEY_QUEUE")
-        , m_value(tableName + "_VALUE_QUEUE")
-        , m_op(tableName + "_OP_QUEUE")
-        , m_keyvalueop(tableName + "_KEY_VALUE_OP_QUEUE")
+        : m_keyvalueop(tableName + "_KEY_VALUE_OP_QUEUE")
     {
     }
 
-    std::string getKeyQueueTableName() const { return m_key; }
-    std::string getValueQueueTableName() const { return m_value; }
-    std::string getOpQueueTableName() const { return m_op; }
     std::string getKeyValueOpQueueTableName() const { return m_keyvalueop; }
 };
 


### PR DESCRIPTION
Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>

This is to combine the three separate operations for key, op and value into one operation.

With swssconfig to load route to appDB and trigger route download to ASIC, the overall loading speed increased 5~10% in multiple rounds of test.   Don't have the direct speed improvement number for producer/consumer channel only,  it should be better than that number.
   
Since the change is pretty straight forward and simple, and the improvement is obvious, please consider merging this change.


