### PR TITLE
swss-common: add op 'create' case to avoid flush immediately

### DIFF
--- a/common/producertable.cpp
+++ b/common/producertable.cpp
@@ -101,8 +101,8 @@ void ProducerTable::set(const string &key, const vector<FieldValueTuple> &values
     }
 
     enqueueDbChange(key, JSon::buildJson(values), "S" + op, prefix);
-    // Only buffer continuous "set/set" or "del" operations
-    if (!m_buffered || (op != "set" && op != "bulkset" ))
+    // Only buffer "set", "bulkset" or "create" operations
+    if (!m_buffered || (op != "create" && op != "set" && op != "bulkset" ))
     {
         m_pipe->flush();
     }


### PR DESCRIPTION
* create operation is used when writing routes into ASIC_DB
* operation create is added to make sure 'create' cases are redis pipelined
* with the changes in sairedis and swss, route performance improved by 200~300 routes/sec

  Signed-off-by: Dong Zhang d.zhang@alibaba-inc.com