### PR TITLE
Add an assert to logger, which will log a message and abort. (#286)

### DIFF
--- a/common/logger.cpp
+++ b/common/logger.cpp
@@ -17,6 +17,21 @@
 
 namespace swss {
 
+void err_exit(const char *fn, int ln, int e, const char *fmt, ...)
+{
+    va_list ap;
+    char buff[1024];
+    size_t len;
+
+    va_start(ap, fmt);
+    snprintf(buff, sizeof(buff), "%s::%d err(%d/%s): ", fn, ln, e, strerror(e));
+    len = strlen(buff);
+    vsnprintf(buff+len, sizeof(buff)-len, fmt, ap);
+    va_end(ap);
+    SWSS_LOG_ERROR("Aborting: %s", buff);
+    abort();
+}
+
 Logger::~Logger() {
     if (m_settingThread) {
         m_settingThread->detach();

--- a/common/logger.h
+++ b/common/logger.h
@@ -23,6 +23,21 @@ namespace swss {
 
 #define SWSS_LOG_THROW(MSG, ...)       swss::Logger::getInstance().wthrow(swss::Logger::SWSS_ERROR,  ":- %s: " MSG, __FUNCTION__, ##__VA_ARGS__)
 
+void err_exit(const char *fn, int ln, int e, const char *fmt, ...)
+#ifdef __GNUC__
+        __attribute__ ((format (printf, 4, 5)))
+        __attribute__ ((noreturn))
+#endif
+        ;
+
+
+#define ABORT_IF_NOT(x, fmt, args...)                      \
+    if (!(x)) {                                             \
+        int e = errno;                                      \
+        err_exit(__FUNCTION__, __LINE__, e, (fmt), ##args); \
+    }
+
+
 class Logger
 {
 public:

--- a/common/selectabletimer.cpp
+++ b/common/selectabletimer.cpp
@@ -15,7 +15,7 @@ SelectableTimer::SelectableTimer(const timespec& interval, int pri)
     : Selectable(pri), m_zero({{0, 0}, {0, 0}})
 {
     // Create the timer
-    m_tfd = timerfd_create(CLOCK_REALTIME, 0);
+    m_tfd = timerfd_create(CLOCK_MONOTONIC, 0);
     if (m_tfd == -1)
     {
         SWSS_LOG_THROW("failed to create timerfd, errno: %s", strerror(errno));
@@ -84,7 +84,28 @@ void SelectableTimer::readData()
     }
     while(s == -1 && errno == EINTR);
 
-    ABORT_IF_NOT(s == sizeof(uint64_t), "Failed to read timerfd. s=%ld", s)
+    /*
+     * By right or most likely s = 8 here.
+     * Else in failure case, s = -1 with errno != 0, b
+     * But due to a (HW influenced) Kernel bug, it could be s=0 & errno=0
+     *
+     * This bug has been observed in S6100 only.
+     * The bug incidence is pretty seldom.
+     *
+     * A short note on kernel bug:
+     *  timerfd_read, upon asserting that underlying hrtimer has triggered once,
+     *  calls hrtimer_forward_now, to get total count of expiries since timer start
+     *  to now, as read gets called asynchronously at a time later than the time
+     *  point of trigger.
+     *  The hrtimer_forward_now is expected to return >= 1, as it is certain
+     *  that one trigger/expiry is confirmed to have occurred.
+     *  But in the buggy case, the hrtimer_forward_now returned 0, that results
+     *  in read call to return 0.
+     *  
+     *  The behavior of read returning 0, with errno=0 is an unexpected behavior.
+     */
+    ABORT_IF_NOT((s == sizeof(uint64_t)) || ((s == 0) && (errno == 0)),
+            "Failed to read timerfd. s=%ld", s)
 
     // r = count of timer events happened since last read.
 }

--- a/common/selectabletimer.cpp
+++ b/common/selectabletimer.cpp
@@ -74,22 +74,19 @@ int SelectableTimer::getFd()
 
 void SelectableTimer::readData()
 {
-    uint64_t r;
+    uint64_t r = UINT64_MAX;
 
     ssize_t s;
+    errno = 0;
     do
     {
-        // Read the timefd so it will be reset
         s = read(m_tfd, &r, sizeof(uint64_t));
     }
     while(s == -1 && errno == EINTR);
 
-    if (s != sizeof(uint64_t))
-    {
-        SWSS_LOG_THROW("read failed, errno: %s", strerror(errno));
-    }
-}
+    ABORT_IF_NOT(s == sizeof(uint64_t), "Failed to read timerfd. s=%ld", s)
 
-// FIXME: if timer events are read slower than timer frequency we will lost time events
+    // r = count of timer events happened since last read.
+}
 
 }


### PR DESCRIPTION
* Add an assert to logger, which will log a message and abort.
Upon failure to read timer_fd, do an assert instead of throw.
This way, the core can be obtained at the point of failure, instead of silent process termination.

* Comments corrected per review comments.

* Changes per comments; No logical code changes.

* s/ASSERT/ABORT_IF_NOT/ per review comments.

* Initialize counter, so when we fail and get core, we could assess, if it was written to or not.

* Made it better per review comments. No logical change in code.