### PR TITLE
One lrange and test, Reduce the number of LPUSH/LRANGE/LTRIM operations for producer/consumer

### DIFF
--- a/common/consumertable.cpp
+++ b/common/consumertable.cpp
@@ -31,7 +31,9 @@ ConsumerTable::ConsumerTable(DBConnector *db, const string &tableName, int popBa
     }
 
     RedisReply r(dequeueReply());
-    setQueueLength(r.getReply<long long int>());
+    long long int len = r.getReply<long long int>();
+    //Key, Value and OP are in one list, they are processed in one shot
+    setQueueLength(len/3);
 }
 
 void ConsumerTable::pops(deque<KeyOpFieldsValuesTuple> &vkco, const string &prefix)
@@ -41,7 +43,7 @@ void ConsumerTable::pops(deque<KeyOpFieldsValuesTuple> &vkco, const string &pref
     static string sha = loadRedisScript(m_db, luaScript);
     RedisCommand command;
     command.format(
-        "EVALSHA %s 2 %s %s %d '' '' ''",
+        "EVALSHA %s 2 %s %s %d ''",
         sha.c_str(),
         getKeyValueOpQueueTableName().c_str(),
         (prefix+getTableName()).c_str(),

--- a/common/consumertable.cpp
+++ b/common/consumertable.cpp
@@ -20,12 +20,12 @@ ConsumerTable::ConsumerTable(DBConnector *db, const string &tableName, int popBa
 {
     for (;;)
     {
-        RedisReply watch(m_db, string("WATCH ") + getKeyQueueTableName(), REDIS_REPLY_STATUS);
+        RedisReply watch(m_db, string("WATCH ") + getKeyValueOpQueueTableName(), REDIS_REPLY_STATUS);
         watch.checkStatusOK();
         multi();
-        enqueue(string("LLEN ") + getKeyQueueTableName(), REDIS_REPLY_INTEGER);
+        enqueue(string("LLEN ") + getKeyValueOpQueueTableName(), REDIS_REPLY_INTEGER);
         subscribe(m_db, getChannelName());
-        enqueue(string("LLEN ") + getKeyQueueTableName(), REDIS_REPLY_INTEGER);
+        enqueue(string("LLEN ") + getKeyValueOpQueueTableName(), REDIS_REPLY_INTEGER);
         bool succ = exec();
         if (succ) break;
     }
@@ -41,11 +41,9 @@ void ConsumerTable::pops(deque<KeyOpFieldsValuesTuple> &vkco, const string &pref
     static string sha = loadRedisScript(m_db, luaScript);
     RedisCommand command;
     command.format(
-        "EVALSHA %s 4 %s %s %s %s %d '' '' ''",
+        "EVALSHA %s 2 %s %s %d '' '' ''",
         sha.c_str(),
-        getKeyQueueTableName().c_str(),
-        getOpQueueTableName().c_str(),
-        getValueQueueTableName().c_str(),
+        getKeyValueOpQueueTableName().c_str(),
         (prefix+getTableName()).c_str(),
         POP_BATCH_SIZE);
 

--- a/common/producertable.cpp
+++ b/common/producertable.cpp
@@ -25,11 +25,17 @@ ProducerTable::ProducerTable(RedisPipeline *pipeline, const string &tableName, b
     , m_pipeowned(false)
     , m_pipe(pipeline)
 {
+    /*
+     * KEYS[1] : tableName + "_KEY_VALUE_OP_QUEUE
+     * ARGV[1] : key
+     * ARGV[2] : value
+     * ARGV[3] : op
+     * KEYS[2] : tableName + "_CHANNEL"
+     * ARGV[4] : "G"
+     */
     string luaEnque =
-        "redis.call('LPUSH', KEYS[1], ARGV[1]);"
-        "redis.call('LPUSH', KEYS[2], ARGV[2]);"
-        "redis.call('LPUSH', KEYS[3], ARGV[3]);"
-        "redis.call('PUBLISH', KEYS[4], ARGV[4]);";
+        "redis.call('LPUSH', KEYS[1], ARGV[1], ARGV[2], ARGV[3]);"
+        "redis.call('PUBLISH', KEYS[2], ARGV[4]);";
 
     m_shaEnque = m_pipe->loadRedisScript(luaEnque);
 }
@@ -62,12 +68,11 @@ void ProducerTable::setBuffered(bool buffered)
 void ProducerTable::enqueueDbChange(const string &key, const string &value, const string &op, const string& /* prefix */)
 {
     RedisCommand command;
+
     command.format(
-        "EVALSHA %s 4 %s %s %s %s %s %s %s %s",
+        "EVALSHA %s 2 %s %s %s %s %s %s",
         m_shaEnque.c_str(),
-        getKeyQueueTableName().c_str(),
-        getValueQueueTableName().c_str(),
-        getOpQueueTableName().c_str(),
+        getKeyValueOpQueueTableName().c_str(),
         getChannelName().c_str(),
         key.c_str(),
         value.c_str(),

--- a/common/table.h
+++ b/common/table.h
@@ -172,20 +172,14 @@ protected:
 
 class TableName_KeyValueOpQueues {
 private:
-    std::string m_key;
-    std::string m_value;
-    std::string m_op;
+    std::string m_keyvalueop;
 public:
     TableName_KeyValueOpQueues(const std::string &tableName)
-        : m_key(tableName + "_KEY_QUEUE")
-        , m_value(tableName + "_VALUE_QUEUE")
-        , m_op(tableName + "_OP_QUEUE")
+        : m_keyvalueop(tableName + "_KEY_VALUE_OP_QUEUE")
     {
     }
 
-    std::string getKeyQueueTableName() const { return m_key; }
-    std::string getValueQueueTableName() const { return m_value; }
-    std::string getOpQueueTableName() const { return m_op; }
+    std::string getKeyValueOpQueueTableName() const { return m_keyvalueop; }
 };
 
 class TableName_KeySet {

--- a/tests/redis_ut.cpp
+++ b/tests/redis_ut.cpp
@@ -633,6 +633,12 @@ TEST(ProducerConsumer, ConsumerSelectWithInitData)
             break;
     }
 
+    /* Second select operation */
+    {
+        int ret = cs.select(&selectcs, 1000);
+        EXPECT_EQ(ret, Select::TIMEOUT);
+    }
+
     for (i = 0; i < NUMBER_OF_OPS; i++)
     {
         p.del(key(i));
@@ -652,6 +658,11 @@ TEST(ProducerConsumer, ConsumerSelectWithInitData)
 
         if (numberOfKeyDeleted == NUMBER_OF_OPS)
             break;
+    }
+    /* check select operation again */
+    {
+        int ret = cs.select(&selectcs, 1000);
+        EXPECT_EQ(ret, Select::TIMEOUT);
     }
 
     EXPECT_LE(numberOfKeysSet, numberOfKeyDeleted);

--- a/tests/redis_ut.cpp
+++ b/tests/redis_ut.cpp
@@ -173,7 +173,7 @@ void TableBasicTest(string tableName)
     vector<string> keys;
     t.getKeys(keys);
     EXPECT_EQ(keys.size(), (size_t)2);
- 
+
     for (auto k : keys)
     {
         cout << "Get key [" << k << "]" << flush;
@@ -586,4 +586,78 @@ TEST(ProducerConsumer, PopEmpty)
     EXPECT_EQ(key, "");
     EXPECT_EQ(op, "");
     EXPECT_EQ(fvs.size(), 0U);
+}
+
+TEST(ProducerConsumer, ConsumerSelectWithInitData)
+{
+    clearDB();
+
+    string tableName = "tableName";
+    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    ProducerTable p(&db, tableName);
+
+    for (int i = 0; i < NUMBER_OF_OPS; i++)
+    {
+        vector<FieldValueTuple> fields;
+        int maxNumOfFields = getMaxFields(i);
+        for (int j = 0; j < maxNumOfFields; j++)
+        {
+            FieldValueTuple t(field(j), value(j));
+            fields.push_back(t);
+        }
+        if ((i % 100) == 0)
+            cout << "+" << flush;
+
+        p.set(key(i), fields);
+    }
+
+    ConsumerTable c(&db, tableName);
+    Select cs;
+    Selectable *selectcs;
+    int ret, i = 0;
+    KeyOpFieldsValuesTuple kco;
+
+    cs.addSelectable(&c);
+    int numberOfKeysSet = 0;
+    while ((ret = cs.select(&selectcs)) == Select::OBJECT)
+    {
+        c.pop(kco);
+        EXPECT_EQ(kfvOp(kco), "SET");
+        numberOfKeysSet++;
+        validateFields(kfvKey(kco), kfvFieldsValues(kco));
+
+        if ((i++ % 100) == 0)
+            cout << "-" << flush;
+
+        if (numberOfKeysSet == NUMBER_OF_OPS)
+            break;
+    }
+
+    for (i = 0; i < NUMBER_OF_OPS; i++)
+    {
+        p.del(key(i));
+        if ((i % 100) == 0)
+            cout << "+" << flush;
+    }
+
+    int numberOfKeyDeleted = 0;
+    while ((ret = cs.select(&selectcs)) == Select::OBJECT)
+    {
+        c.pop(kco);
+        EXPECT_EQ(kfvOp(kco), "DEL");
+        numberOfKeyDeleted++;
+
+        if ((i++ % 100) == 0)
+            cout << "-" << flush;
+
+        if (numberOfKeyDeleted == NUMBER_OF_OPS)
+            break;
+    }
+
+    EXPECT_LE(numberOfKeysSet, numberOfKeyDeleted);
+    EXPECT_EQ(ret, Select::OBJECT);
+
+    cout << "Done. Waiting for all job to finish " << NUMBER_OF_OPS << " jobs." << endl;
+
+    cout << endl << "Done." << endl;
 }

--- a/tests/redis_ut.cpp
+++ b/tests/redis_ut.cpp
@@ -635,7 +635,7 @@ TEST(ProducerConsumer, ConsumerSelectWithInitData)
 
     /* Second select operation */
     {
-        int ret = cs.select(&selectcs, 1000);
+        ret = cs.select(&selectcs, 1000);
         EXPECT_EQ(ret, Select::TIMEOUT);
     }
 
@@ -661,12 +661,11 @@ TEST(ProducerConsumer, ConsumerSelectWithInitData)
     }
     /* check select operation again */
     {
-        int ret = cs.select(&selectcs, 1000);
+        ret = cs.select(&selectcs, 1000);
         EXPECT_EQ(ret, Select::TIMEOUT);
     }
 
     EXPECT_LE(numberOfKeysSet, numberOfKeyDeleted);
-    EXPECT_EQ(ret, Select::OBJECT);
 
     cout << "Done. Waiting for all job to finish " << NUMBER_OF_OPS << " jobs." << endl;
 


### PR DESCRIPTION
This is a redo of https://github.com/Azure/sonic-swss-common/pull/203, fixed the problem of wrong m_queueLength for ConsumerTable constructor when there is data available before consumer is created.

Test case ConsumerSelectWithInitData added to swss-common unit test to cover this scenario.

Passed sonic-sairedis and swss-common unit test.

brcm.pl 
```
root@7ab17491ef82:/sonic/src/sonic-sairedis/tests# ./brcm.pl 
Using scripts dir 'brcm'
main::test_brcm_start_empty: Fresh start
Killing syncd
.......
Starting syncd
Replay full_no_queue_no_ipg_no_buffer_pfofile.rec
WARN: sai_metadata_apis_query: :- failed to query api SAI_API_IPMC: SAI_STATUS_INVALID_PARAMETER (-5)WARN: sai_metadata_apis_query: :- failed to query api SAI_API_IPMC_GROUP: SAI_STATUS_INVALID_PARAMETER (-5)WARN: sai_metadata_apis_query: :- failed to query api SAI_API_L2MC: SAI_STATUS_INVALID_PARAMETER (-5)WARN: sai_metadata_apis_query: :- failed to query api SAI_API_L2MC_GROUP: SAI_STATUS_INVALID_PARAMETER (-5)WARN: sai_metadata_apis_query: :- failed to query api SAI_API_MCAST_FDB: SAI_STATUS_INVALID_PARAMETER (-5)WARN: sai_metadata_apis_query: :- failed to query api SAI_API_MPLS: SAI_STATUS_INVALID_PARAMETER (-5)WARN: sai_metadata_apis_query: :- failed to query api SAI_API_RPF_GROUP: SAI_STATUS_INVALID_PARAMETER (-5)WARN: sai_metadata_apis_query: :- failed to query api SAI_API_SEGMENTROUTE: SAI_STATUS_INVALID_PARAMETER (-5)WARN: sai_metadata_apis_query: :- failed to query api SAI_API_TAM: SAI_STATUS_INVALID_PARAMETER (-5)WARN: sai_metadata_apis_query: :- failed to query api SAI_API_UBURST: SAI_STATUS_INVALID_PARAMETER (-5)Replay empty_sw.rec
WARN: sai_metadata_apis_query: :- failed to query api SAI_API_IPMC: SAI_STATUS_INVALID_PARAMETER (-5)WARN: sai_metadata_apis_query: :- failed to query api SAI_API_IPMC_GROUP: SAI_STATUS_INVALID_PARAMETER (-5)WARN: sai_metadata_apis_query: :- failed to query api SAI_API_L2MC: SAI_STATUS_INVALID_PARAMETER (-5)WARN: sai_metadata_apis_query: :- failed to query api SAI_API_L2MC_GROUP: SAI_STATUS_INVALID_PARAMETER (-5)WARN: sai_metadata_apis_query: :- failed to query api SAI_API_MCAST_FDB: SAI_STATUS_INVALID_PARAMETER (-5)WARN: sai_metadata_apis_query: :- failed to query api SAI_API_MPLS: SAI_STATUS_INVALID_PARAMETER (-5)WARN: sai_metadata_apis_query: :- failed to query api SAI_API_RPF_GROUP: SAI_STATUS_INVALID_PARAMETER (-5)WARN: sai_metadata_apis_query: :- failed to query api SAI_API_SEGMENTROUTE: SAI_STATUS_INVALID_PARAMETER (-5)WARN: sai_metadata_apis_query: :- failed to query api SAI_API_TAM: SAI_STATUS_INVALID_PARAMETER (-5)WARN: sai_metadata_apis_query: :- failed to query api SAI_API_UBURST: SAI_STATUS_INVALID_PARAMETER (-5)Killing syncd
root@7ab17491ef82:/sonic/src/sonic-sairedis/tests# 
```
mlnx.pl 
```
root@7ab17491ef82:/sonic/src/sonic-sairedis/tests# ./mlnx.pl 
Using scripts dir 'mlnx'
main::test_mlnx_nhg_member: Fresh start
Killing syncd
Flushing redis
Starting syncd
....

Replay full_no_hostif_entry.rec
WARN: sai_metadata_apis_query: :- failed to query api SAI_API_IPMC: 
......
sai_metadata_apis_query: :- failed to query api SAI_API_UBURST: SAI_STATUS_INVALID_PARAMETER (-5)Killing syncd
````

swss-common unit test with new ConsumerSelectWithInitData test case
```
root@7ab17491ef82:/sonic/src/sonic-swss-common/tests# ./tests 
Running main() from gtest_main.cc
[==========] Running 69 tests from 17 test cases.
.....
[       OK ] ProducerConsumer.PopEmpty (1 ms)
[ RUN      ] ProducerConsumer.ConsumerSelectWithInitData
++++++++++----------++++++++++----------Done. Waiting for all job to finish 1000 jobs.

Done.
[       OK ] ProducerConsumer.ConsumerSelectWithInitData (245 ms)

.....


[----------] Global test environment tear-down
[==========] 69 tests from 17 test cases ran. (120299 ms total)
[  PASSED  ] 69 tests.
root@7ab17491ef82:/sonic/src/sonic-swss-common/tests# 
```