### PR TITLE
Align the argument type with epoll_wait()

### DIFF
--- a/common/select.cpp
+++ b/common/select.cpp
@@ -135,15 +135,13 @@ int Select::poll_descriptors(Selectable **c, unsigned int timeout)
     return Select::TIMEOUT;
 }
 
-int Select::select(Selectable **c, unsigned int timeout)
+int Select::select(Selectable **c, int timeout)
 {
     SWSS_LOG_ENTER();
 
     int ret;
 
     *c = NULL;
-    if (timeout == numeric_limits<unsigned int>::max())
-        timeout = -1;
 
     /* check if we have some data */
     ret = poll_descriptors(c, 0);

--- a/common/select.h
+++ b/common/select.h
@@ -6,7 +6,6 @@
 #include <queue>
 #include <unordered_map>
 #include <set>
-#include <limits>
 #include <hiredis/hiredis.h>
 #include "selectable.h"
 
@@ -33,7 +32,7 @@ public:
         TIMEOUT = 2,
     };
 
-    int select(Selectable **c, unsigned int timeout = std::numeric_limits<unsigned int>::max());
+    int select(Selectable **c, int timeout = -1);
     bool isQueueEmpty();
 private:
     struct cmp


### PR DESCRIPTION
epool_wait() requires a timeout parameter with int type, but the
Select class use unsigned int.

Signed-off-by: Kevin Wang <kevinw@mellanox.com>