### PR TITLE
Add BGP_STATE_TABLE in stateDB

### DIFF
--- a/common/schema.h
+++ b/common/schema.h
@@ -198,6 +198,7 @@ namespace swss {
 #define STATE_MIRROR_SESSION_TABLE_NAME             "MIRROR_SESSION_TABLE"
 #define STATE_VXLAN_TABLE_NAME                      "VXLAN_TABLE"
 #define STATE_MIRROR_SESSION_TABLE_NAME             "MIRROR_SESSION_TABLE"
+#define STATE_BGP_TABLE_NAME                        "BGP_STATE_TABLE"
 
 /***** MISC *****/
 


### PR DESCRIPTION
Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>


Add BGP_STATE_TABLE in stateDB for storing BGP related states.

Three PRs for adding BGP eoiu support to speed up route reconciliation in fpmsyncd

sonic-buildimage:  https://github.com/Azure/sonic-buildimage/pull/2823
sonic-swss-common: https://github.com/Azure/sonic-swss-common/pull/273
sonic-swss:  https://github.com/Azure/sonic-swss/pull/856