### PR TITLE
FixProducerStateTable::clear() to clear StateHash properly

### DIFF
--- a/common/producerstatetable.cpp
+++ b/common/producerstatetable.cpp
@@ -43,7 +43,10 @@ ProducerStateTable::ProducerStateTable(RedisPipeline *pipeline, const string &ta
 
     string luaClear =
         "redis.call('DEL', KEYS[1])\n"
-        "redis.call('DEL', KEYS[2])\n"
+        "local keys = redis.call('KEYS', KEYS[2] .. '*')\n"
+        "for i,k in pairs(keys) do\n"
+        "    redis.call('DEL', k)\n"
+        "end\n"
         "redis.call('DEL', KEYS[3])\n";
     m_shaClear = m_pipe->loadRedisScript(luaClear);
 }


### PR DESCRIPTION
Current `FixProducerStateTable::clear()` implementation is calling `DEL` with `getStateHashPrefix() + getTableName()` (something like `DEL _ROUTE_TABLE`), which will not clear StateHash correctly. 

This change fixes it by `DEL` `_ROUTE_TABLE*` instead.