### PR TITLE
[ut]: explicit convert is to bool type

### DIFF
--- a/tests/redis_piped_state_ut.cpp
+++ b/tests/redis_piped_state_ut.cpp
@@ -55,7 +55,7 @@ static inline int readNumberAtEOL(const string& str)
     istringstream is(str.substr(pos - str.begin()));
     int ret;
     is >> ret;
-    EXPECT_TRUE(is);
+    EXPECT_TRUE((bool)is);
     return ret;
 }
 

--- a/tests/redis_state_ut.cpp
+++ b/tests/redis_state_ut.cpp
@@ -55,7 +55,7 @@ static inline int readNumberAtEOL(const string& str)
     istringstream is(str.substr(pos - str.begin()));
     int ret;
     is >> ret;
-    EXPECT_TRUE(is);
+    EXPECT_TRUE((bool)is);
     return ret;
 }
 

--- a/tests/redis_subscriber_state_ut.cpp
+++ b/tests/redis_subscriber_state_ut.cpp
@@ -66,7 +66,7 @@ static inline int readNumberAtEOL(const string& str)
     int ret;
     is >> ret;
 
-    EXPECT_TRUE(is);
+    EXPECT_TRUE((bool)is);
 
     return ret;
 }


### PR DESCRIPTION
since ios has explicit operator bool, we need to explicitly convert it to bool

see compilation error under ubuntu 16.04
```
g++ -DHAVE_CONFIG_H -I. -I.. -I .. -g -DNDEBUG  -ansi -fPIC -std=c++11 -Wall -Wcast-align -Wcast-qual -Wconversion -Wdisabled-optimization -Werror -Wextra -Wfloat-equal -Wformat=2 -Wformat-nonliteral -Wformat-security -Wformat-y2k -Wimport -Winit-self -Winvalid-pch -Wlong-long -Wmissing-field-initializers -Wmissing-format-attribute -Wmissing-include-dirs -Wmissing-noreturn -Wno-aggregate-return -Wno-padded -Wno-switch-enum -Wno-unused-parameter -Wpacked -Wpointer-arith -Wredundant-decls -Wshadow -Wstack-protector -Wstrict-aliasing=3 -Wswitch -Wswitch-default -Wunreachable-code -Wunused -Wvariadic-macros -Wno-write-strings -Wno-missing-format-attribute -Wno-long-long  -I/usr/include/libnl3 -Wdate-time -D_FORTIFY_SOURCE=2  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -c -o tests-redis_state_ut.o `test -f 'redis_state_ut.cpp' || echo './'`redis_state_ut.cpp
In file included from /usr/include/gtest/gtest.h:58:0,
                 from redis_state_ut.cpp:5:
redis_state_ut.cpp: In function ‘int readNumberAtEOL(const string&)’:
redis_state_ut.cpp:58:5: error: no matching function for call to ‘testing::AssertionResult::AssertionResult(std::istringstream&)’
     EXPECT_TRUE(is);
     ^
In file included from redis_state_ut.cpp:5:0:
/usr/include/gtest/gtest.h:262:12: note: candidate: testing::AssertionResult::AssertionResult(bool)
   explicit AssertionResult(bool success) : success_(success) {}
            ^
/usr/include/gtest/gtest.h:262:12: note:   no known conversion for argument 1 from ‘std::istringstream {aka std::__cxx11::basic_istringstream<char>}’ to ‘bool’
/usr/include/gtest/gtest.h:260:3: note: candidate: testing::AssertionResult::AssertionResult(const testing::AssertionResult&)
   AssertionResult(const AssertionResult& other);
   ^
/usr/include/gtest/gtest.h:260:3: note:   no known conversion for argument 1 from ‘std::istringstream {aka std::__cxx11::basic_istringstream<char>}’ to ‘const testing::AssertionResult&’
Makefile:510: recipe for target 'tests-redis_state_ut.o' failed
```