### PR TITLE
do not abort when read timerfd return 0 and errno = 0

### DIFF
--- a/common/selectabletimer.cpp
+++ b/common/selectabletimer.cpp
@@ -15,7 +15,7 @@ SelectableTimer::SelectableTimer(const timespec& interval, int pri)
     : Selectable(pri), m_zero({{0, 0}, {0, 0}})
 {
     // Create the timer
-    m_tfd = timerfd_create(CLOCK_REALTIME, 0);
+    m_tfd = timerfd_create(CLOCK_MONOTONIC, 0);
     if (m_tfd == -1)
     {
         SWSS_LOG_THROW("failed to create timerfd, errno: %s", strerror(errno));
@@ -84,7 +84,28 @@ void SelectableTimer::readData()
     }
     while(s == -1 && errno == EINTR);
 
-    ABORT_IF_NOT(s == sizeof(uint64_t), "Failed to read timerfd. s=%ld", s)
+    /*
+     * By right or most likely s = 8 here.
+     * Else in failure case, s = -1 with errno != 0, b
+     * But due to a (HW influenced) Kernel bug, it could be s=0 & errno=0
+     *
+     * This bug has been observed in S6100 only.
+     * The bug incidence is pretty seldom.
+     *
+     * A short note on kernel bug:
+     *  timerfd_read, upon asserting that underlying hrtimer has triggered once,
+     *  calls hrtimer_forward_now, to get total count of expiries since timer start
+     *  to now, as read gets called asynchronously at a time later than the time
+     *  point of trigger.
+     *  The hrtimer_forward_now is expected to return >= 1, as it is certain
+     *  that one trigger/expiry is confirmed to have occurred.
+     *  But in the buggy case, the hrtimer_forward_now returned 0, that results
+     *  in read call to return 0.
+     *  
+     *  The behavior of read returning 0, with errno=0 is an unexpected behavior.
+     */
+    ABORT_IF_NOT((s == sizeof(uint64_t)) || ((s == 0) && (errno == 0)),
+            "Failed to read timerfd. s=%ld", s)
 
     // r = count of timer events happened since last read.
 }


### PR DESCRIPTION
Work around a kernel bug, where read(timerfd, ...) return code can be 0,
with errno = 0 as proper timer expiry.

Current code, though set it as CLOCK_REALTIME, since we set relative timestamp
for initial expiry & interval, the kernel handles it as MONOTONIC.
So this fix, does not affect any functionality, but just makes it explicit.

