### PR TITLE
Optimized ProducerStateTable set/del notification processing to avoid…

### DIFF
--- a/common/producerstatetable.cpp
+++ b/common/producerstatetable.cpp
@@ -30,20 +30,20 @@ ProducerStateTable::ProducerStateTable(RedisPipeline *pipeline, const string &ta
     // num in luaSet and luaDel means number of elements that were added to the key set,
     // not including all the elements already present into the set.
     string luaSet =
-        "local num = redis.call('SADD', KEYS[2], ARGV[2])\n"
+        "local added = redis.call('SADD', KEYS[2], ARGV[2])\n"
         "for i = 0, #KEYS - 3 do\n"
         "    redis.call('HSET', KEYS[3 + i], ARGV[3 + i * 2], ARGV[4 + i * 2])\n"
         "end\n"
-        " if num > 0 then \n"
+        " if added > 0 then \n"
         "    redis.call('PUBLISH', KEYS[1], ARGV[1])\n"
         "end\n";
     m_shaSet = m_pipe->loadRedisScript(luaSet);
 
     string luaDel =
-        "local num = redis.call('SADD', KEYS[2], ARGV[2])\n"
+        "local added = redis.call('SADD', KEYS[2], ARGV[2])\n"
         "redis.call('SADD', KEYS[4], ARGV[2])\n"
         "redis.call('DEL', KEYS[3])\n"
-        "if num > 0 then \n"
+        "if added > 0 then \n"
         "    redis.call('PUBLISH', KEYS[1], ARGV[1])\n"
         "end\n";
     m_shaDel = m_pipe->loadRedisScript(luaDel);

--- a/common/producerstatetable.cpp
+++ b/common/producerstatetable.cpp
@@ -28,18 +28,22 @@ ProducerStateTable::ProducerStateTable(RedisPipeline *pipeline, const string &ta
     , m_pipe(pipeline)
 {
     string luaSet =
-        "redis.call('SADD', KEYS[2], ARGV[2])\n"
+        "local num = redis.call('SADD', KEYS[2], ARGV[2])\n"
         "for i = 0, #KEYS - 3 do\n"
         "    redis.call('HSET', KEYS[3 + i], ARGV[3 + i * 2], ARGV[4 + i * 2])\n"
         "end\n"
-        "redis.call('PUBLISH', KEYS[1], ARGV[1])\n";
+        " if num == 1 then \n"
+        "    redis.call('PUBLISH', KEYS[1], ARGV[1])\n"
+        "end\n";
     m_shaSet = m_pipe->loadRedisScript(luaSet);
 
     string luaDel =
-        "redis.call('SADD', KEYS[2], ARGV[2])\n"
+        "local num = redis.call('SADD', KEYS[2], ARGV[2])\n"
         "redis.call('SADD', KEYS[4], ARGV[2])\n"
         "redis.call('DEL', KEYS[3])\n"
-        "redis.call('PUBLISH', KEYS[1], ARGV[1])\n";
+        "if num == 1 then \n"
+        "    redis.call('PUBLISH', KEYS[1], ARGV[1])\n"
+        "end\n";
     m_shaDel = m_pipe->loadRedisScript(luaDel);
 
     string luaClear =
@@ -196,7 +200,7 @@ void ProducerStateTable::create_temp_view()
         SWSS_LOG_WARN("create_temp_view() called for table %s when another temp view is under work, %zd objects in existing temp view will be discarded.", getTableName().c_str(), m_tempViewState.size());
     }
     m_tempViewActive = true;
-    m_tempViewState.clear(); 
+    m_tempViewState.clear();
 }
 
 void ProducerStateTable::apply_temp_view()
@@ -233,13 +237,13 @@ void ProducerStateTable::apply_temp_view()
     std::vector<std::string> keysToDel;
 
     // Compare based on existing objects.
-    //     Please note that this comparation is literal not contextual - 
+    //     Please note that this comparation is literal not contextual -
     //     e.g. {nexthop: 10.1.1.1, 10.1.1.2} and {nexthop: 10.1.1.2, 10.1.1.1} will be treated as different.
     //     Application will need to handle it, to make sure contextually identical field values also literally identical.
     for (auto const & kfvPair : currentState)
     {
         const string& key = kfvPair.first;
-        const TableMap& fieldValueMap = kfvPair.second; 
+        const TableMap& fieldValueMap = kfvPair.second;
         // DEL is needed if object does not exist in new state, or any field is not presented in new state
         // SET is almost always needed, unless old state and new state exactly match each other
         //     (All old fields exists in new state, values match, and there is no additional field in new state)
@@ -272,18 +276,18 @@ void ProducerStateTable::apply_temp_view()
             needSet = true;
         }
 
-        if (needDel) 
-        { 
+        if (needDel)
+        {
             keysToDel.emplace_back(key);
         }
-        if (needSet) 
+        if (needSet)
         {
             keysToSet.emplace_back(key);
         }
-        else  // If exactly match, no need to sync new state to StateHash in DB 
+        else  // If exactly match, no need to sync new state to StateHash in DB
         {
             m_tempViewState.erase(key);
-        }            
+        }
     }
     // Objects that do not exist currently need to be created
     for (auto const & kfvPair : m_tempViewState)
@@ -314,7 +318,7 @@ void ProducerStateTable::apply_temp_view()
     for (auto const & kfvPair : m_tempViewState)
     {
         const string& key = kfvPair.first;
-        const TableMap& fieldValueMap = kfvPair.second; 
+        const TableMap& fieldValueMap = kfvPair.second;
         args.emplace_back(getStateHashPrefix() + getKeyName(key));
         argvs.emplace_back(to_string(fieldValueMap.size()));
         for (auto const& fvPair : fieldValueMap)

--- a/common/producerstatetable.cpp
+++ b/common/producerstatetable.cpp
@@ -27,12 +27,14 @@ ProducerStateTable::ProducerStateTable(RedisPipeline *pipeline, const string &ta
     , m_tempViewActive(false)
     , m_pipe(pipeline)
 {
+    // num in luaSet and luaDel means number of elements that were added to the key set,
+    // not including all the elements already present into the set.
     string luaSet =
         "local num = redis.call('SADD', KEYS[2], ARGV[2])\n"
         "for i = 0, #KEYS - 3 do\n"
         "    redis.call('HSET', KEYS[3 + i], ARGV[3 + i * 2], ARGV[4 + i * 2])\n"
         "end\n"
-        " if num == 1 then \n"
+        " if num > 0 then \n"
         "    redis.call('PUBLISH', KEYS[1], ARGV[1])\n"
         "end\n";
     m_shaSet = m_pipe->loadRedisScript(luaSet);
@@ -41,7 +43,7 @@ ProducerStateTable::ProducerStateTable(RedisPipeline *pipeline, const string &ta
         "local num = redis.call('SADD', KEYS[2], ARGV[2])\n"
         "redis.call('SADD', KEYS[4], ARGV[2])\n"
         "redis.call('DEL', KEYS[3])\n"
-        "if num == 1 then \n"
+        "if num > 0 then \n"
         "    redis.call('PUBLISH', KEYS[1], ARGV[1])\n"
         "end\n";
     m_shaDel = m_pipe->loadRedisScript(luaDel);

--- a/tests/redis_state_ut.cpp
+++ b/tests/redis_state_ut.cpp
@@ -480,6 +480,7 @@ TEST(ConsumerStateTable, set_pop_del_set_pop_get)
      * Third pop operation, consumer received two consectuive signals.
      * data depleted upon first one
      */
+    /*
     {
         int ret = cs.select(&selectcs, 1000);
         EXPECT_EQ(ret, Select::OBJECT);
@@ -487,6 +488,14 @@ TEST(ConsumerStateTable, set_pop_del_set_pop_get)
         c.pop(kco);
         EXPECT_EQ(kfvKey(kco), "");
     }
+    */
+
+    /*
+     * With the optimization in ProducerStateTable set/del operation,
+     * if there is pending operations on the same key, producer won't publish
+     * redundant notification again.
+     * So the check above was commented out.
+     */
 
     /* Third select operation */
     {
@@ -506,7 +515,7 @@ TEST(ConsumerStateTable, view_switch)
 {
     clearDB();
 
-    // Prepare producer 
+    // Prepare producer
     int index = 0;
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
     DBConnector db(TEST_DB, "localhost", 6379, 0);
@@ -603,7 +612,7 @@ TEST(ConsumerStateTable, view_switch)
     RedisReply r2(&db, cmdDelCount, REDIS_REPLY_INTEGER);
     EXPECT_EQ(r2.getReply<long long int>(), (long long int) numOfKeys);
 
-    // When there is more field. objects does not need to be deleted 
+    // When there is more field. objects does not need to be deleted
     clearDB();
     maxNumOfFieldsNew = 3;
     p.create_temp_view();
@@ -634,7 +643,7 @@ TEST(ConsumerStateTable, view_switch_abnormal_sequence)
 {
     clearDB();
 
-    // Prepare producer 
+    // Prepare producer
     int index = 0;
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
     DBConnector db(TEST_DB, "localhost", 6379, 0);
@@ -688,7 +697,7 @@ TEST(ConsumerStateTable, view_switch_with_consumer)
     int maxNumOfFields = 2;
     int maxNumOfFieldsNew = 1;
 
-    // Prepare producer 
+    // Prepare producer
     int index = 0;
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
     DBConnector db(TEST_DB, "localhost", 6379, 0);
@@ -713,7 +722,7 @@ TEST(ConsumerStateTable, view_switch_with_consumer)
     Selectable *selectcs;
     cs.addSelectable(&c);
     int ret;
-    do 
+    do
     {
         ret = cs.select(&selectcs, 1000);
         if (ret == Select::OBJECT)
@@ -724,7 +733,7 @@ TEST(ConsumerStateTable, view_switch_with_consumer)
     }
     while (ret != Select::TIMEOUT);
 
-    // State Queue should be empty 
+    // State Queue should be empty
     RedisCommand keys;
     keys.format("KEYS %s*", (c.getStateHashPrefix() + tableName).c_str());
     RedisReply r(&db, keys, REDIS_REPLY_ARRAY);
@@ -753,7 +762,7 @@ TEST(ConsumerStateTable, view_switch_with_consumer)
     }
     p.apply_temp_view();
 
-    do 
+    do
     {
         ret = cs.select(&selectcs, 1000);
         if (ret == Select::OBJECT)
@@ -764,7 +773,7 @@ TEST(ConsumerStateTable, view_switch_with_consumer)
     }
     while (ret != Select::TIMEOUT);
 
-    // State Queue should be empty 
+    // State Queue should be empty
     keys.format("KEYS %s*", (c.getStateHashPrefix() + tableName).c_str());
     RedisReply r4(&db, keys, REDIS_REPLY_ARRAY);
     EXPECT_EQ(r4.getContext()->elements, (size_t) 0);
@@ -784,7 +793,7 @@ TEST(ConsumerStateTable, view_switch_delete_with_consumer)
     int numOfKeys = 20;
     int maxNumOfFields = 2;
 
-    // Prepare producer 
+    // Prepare producer
     int index = 0;
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
     DBConnector db(TEST_DB, "localhost", 6379, 0);
@@ -809,7 +818,7 @@ TEST(ConsumerStateTable, view_switch_delete_with_consumer)
     Selectable *selectcs;
     cs.addSelectable(&c);
     int ret;
-    do 
+    do
     {
         ret = cs.select(&selectcs, 1000);
         if (ret == Select::OBJECT)
@@ -820,7 +829,7 @@ TEST(ConsumerStateTable, view_switch_delete_with_consumer)
     }
     while (ret != Select::TIMEOUT);
 
-    // State Queue should be empty 
+    // State Queue should be empty
     RedisCommand keys;
     keys.format("KEYS %s*", (c.getStateHashPrefix() + tableName).c_str());
     RedisReply r(&db, keys, REDIS_REPLY_ARRAY);
@@ -835,11 +844,11 @@ TEST(ConsumerStateTable, view_switch_delete_with_consumer)
     RedisReply r3(&db, hlen, REDIS_REPLY_INTEGER);
     EXPECT_EQ(r3.getReply<long long int>(), (long long int) maxNumOfFields);
 
-    // Apply empty temp view 
+    // Apply empty temp view
     p.create_temp_view();
     p.apply_temp_view();
 
-    do 
+    do
     {
         ret = cs.select(&selectcs, 1000);
         if (ret == Select::OBJECT)
@@ -850,7 +859,7 @@ TEST(ConsumerStateTable, view_switch_delete_with_consumer)
     }
     while (ret != Select::TIMEOUT);
 
-    // State Queue should be empty 
+    // State Queue should be empty
     keys.format("KEYS %s*", (c.getStateHashPrefix() + tableName).c_str());
     RedisReply r4(&db, keys, REDIS_REPLY_ARRAY);
     EXPECT_EQ(r4.getContext()->elements, (size_t) 0);
@@ -866,7 +875,7 @@ TEST(ConsumerStateTable, view_switch_delete_with_consumer_2)
     int numOfKeys = 20;
     int maxNumOfFields = 2;
 
-    // Prepare producer 
+    // Prepare producer
     int index = 0;
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
     DBConnector db(TEST_DB, "localhost", 6379, 0);
@@ -891,7 +900,7 @@ TEST(ConsumerStateTable, view_switch_delete_with_consumer_2)
         }
         p.set(key(i), fields);
     }
-    do 
+    do
     {
         ret = cs.select(&selectcs, 1000);
         if (ret == Select::OBJECT)
@@ -901,7 +910,7 @@ TEST(ConsumerStateTable, view_switch_delete_with_consumer_2)
         }
     }
     while (ret != Select::TIMEOUT);
-    // State Queue should be empty 
+    // State Queue should be empty
     RedisCommand keys;
     keys.format("KEYS %s*", (c.getStateHashPrefix() + tableName).c_str());
     RedisReply r6(&db, keys, REDIS_REPLY_ARRAY);
@@ -925,7 +934,7 @@ TEST(ConsumerStateTable, view_switch_delete_with_consumer_2)
     }
     p.apply_temp_view();
 
-    do 
+    do
     {
         ret = cs.select(&selectcs, 1000);
         if (ret == Select::OBJECT)
@@ -936,7 +945,7 @@ TEST(ConsumerStateTable, view_switch_delete_with_consumer_2)
     }
     while (ret != Select::TIMEOUT);
 
-    // State Queue should be empty 
+    // State Queue should be empty
     keys.format("KEYS %s*", (c.getStateHashPrefix() + tableName).c_str());
     RedisReply r7(&db, keys, REDIS_REPLY_ARRAY);
     EXPECT_EQ(r7.getContext()->elements, (size_t) 0);


### PR DESCRIPTION
… memory exaustion problem during route flapping

Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>

@zhenggen-xu  As discussed, during route flapping scenario, it is the notifications to consumer that are taking up most of the memory since orchagent  is not able to pick up the notification in time.

Here we eliminate the redundant notification publish operation if the same key is still pending in producerStateTable key set. 
