### PR TITLE
Fix incorret table data issue with consecutive producerState del/set …

### DIFF
--- a/common/consumer_state_table_pops.lua
+++ b/common/consumer_state_table_pops.lua
@@ -6,18 +6,18 @@ local keys = redis.call('SPOP', KEYS[1], ARGV[1])
 local n = table.getn(keys)
 for i = 1, n do
    local key = keys[i]
--- Check if there was request to delte the key, clear the key in table first
-   local num = redis.call('SREM', KEYS[1]..'_DEL', key)
+   -- Check if there was request to delete the key, clear it in table first
+   local num = redis.call('SREM', KEYS[3], key)
    if num == 1 then
       redis.call('DEL', tablename..key)
    end
--- Push the new set of field/value with the key in table
+   -- Push the new set of field/value for this key in table
    local fieldvalues = redis.call('HGETALL', stateprefix..tablename..key)
    table.insert(ret, {key, fieldvalues})
    for i = 1, #fieldvalues, 2 do
       redis.call('HSET', tablename..key, fieldvalues[i], fieldvalues[i + 1])
    end
--- Clean up the key in temporary state table
+   -- Clean up the key in temporary state table
    redis.call('DEL', stateprefix..tablename..key)
 end
 return ret

--- a/common/consumer_state_table_pops.lua
+++ b/common/consumer_state_table_pops.lua
@@ -6,14 +6,18 @@ local keys = redis.call('SPOP', KEYS[1], ARGV[1])
 local n = table.getn(keys)
 for i = 1, n do
    local key = keys[i]
+-- Check if there was request to delte the key, clear the key in table first
+   local num = redis.call('SREM', KEYS[1]..'_DEL', key)
+   if num == 1 then
+      redis.call('DEL', tablename..key)
+   end
+-- Push the new set of field/value with the key in table
    local fieldvalues = redis.call('HGETALL', stateprefix..tablename..key)
    table.insert(ret, {key, fieldvalues})
    for i = 1, #fieldvalues, 2 do
       redis.call('HSET', tablename..key, fieldvalues[i], fieldvalues[i + 1])
    end
+-- Clean up the key in temporary state table
    redis.call('DEL', stateprefix..tablename..key)
-   if #fieldvalues == 0 then
-      redis.call('DEL', tablename..key)
-   end
 end
 return ret

--- a/common/consumerstatetable.cpp
+++ b/common/consumerstatetable.cpp
@@ -38,10 +38,11 @@ void ConsumerStateTable::pops(std::deque<KeyOpFieldsValuesTuple> &vkco, const st
 
     RedisCommand command;
     command.format(
-        "EVALSHA %s 2 %s %s: %d %s",
+        "EVALSHA %s 3 %s %s: %s %d %s",
         sha.c_str(),
         getKeySetName().c_str(),
         getTableName().c_str(),
+        getDelKeySetName().c_str(),
         POP_BATCH_SIZE,
         getStateHashPrefix().c_str());
 

--- a/common/producerstatetable.cpp
+++ b/common/producerstatetable.cpp
@@ -36,12 +36,14 @@ ProducerStateTable::ProducerStateTable(RedisPipeline *pipeline, const string &ta
 
     string luaDel =
         "redis.call('SADD', KEYS[2], ARGV[2])\n"
+        "redis.call('SADD', KEYS[2] .. '_DEL', ARGV[2])\n"
         "redis.call('DEL', KEYS[3])\n"
         "redis.call('PUBLISH', KEYS[1], ARGV[1])\n";
     m_shaDel = m_pipe->loadRedisScript(luaDel);
 
     string luaClear =
         "redis.call('DEL', KEYS[1])\n"
+        "redis.call('DEL', KEYS[1] .. '_DEL')\n"
         "redis.call('DEL', KEYS[2])\n";
     m_shaClear = m_pipe->loadRedisScript(luaClear);
 }

--- a/common/table.h
+++ b/common/table.h
@@ -194,13 +194,16 @@ public:
 class TableName_KeySet {
 private:
     std::string m_key;
+    std::string m_delkey;
 public:
     TableName_KeySet(const std::string &tableName)
         : m_key(tableName + "_KEY_SET")
+        , m_delkey(tableName + "_DEL_SET")
     {
     }
 
     std::string getKeySetName() const { return m_key; }
+    std::string getDelKeySetName() const { return m_delkey; }
     std::string getStateHashPrefix() const { return "_"; }
 };
 

--- a/tests/redis_state_ut.cpp
+++ b/tests/redis_state_ut.cpp
@@ -397,7 +397,7 @@ TEST(ConsumerStateTable, set_pop_del_set_pop_get)
         p.set(key, fields);
     }
 
-  /* Prepare consumer */
+    /* Prepare consumer */
     ConsumerStateTable c(&db, tableName);
     Select cs;
     Selectable *selectcs;


### PR DESCRIPTION
…operations

Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>

This is to fix issue: https://github.com/Azure/sonic-swss-common/issues/236

Without the fix, ConsumerStateTable.set_pop_del_set_pop_get unit test will fail with:

```
root@e344622f6661:/sonic/src/sonic-swss-common/tests# ./tests --gtest_filter=ConsumerStateTable.set_pop_del_set_pop_get
Running main() from gtest_main.cc
Note: Google Test filter = ConsumerStateTable.set_pop_del_set_pop_get
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from ConsumerStateTable
[ RUN      ] ConsumerStateTable.set_pop_del_set_pop_get
redis_state_ut.cpp:477: Failure
      Expected: values.size()
      Which is: 3
To be equal to: (unsigned int)maxNumOfFields
      Which is: 2
[  FAILED  ] ConsumerStateTable.set_pop_del_set_pop_get (1003 ms)
[----------] 1 test from ConsumerStateTable (1003 ms total)
```
