### PR TITLE
[pyext] enable types in stdint.h

### DIFF
--- a/pyext/swsscommon.i
+++ b/pyext/swsscommon.i
@@ -25,6 +25,7 @@
 %include <std_vector.i>
 %include <std_pair.i>
 %include <typemaps.i>
+%include <stdint.i>
 
 %template(FieldValuePair) std::pair<std::string, std::string>;
 %template(FieldValuePairs) std::vector<std::pair<std::string, std::string>>;


### PR DESCRIPTION
enable types in stdint.h

e.g. uint32_t

Signed-off-by: Ying Xie <ying.xie@microsoft.com>