### PR TITLE
Add multiple fields hdel support

### DIFF
--- a/common/redisclient.cpp
+++ b/common/redisclient.cpp
@@ -41,6 +41,14 @@ int64_t RedisClient::hdel(const string &key, const string &field)
     return r.getContext()->integer;
 }
 
+int64_t RedisClient::hdel(const std::string &key, const std::vector<std::string> &fields)
+{
+    RedisCommand shdel;
+    shdel.formatHDEL(key, fields);
+    RedisReply r(m_db, shdel, REDIS_REPLY_INTEGER);
+    return r.getContext()->integer;
+}
+
 void RedisClient::hset(const string &key, const string &field, const string &value)
 {
     RedisCommand shset;

--- a/common/redisclient.h
+++ b/common/redisclient.h
@@ -30,6 +30,8 @@ class RedisClient
 
         int64_t hdel(const std::string &key, const std::string &field);
 
+        int64_t hdel(const std::string &key, const std::vector<std::string> &fields);
+
         std::unordered_map<std::string, std::string> hgetall(const std::string &key);
 
         template <typename OutputIterator>

--- a/common/rediscommand.cpp
+++ b/common/rediscommand.cpp
@@ -63,6 +63,19 @@ void RedisCommand::formatHDEL(const std::string& key, const std::string& field)
     return format("HDEL %s %s", key.c_str(), field.c_str());
 }
 
+/* Format HDEL key multiple fields command */
+void RedisCommand::formatHDEL(const std::string& key, const std::vector<std::string>& fields)
+{
+    if (fields.empty()) throw std::invalid_argument("empty values");
+
+    std::vector<const char *> args = {"HDEL", key.c_str()};
+    for (const std::string &f : fields)
+    {
+        args.push_back(f.c_str());
+    }
+    formatArgv(static_cast<int>(args.size()), args.data(), NULL);
+}
+
 const char *RedisCommand::c_str() const
 {
     return temp;

--- a/common/rediscommand.h
+++ b/common/rediscommand.h
@@ -44,6 +44,9 @@ public:
     /* Format HDEL key field command */
     void formatHDEL(const std::string& key, const std::string& field);
 
+    /* Format HDEL key multiple fields command */
+    void formatHDEL(const std::string& key, const std::vector<std::string>& fields);
+
     const char *c_str() const;
 
     size_t length() const;

--- a/tests/redis_ut.cpp
+++ b/tests/redis_ut.cpp
@@ -331,13 +331,37 @@ TEST(DBConnector, RedisClient)
         cout << endl;
     }
 
-    cout << "- Step 4. DEL" << endl;
+    cout << "- Step 4. HDEL single field" << endl;
+    cout << "Delete field_2 under key [a]" << endl;
+    int64_t rval = redic.hdel(key_1, "field_2");
+    EXPECT_EQ(rval, 1);
+
+    auto fvs = redic.hgetall(key_1);
+    EXPECT_EQ(fvs.size(), 2);
+    for (auto fv: fvs)
+    {
+        string value_1 = "1", value_3 = "3";
+        cout << " " << fvField(fv) << ":" << fvValue(fv) << flush;
+        if (fvField(fv) == "field_1")
+        {
+            EXPECT_EQ(fvValue(fv), value_1);
+        }
+        if (fvField(fv) == "field_3")
+        {
+            EXPECT_EQ(fvValue(fv), value_3);
+        }
+
+        ASSERT_FALSE(fvField(fv) == "2");
+    }
+    cout << endl;
+
+    cout << "- Step 5. DEL" << endl;
     cout << "Delete key [a]" << endl;
     redic.del(key_1);
 
-    cout << "- Step 5. GET" << endl;
+    cout << "- Step 6. GET" << endl;
     cout << "Get key [a] and key [b]" << endl;
-    auto fvs = redic.hgetall(key_1);
+    fvs = redic.hgetall(key_1);
     EXPECT_TRUE(fvs.empty());
     fvs = redic.hgetall(key_2);
 
@@ -357,7 +381,28 @@ TEST(DBConnector, RedisClient)
     }
     cout << endl;
 
-    cout << "- Step 6. DEL and GET_TABLE_CONTENT" << endl;
+    cout << "- Step 7. HDEL multiple fields" << endl;
+    cout << "Delete field_2, field_3 under key [b]" << endl;
+    rval = redic.hdel(key_2, vector<string>({"field_2", "field_3"}));
+    EXPECT_EQ(rval, 2);
+
+    fvs = redic.hgetall(key_2);
+    EXPECT_EQ(fvs.size(), 1);
+    for (auto fv: fvs)
+    {
+        string value_1 = "1";
+        cout << " " << fvField(fv) << ":" << fvValue(fv) << flush;
+        if (fvField(fv) == "field_1")
+        {
+            EXPECT_EQ(fvValue(fv), value_1);
+        }
+
+        ASSERT_FALSE(fvField(fv) == "field_2");
+        ASSERT_FALSE(fvField(fv) == "field_3");
+    }
+    cout << endl;
+
+    cout << "- Step 8. DEL and GET_TABLE_CONTENT" << endl;
     cout << "Delete key [b]" << endl;
     redic.del(key_2);
     fvs = redic.hgetall(key_2);


### PR DESCRIPTION
Add multiple fields hdel support

$ ./tests/tests --gtest_filter=DBConnector.RedisClient      
Running main() from gtest_main.cc
Note: Google Test filter = DBConnector.RedisClient
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from DBConnector
[ RUN      ] DBConnector.RedisClient
Starting table manipulations
- Step 1. SET
Set key [a] field_1:1 field_2:2 field_3:3
Set key [b] field_1:1 field_2:2 field_3:3
- Step 2. GET_TABLE_KEYS
Get key [b]Get key [a]- Step 3. GET_TABLE_CONTENT
Get key [b] field_3:3 field_2:2 field_1:1
Get key [a] field_3:3 field_2:2 field_1:1
- Step 4. HDEL single field
Delete field_2 under key [a]
 field_3:3 field_1:1
- Step 5. DEL
Delete key [a]
- Step 6. GET
Get key [a] and key [b]
Get key [b] field_3:3 field_2:2 field_1:1
- Step 7. HDEL multiple fields
Delete field_2, field_3 under key [b]
 field_1:1
- Step 8. DEL and GET_TABLE_CONTENT
Delete key [b]
Done.
[       OK ] DBConnector.RedisClient (15 ms)
[----------] 1 test from DBConnector (15 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (15 ms total)
[  PASSED  ] 1 test.

Signed-off-by: Wenda Ni <wenni@microsoft.com>