### PR TITLE
Improve ConsumerStateTable: del after consumed, and let consumer writes the final table

### DIFF
--- a/common/consumer_state_table_pops.lua
+++ b/common/consumer_state_table_pops.lua
@@ -8,8 +8,8 @@ for i = 1, n do
    local key = keys[i]
    local fieldvalues = redis.call('HGETALL', stateprefix..tablename..key)
    table.insert(ret, {key, fieldvalues})
-   for f, v in pairs(fieldvalues) do
-      redis.call('HSET', tablename..key, f, v)
+   for i = 1, #fieldvalues, 2 do
+      redis.call('HSET', tablename..key, fieldvalues[i], fieldvalues[i + 1])
    end
    redis.call('DEL', stateprefix..tablename..key)
 end

--- a/common/consumer_state_table_pops.lua
+++ b/common/consumer_state_table_pops.lua
@@ -12,5 +12,8 @@ for i = 1, n do
       redis.call('HSET', tablename..key, fieldvalues[i], fieldvalues[i + 1])
    end
    redis.call('DEL', stateprefix..tablename..key)
+   if #fieldvalues == 0 then
+      redis.call('DEL', tablename..key)
+   end
 end
 return ret

--- a/common/consumer_state_table_pops.lua
+++ b/common/consumer_state_table_pops.lua
@@ -1,11 +1,16 @@
 redis.replicate_commands()
 local ret = {}
+local tablename = KEYS[2]
+local stateprefix = ARGV[2]
 local keys = redis.call('SPOP', KEYS[1], ARGV[1])
 local n = table.getn(keys)
 for i = 1, n do
    local key = keys[i]
-   local values = redis.call('HGETALL', KEYS[2] .. key)
-   table.insert(ret, {key, values})
-   redis.call('DEL', KEYS[2] .. key)
+   local fieldvalues = redis.call('HGETALL', stateprefix..tablename..key)
+   table.insert(ret, {key, fieldvalues})
+   for f, v in pairs(fieldvalues) do
+      redis.call('HSET', tablename..key, f, v)
+   end
+   redis.call('DEL', stateprefix..tablename..key)
 end
 return ret

--- a/common/consumer_state_table_pops.lua
+++ b/common/consumer_state_table_pops.lua
@@ -1,3 +1,4 @@
+redis.replicate_commands()
 local ret = {}
 local keys = redis.call('SPOP', KEYS[1], ARGV[1])
 local n = table.getn(keys)
@@ -5,5 +6,6 @@ for i = 1, n do
    local key = keys[i]
    local values = redis.call('HGETALL', KEYS[2] .. key)
    table.insert(ret, {key, values})
+   redis.call('DEL', KEYS[2] .. key)
 end
 return ret

--- a/common/consumerstatetable.cpp
+++ b/common/consumerstatetable.cpp
@@ -38,11 +38,12 @@ void ConsumerStateTable::pops(std::deque<KeyOpFieldsValuesTuple> &vkco, const st
 
     RedisCommand command;
     command.format(
-        "EVALSHA %s 2 %s %s: %d ''",
+        "EVALSHA %s 2 %s %s: %d %s",
         sha.c_str(),
         getKeySetName().c_str(),
         getTableName().c_str(),
-        POP_BATCH_SIZE);
+        POP_BATCH_SIZE,
+        getStateHashPrefix().c_str());
 
     RedisReply r(m_db, command);
     auto ctx0 = r.getContext();
@@ -64,7 +65,6 @@ void ConsumerStateTable::pops(std::deque<KeyOpFieldsValuesTuple> &vkco, const st
         assert(values.empty());
 
         auto& ctx = ctx0->element[ie];
-        assert(ctx->elements == 2);
         assert(ctx->element[0]->type == REDIS_REPLY_STRING);
         std::string key = ctx->element[0]->str;
         kfvKey(kco) = key;

--- a/common/producerstatetable.cpp
+++ b/common/producerstatetable.cpp
@@ -65,7 +65,7 @@ void ProducerStateTable::set(const string &key, const vector<FieldValueTuple> &v
     args.emplace_back(getChannelName());
     args.emplace_back(getKeySetName());
 
-    args.insert(args.end(), values.size(), getKeyName(key));
+    args.insert(args.end(), values.size(), getStateHashPrefix() + getKeyName(key));
 
     args.emplace_back("G");
     args.emplace_back(key);
@@ -98,7 +98,7 @@ void ProducerStateTable::del(const string &key, const string &op /*= DEL_COMMAND
     args.emplace_back("3");
     args.emplace_back(getChannelName());
     args.emplace_back(getKeySetName());
-    args.emplace_back(getKeyName(key));
+    args.emplace_back(getStateHashPrefix() + getKeyName(key));
     args.emplace_back("G");
     args.emplace_back(key);
     args.emplace_back("''");

--- a/common/table.h
+++ b/common/table.h
@@ -192,6 +192,7 @@ public:
     }
 
     std::string getKeySetName() const { return m_key; }
+    std::string getStateHashPrefix() const { return "_"; }
 };
 
 }

--- a/tests/redis_state_ut.cpp
+++ b/tests/redis_state_ut.cpp
@@ -215,6 +215,13 @@ TEST(ConsumerStateTable, double_set)
         int ret = cs.select(&selectcs, 1000);
         EXPECT_EQ(ret, Select::TIMEOUT);
     }
+
+    /* State Queue should be empty */
+    RedisCommand keys;
+    keys.format("KEYS %s*", tableName.c_str());
+    RedisReply r(&db, keys, REDIS_REPLY_ARRAY);
+    auto qlen = r.getContext()->elements;
+    EXPECT_EQ(qlen, 0U);
 }
 
 TEST(ConsumerStateTable, set_del)


### PR DESCRIPTION
Original implementation will have 2 issues:
1. The consumer side will accumulate all the state into redis hashes, and each time a new field/value, the consumer will pop it, and return all the filed/value accumulated.
2. The producer side modify the redis hashes directly. To behavior the same way as Producer/ConsumerTable, let the consumer side modify the redis hashes.