### PR TITLE
fix bug that Executor does not get correct priority saved in m_select…

### DIFF
--- a/common/selectable.h
+++ b/common/selectable.h
@@ -53,7 +53,7 @@ public:
     {
     }
 
-    int getPri() const
+    virtual int getPri() const
     {
         return m_priority;
     }


### PR DESCRIPTION
1、What I did
changes in sonic-swss-common: make member function `Select::getPri() `to be virtual
changes in sonic-swss: override `getPri()` in class Executor to return priority of m_selectables

2、Why I do it
`Select:cmp` using priority got by function `getPri()` to sort order of event. But class Select's member function `getPri() `is not virtual，so that class Executor can't not override getPri()  to return priority saved in m_selectable. Class Executor  is just a container of pointer m_selectable with type `Select *`.  We should  get priority saved in m_selectable rather than 0, which is default structed by Executor's base class Select.  Thinking of below situation ,  pointer `Select * s` point to object of type Executor,` s -> getPri()` will always return priority of 0

3、How I verify it 
Debug & Test， show priority of Executor Object