### PR TITLE
Add an assert to logger, which will log a message and abort.

### DIFF
--- a/common/logger.cpp
+++ b/common/logger.cpp
@@ -17,6 +17,22 @@
 
 namespace swss {
 
+void
+err_exit(const char *fn, int ln, int e, const char *fmt, ...)
+{
+    va_list ap;
+    char buff[1024];
+    size_t len;
+
+    va_start(ap, fmt);
+    snprintf(buff, sizeof(buff), "%s::%d err(%d/%s): ", fn, ln, e, strerror(e));
+    len = strlen(buff);
+    vsnprintf(buff+len, sizeof(buff)-len, fmt, ap);
+    va_end(ap);
+    SWSS_LOG_ERROR("Aborting: %s", buff);
+    abort();
+}
+
 Logger::~Logger() {
     if (m_settingThread) {
         m_settingThread->detach();

--- a/common/logger.cpp
+++ b/common/logger.cpp
@@ -17,8 +17,7 @@
 
 namespace swss {
 
-void
-err_exit(const char *fn, int ln, int e, const char *fmt, ...)
+void err_exit(const char *fn, int ln, int e, const char *fmt, ...)
 {
     va_list ap;
     char buff[1024];

--- a/common/logger.h
+++ b/common/logger.h
@@ -31,7 +31,7 @@ void err_exit(const char *fn, int ln, int e, const char *fmt, ...)
         ;
 
 
-#define ASSERT(x, fmt, args...)                             \
+#define ABORT_IF_NOT(x, fmt, args...)                      \
     if (!(x)) {                                             \
         int e = errno;                                      \
         err_exit(__FUNCTION__, __LINE__, e, (fmt), ##args); \

--- a/common/logger.h
+++ b/common/logger.h
@@ -23,6 +23,21 @@ namespace swss {
 
 #define SWSS_LOG_THROW(MSG, ...)       swss::Logger::getInstance().wthrow(swss::Logger::SWSS_ERROR,  ":- %s: " MSG, __FUNCTION__, ##__VA_ARGS__)
 
+extern void err_exit(const char *fn, int ln, int e, const char *fmt, ...)
+#ifdef __GNUC__
+        __attribute__ ((format (printf, 4, 5)))
+        __attribute__ ((noreturn))
+#endif
+        ;
+
+
+#define ASSERT(x, fmt, args...)                             \
+    if (!(x)) {                                             \
+        int _e = errno;                                     \
+        err_exit(__FUNCTION__, __LINE__, _e, fmt, ##args);  \
+    }
+
+
 class Logger
 {
 public:

--- a/common/logger.h
+++ b/common/logger.h
@@ -23,7 +23,7 @@ namespace swss {
 
 #define SWSS_LOG_THROW(MSG, ...)       swss::Logger::getInstance().wthrow(swss::Logger::SWSS_ERROR,  ":- %s: " MSG, __FUNCTION__, ##__VA_ARGS__)
 
-extern void err_exit(const char *fn, int ln, int e, const char *fmt, ...)
+void err_exit(const char *fn, int ln, int e, const char *fmt, ...)
 #ifdef __GNUC__
         __attribute__ ((format (printf, 4, 5)))
         __attribute__ ((noreturn))
@@ -33,8 +33,8 @@ extern void err_exit(const char *fn, int ln, int e, const char *fmt, ...)
 
 #define ASSERT(x, fmt, args...)                             \
     if (!(x)) {                                             \
-        int _e = errno;                                     \
-        err_exit(__FUNCTION__, __LINE__, _e, fmt, ##args);  \
+        int e = errno;                                      \
+        err_exit(__FUNCTION__, __LINE__, e, (fmt), ##args); \
     }
 
 

--- a/common/selectabletimer.cpp
+++ b/common/selectabletimer.cpp
@@ -77,20 +77,16 @@ void SelectableTimer::readData()
     uint64_t r;
 
     ssize_t s;
+    errno = 0;
     do
     {
-        // Read the timefd so it will be reset
         s = read(m_tfd, &r, sizeof(uint64_t));
     }
     while(s == -1 && errno == EINTR);
 
-    if (s != sizeof(uint64_t))
-    {
-        SWSS_LOG_THROW("SelectableTimer read failed, s:%zd errno: %s",
-                s, strerror(errno));
-    }
-}
+    ASSERT(s == sizeof(uint64_t), "Failed to read timerfd. s=%ld", s)
 
-// FIXME: if timer events are read slower than timer frequency we will lost time events
+    // s = count of timer events happened since last read.
+}
 
 }

--- a/common/selectabletimer.cpp
+++ b/common/selectabletimer.cpp
@@ -74,7 +74,7 @@ int SelectableTimer::getFd()
 
 void SelectableTimer::readData()
 {
-    uint64_t r;
+    uint64_t r = UINTPTR_MAX;
 
     ssize_t s;
     errno = 0;

--- a/common/selectabletimer.cpp
+++ b/common/selectabletimer.cpp
@@ -74,7 +74,7 @@ int SelectableTimer::getFd()
 
 void SelectableTimer::readData()
 {
-    uint64_t r = UINTPTR_MAX;
+    uint64_t r = UINT64_MAX;
 
     ssize_t s;
     errno = 0;

--- a/common/selectabletimer.cpp
+++ b/common/selectabletimer.cpp
@@ -86,7 +86,7 @@ void SelectableTimer::readData()
 
     ASSERT(s == sizeof(uint64_t), "Failed to read timerfd. s=%ld", s)
 
-    // s = count of timer events happened since last read.
+    // r = count of timer events happened since last read.
 }
 
 }

--- a/common/selectabletimer.cpp
+++ b/common/selectabletimer.cpp
@@ -84,7 +84,7 @@ void SelectableTimer::readData()
     }
     while(s == -1 && errno == EINTR);
 
-    ASSERT(s == sizeof(uint64_t), "Failed to read timerfd. s=%ld", s)
+    ABORT_IF_NOT(s == sizeof(uint64_t), "Failed to read timerfd. s=%ld", s)
 
     // r = count of timer events happened since last read.
 }


### PR DESCRIPTION
Upon failure to read timer_fd, do an assert instead of throw.
This way, the core can be obtained at the point of failure, instead of silent process termination.