### PR TITLE
timerfd:read failure - Record in logs as error.

### DIFF
--- a/common/selectabletimer.cpp
+++ b/common/selectabletimer.cpp
@@ -107,6 +107,11 @@ void SelectableTimer::readData()
     ABORT_IF_NOT((s == sizeof(uint64_t)) || ((s == 0) && (errno == 0)),
             "Failed to read timerfd. s=%ld", s)
 
+    if (s != sizeof(uint64_t)) {
+        SWSS_LOG_ERROR("Benign failure to read from timerfd return=%d error=%s",
+                s, strerror(errno));
+    }
+
     // r = count of timer events happened since last read.
 }
 

--- a/common/selectabletimer.cpp
+++ b/common/selectabletimer.cpp
@@ -108,8 +108,7 @@ void SelectableTimer::readData()
             "Failed to read timerfd. s=%ld", s)
 
     if (s != sizeof(uint64_t)) {
-        SWSS_LOG_ERROR("Benign failure to read from timerfd return=%zd error=%s",
-                s, strerror(errno));
+        SWSS_LOG_ERROR("Benign failure to read from timerfd return=%zd Expect: 8", s);
     }
 
     // r = count of timer events happened since last read.

--- a/common/selectabletimer.cpp
+++ b/common/selectabletimer.cpp
@@ -108,7 +108,7 @@ void SelectableTimer::readData()
             "Failed to read timerfd. s=%ld", s)
 
     if (s != sizeof(uint64_t)) {
-        SWSS_LOG_ERROR("Benign failure to read from timerfd return=%zd Expect: %d",
+        SWSS_LOG_ERROR("Benign failure to read from timerfd return=%zd Expect: %zd",
                     s, sizeof(uint64_t));
     }
 

--- a/common/selectabletimer.cpp
+++ b/common/selectabletimer.cpp
@@ -86,7 +86,7 @@ void SelectableTimer::readData()
 
     /*
      * By right or most likely s = 8 here.
-     * Else in failure case, s = -1 with errno != 0, b
+     * Else in failure case, s = -1 with errno != 0
      * But due to a (HW influenced) Kernel bug, it could be s=0 & errno=0
      *
      * This bug has been observed in S6100 only.
@@ -104,8 +104,8 @@ void SelectableTimer::readData()
      *  
      *  The behavior of read returning 0, with errno=0 is an unexpected behavior.
      */
-    ABORT_IF_NOT((s == sizeof(uint64_t)) || ((s == 0) && (errno == 0)),
-            "Failed to read timerfd. s=%ld", s)
+    ABORT_IF_NOT((s == sizeof(uint64_t)) || (s == 0),
+            "Failed to read timerfd. s=%ld", s);
 
     if (s != sizeof(uint64_t)) {
         SWSS_LOG_ERROR("Benign failure to read from timerfd return=%zd Expect: %zd",

--- a/common/selectabletimer.cpp
+++ b/common/selectabletimer.cpp
@@ -108,7 +108,7 @@ void SelectableTimer::readData()
             "Failed to read timerfd. s=%ld", s)
 
     if (s != sizeof(uint64_t)) {
-        SWSS_LOG_ERROR("Benign failure to read from timerfd return=%d error=%s",
+        SWSS_LOG_ERROR("Benign failure to read from timerfd return=%zd error=%s",
                 s, strerror(errno));
     }
 

--- a/common/selectabletimer.cpp
+++ b/common/selectabletimer.cpp
@@ -108,7 +108,8 @@ void SelectableTimer::readData()
             "Failed to read timerfd. s=%ld", s)
 
     if (s != sizeof(uint64_t)) {
-        SWSS_LOG_ERROR("Benign failure to read from timerfd return=%zd Expect: 8", s);
+        SWSS_LOG_ERROR("Benign failure to read from timerfd return=%zd Expect: %d",
+                    s, sizeof(uint64_t));
     }
 
     // r = count of timer events happened since last read.

--- a/common/selectabletimer.cpp
+++ b/common/selectabletimer.cpp
@@ -84,32 +84,31 @@ void SelectableTimer::readData()
     }
     while(s == -1 && errno == EINTR);
 
-    /*
-     * By right or most likely s = 8 here.
-     * Else in failure case, s = -1 with errno != 0
-     * But due to a (HW influenced) Kernel bug, it could be s=0 & errno=0
-     *
-     * This bug has been observed in S6100 only.
-     * The bug incidence is pretty seldom.
-     *
-     * A short note on kernel bug:
-     *  timerfd_read, upon asserting that underlying hrtimer has triggered once,
-     *  calls hrtimer_forward_now, to get total count of expiries since timer start
-     *  to now, as read gets called asynchronously at a time later than the time
-     *  point of trigger.
-     *  The hrtimer_forward_now is expected to return >= 1, as it is certain
-     *  that one trigger/expiry is confirmed to have occurred.
-     *  But in the buggy case, the hrtimer_forward_now returned 0, that results
-     *  in read call to return 0.
-     *  
-     *  The behavior of read returning 0, with errno=0 is an unexpected behavior.
-     */
-    ABORT_IF_NOT((s == sizeof(uint64_t)) || (s == 0),
-            "Failed to read timerfd. s=%ld", s);
-
     if (s != sizeof(uint64_t)) {
+        /*
+         * By right or most likely s = 8 here.
+         * Else in failure case, s = -1 with errno != 0
+         * But due to a (HW influenced) Kernel bug, it could be s=0 & errno=0
+         *
+         * This bug has been observed in S6100 only.
+         * The bug incidence is pretty seldom.
+         *
+         * A short note on kernel bug:
+         *  timerfd_read, upon asserting that underlying hrtimer has triggered once,
+         *  calls hrtimer_forward_now, to get total count of expiries since timer start
+         *  to now, as read gets called asynchronously at a time later than the time
+         *  point of trigger.
+         *  The hrtimer_forward_now is expected to return >= 1, as it is certain
+         *  that one trigger/expiry is confirmed to have occurred.
+         *  But in the buggy case, the hrtimer_forward_now returned 0, that results
+         *  in read call to return 0.
+         *  
+         *  The behavior of read returning 0, with errno=0 is an unexpected behavior.
+         */
+        ABORT_IF_NOT(s == 0, "Failed to read timerfd. s=%ld", s);
+
         SWSS_LOG_ERROR("Benign failure to read from timerfd return=%zd Expect: %zd",
-                    s, sizeof(uint64_t));
+                        s, sizeof(uint64_t));
     }
 
     // r = count of timer events happened since last read.


### PR DESCRIPTION
The return value of 0, with errno=0 is treated as benign, as this appears to be a Hardware related kernel bug.
NOTE: This bug is found to occur in S6100 platforms only.