### PR TITLE
Add support for bool Select::hasCachedSelectable()

### DIFF
--- a/common/select.cpp
+++ b/common/select.cpp
@@ -159,4 +159,9 @@ int Select::select(Selectable **c, unsigned int timeout)
 
 }
 
+bool Select::hasCachedSelectable()
+{
+    return !m_ready.empty();
+}
+
 };

--- a/common/select.h
+++ b/common/select.h
@@ -34,7 +34,7 @@ public:
     };
 
     int select(Selectable **c, unsigned int timeout = std::numeric_limits<unsigned int>::max());
-
+    bool hasCachedSelectable();
 private:
     struct cmp
     {


### PR DESCRIPTION
Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>

For warm restart state restore,  there is need to check if all cached selectables have been processed.