### PR TITLE
Add an assert to logger, which will log a message and abort. (#286)

### DIFF
--- a/common/logger.cpp
+++ b/common/logger.cpp
@@ -17,6 +17,21 @@
 
 namespace swss {
 
+void err_exit(const char *fn, int ln, int e, const char *fmt, ...)
+{
+    va_list ap;
+    char buff[1024];
+    size_t len;
+
+    va_start(ap, fmt);
+    snprintf(buff, sizeof(buff), "%s::%d err(%d/%s): ", fn, ln, e, strerror(e));
+    len = strlen(buff);
+    vsnprintf(buff+len, sizeof(buff)-len, fmt, ap);
+    va_end(ap);
+    SWSS_LOG_ERROR("Aborting: %s", buff);
+    abort();
+}
+
 Logger::~Logger() {
     if (m_settingThread) {
         m_settingThread->detach();

--- a/common/logger.h
+++ b/common/logger.h
@@ -23,6 +23,21 @@ namespace swss {
 
 #define SWSS_LOG_THROW(MSG, ...)       swss::Logger::getInstance().wthrow(swss::Logger::SWSS_ERROR,  ":- %s: " MSG, __FUNCTION__, ##__VA_ARGS__)
 
+void err_exit(const char *fn, int ln, int e, const char *fmt, ...)
+#ifdef __GNUC__
+        __attribute__ ((format (printf, 4, 5)))
+        __attribute__ ((noreturn))
+#endif
+        ;
+
+
+#define ABORT_IF_NOT(x, fmt, args...)                      \
+    if (!(x)) {                                             \
+        int e = errno;                                      \
+        err_exit(__FUNCTION__, __LINE__, e, (fmt), ##args); \
+    }
+
+
 class Logger
 {
 public:

--- a/common/selectabletimer.cpp
+++ b/common/selectabletimer.cpp
@@ -74,23 +74,19 @@ int SelectableTimer::getFd()
 
 void SelectableTimer::readData()
 {
-    uint64_t r;
+    uint64_t r = UINT64_MAX;
 
     ssize_t s;
+    errno = 0;
     do
     {
-        // Read the timefd so it will be reset
         s = read(m_tfd, &r, sizeof(uint64_t));
     }
     while(s == -1 && errno == EINTR);
 
-    if (s != sizeof(uint64_t))
-    {
-        SWSS_LOG_THROW("SelectableTimer read failed, s:%zd errno: %s",
-                s, strerror(errno));
-    }
-}
+    ABORT_IF_NOT(s == sizeof(uint64_t), "Failed to read timerfd. s=%ld", s)
 
-// FIXME: if timer events are read slower than timer frequency we will lost time events
+    // r = count of timer events happened since last read.
+}
 
 }


### PR DESCRIPTION
* Add an assert to logger, which will log a message and abort.
Upon failure to read timer_fd, do an assert instead of throw.
This way, the core can be obtained at the point of failure, instead of silent process termination.

* Comments corrected per review comments.

* Changes per comments; No logical code changes.

* s/ASSERT/ABORT_IF_NOT/ per review comments.

* Initialize counter, so when we fail and get core, we could assess, if it was written to or not.

* Made it better per review comments. No logical change in code.