### PR TITLE
multi-DB Part 2: C++ interface API changes / swsscommon unit test / LOGLEVEL_DB apply new API

### DIFF
--- a/common/consumerstatetable.cpp
+++ b/common/consumerstatetable.cpp
@@ -15,6 +15,10 @@ ConsumerStateTable::ConsumerStateTable(DBConnector *db, const std::string &table
     : ConsumerTableBase(db, tableName, popBatchSize, pri)
     , TableName_KeySet(tableName)
 {
+
+    std::string m_luaScript = loadLuaScript("consumer_state_table_pops.lua");
+    m_sha = loadRedisScript(db, m_luaScript);
+
     for (;;)
     {
         RedisReply watch(m_db, "WATCH " + getKeySetName(), REDIS_REPLY_STATUS);
@@ -32,14 +36,11 @@ ConsumerStateTable::ConsumerStateTable(DBConnector *db, const std::string &table
 
 void ConsumerStateTable::pops(std::deque<KeyOpFieldsValuesTuple> &vkco, const std::string& /*prefix*/)
 {
-    static std::string luaScript = loadLuaScript("consumer_state_table_pops.lua");
-
-    static std::string sha = loadRedisScript(m_db, luaScript);
 
     RedisCommand command;
     command.format(
         "EVALSHA %s 3 %s %s: %s %d %s",
-        sha.c_str(),
+        m_sha.c_str(),
         getKeySetName().c_str(),
         getTableName().c_str(),
         getDelKeySetName().c_str(),

--- a/common/consumerstatetable.cpp
+++ b/common/consumerstatetable.cpp
@@ -15,9 +15,8 @@ ConsumerStateTable::ConsumerStateTable(DBConnector *db, const std::string &table
     : ConsumerTableBase(db, tableName, popBatchSize, pri)
     , TableName_KeySet(tableName)
 {
-
-    std::string m_luaScript = loadLuaScript("consumer_state_table_pops.lua");
-    m_sha = loadRedisScript(db, m_luaScript);
+    std::string luaScript = loadLuaScript("consumer_state_table_pops.lua");
+    m_shaPop = loadRedisScript(db, luaScript);
 
     for (;;)
     {
@@ -40,7 +39,7 @@ void ConsumerStateTable::pops(std::deque<KeyOpFieldsValuesTuple> &vkco, const st
     RedisCommand command;
     command.format(
         "EVALSHA %s 3 %s %s: %s %d %s",
-        m_sha.c_str(),
+        m_shaPop.c_str(),
         getKeySetName().c_str(),
         getTableName().c_str(),
         getDelKeySetName().c_str(),

--- a/common/consumerstatetable.h
+++ b/common/consumerstatetable.h
@@ -14,6 +14,9 @@ public:
 
     /* Get multiple pop elements */
     void pops(std::deque<KeyOpFieldsValuesTuple> &vkco, const std::string &prefix = EMPTY_PREFIX);
+
+private:
+    std::string m_sha;
 };
 
 }

--- a/common/consumerstatetable.h
+++ b/common/consumerstatetable.h
@@ -16,7 +16,7 @@ public:
     void pops(std::deque<KeyOpFieldsValuesTuple> &vkco, const std::string &prefix = EMPTY_PREFIX);
 
 private:
-    std::string m_sha;
+    std::string m_shaPop;
 };
 
 }

--- a/common/consumertable.cpp
+++ b/common/consumertable.cpp
@@ -18,8 +18,8 @@ ConsumerTable::ConsumerTable(DBConnector *db, const string &tableName, int popBa
     : ConsumerTableBase(db, tableName, popBatchSize, pri)
     , TableName_KeyValueOpQueues(tableName)
 {
-    std::string m_luaScript = loadLuaScript("consumer_table_pops.lua");
-    m_sha = loadRedisScript(db, m_luaScript);
+    std::string luaScript = loadLuaScript("consumer_table_pops.lua");
+    m_shaPop = loadRedisScript(db, luaScript);
 
     for (;;)
     {
@@ -44,7 +44,7 @@ void ConsumerTable::pops(deque<KeyOpFieldsValuesTuple> &vkco, const string &pref
     RedisCommand command;
     command.format(
         "EVALSHA %s 2 %s %s %d ''",
-        m_sha.c_str(),
+        m_shaPop.c_str(),
         getKeyValueOpQueueTableName().c_str(),
         (prefix+getTableName()).c_str(),
         POP_BATCH_SIZE);

--- a/common/consumertable.cpp
+++ b/common/consumertable.cpp
@@ -18,6 +18,9 @@ ConsumerTable::ConsumerTable(DBConnector *db, const string &tableName, int popBa
     : ConsumerTableBase(db, tableName, popBatchSize, pri)
     , TableName_KeyValueOpQueues(tableName)
 {
+    std::string m_luaScript = loadLuaScript("consumer_table_pops.lua");
+    m_sha = loadRedisScript(db, m_luaScript);
+
     for (;;)
     {
         RedisReply watch(m_db, string("WATCH ") + getKeyValueOpQueueTableName(), REDIS_REPLY_STATUS);
@@ -38,13 +41,10 @@ ConsumerTable::ConsumerTable(DBConnector *db, const string &tableName, int popBa
 
 void ConsumerTable::pops(deque<KeyOpFieldsValuesTuple> &vkco, const string &prefix)
 {
-    static std::string luaScript = loadLuaScript("consumer_table_pops.lua");
-
-    static string sha = loadRedisScript(m_db, luaScript);
     RedisCommand command;
     command.format(
         "EVALSHA %s 2 %s %s %d ''",
-        sha.c_str(),
+        m_sha.c_str(),
         getKeyValueOpQueueTableName().c_str(),
         (prefix+getTableName()).c_str(),
         POP_BATCH_SIZE);

--- a/common/consumertable.h
+++ b/common/consumertable.h
@@ -19,7 +19,7 @@ public:
     void pops(std::deque<KeyOpFieldsValuesTuple> &vkco, const std::string &prefix = EMPTY_PREFIX);
 
 private:
-    std::string m_sha;
+    std::string m_shaPop;
 };
 
 }

--- a/common/consumertable.h
+++ b/common/consumertable.h
@@ -17,6 +17,9 @@ public:
 
     /* Get multiple pop elements */
     void pops(std::deque<KeyOpFieldsValuesTuple> &vkco, const std::string &prefix = EMPTY_PREFIX);
+
+private:
+    std::string m_sha;
 };
 
 }

--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -4,13 +4,45 @@
 #include <unistd.h>
 #include <errno.h>
 #include <system_error>
+#include <fstream>
+#include "json.hpp"
+#include "schema.h"
 
 #include "common/dbconnector.h"
 #include "common/redisreply.h"
 
+using json = nlohmann::json;
 using namespace std;
 
 namespace swss {
+
+bool RedisConfig::parseRedisDBConfig(string file) {
+
+    ifstream i(file);
+    if (i.good()) {
+        json j;
+        i >> j;
+        for(auto it = j["INSTANCES"].begin(); it!= j["INSTANCES"].end(); it++) {
+           string instName = it.key();
+           string sockPath = it.value().at("socket");
+           int port = it.value().at("port");
+           m_redis_info[instName] = {sockPath, port};
+        }
+
+        for(auto it = j["DATABASES"].begin(); it!= j["DATABASES"].end(); it++) {
+           string dbName = it.key();
+           string instName = it.value().at("instance");
+           int dbId = it.value().at("id");
+           m_db_info[dbId] = {instName, dbName};
+        }
+        return true;
+    }
+    return false;
+};
+
+unordered_map<int, pair<string, string>> RedisConfig::m_db_info;
+unordered_map<string, pair<string, int>> RedisConfig::m_redis_info;
+bool RedisConfig::m_init = RedisConfig::parseRedisDBConfig(DB_CONFIG_FILE);
 
 constexpr const char *DBConnector::DEFAULT_UNIXSOCKET;
 
@@ -55,6 +87,40 @@ DBConnector::DBConnector(int dbId, const string& unixPath, unsigned int timeout)
         m_conn = redisConnectUnixWithTimeout(unixPath.c_str(), tv);
     else
         m_conn = redisConnectUnix(unixPath.c_str());
+
+    if (m_conn->err)
+        throw system_error(make_error_code(errc::address_not_available),
+                           "Unable to connect to redis (unixs-socket)");
+
+    select(this);
+}
+
+DBConnector::DBConnector(const string& hostname, int dbId, unsigned int timeout) :
+    m_dbId(dbId)
+{
+    struct timeval tv = {0, (suseconds_t)timeout * 1000};
+
+    if (timeout)
+        m_conn = redisConnectWithTimeout(hostname.c_str(), RedisConfig::getDbport(dbId), tv);
+    else
+        m_conn = redisConnect(hostname.c_str(), RedisConfig::getDbport(dbId));
+
+    if (m_conn->err)
+        throw system_error(make_error_code(errc::address_not_available),
+                           "Unable to connect to redis");
+
+    select(this);
+}
+
+DBConnector::DBConnector(int dbId, unsigned int timeout) :
+   m_dbId(dbId)
+{
+    struct timeval tv = {0, (suseconds_t)timeout * 1000};
+
+    if (timeout)
+        m_conn = redisConnectUnixWithTimeout(RedisConfig::getDbsock(dbId).c_str(), tv);
+    else
+        m_conn = redisConnectUnix(RedisConfig::getDbsock(dbId).c_str());
 
     if (m_conn->err)
         throw system_error(make_error_code(errc::address_not_available),

--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -6,7 +6,6 @@
 #include <system_error>
 #include <fstream>
 #include "json.hpp"
-#include "schema.h"
 
 #include "common/dbconnector.h"
 #include "common/redisreply.h"
@@ -16,33 +15,75 @@ using namespace std;
 
 namespace swss {
 
-bool RedisConfig::parseRedisDBConfig(string file) {
+void SonicDBConfig::initialize(const string &file)
+{
+    if (m_init)
+        throw runtime_error("SonicDBConfig already initialized");
 
     ifstream i(file);
-    if (i.good()) {
+    if (i.good())
+    {
         json j;
         i >> j;
-        for(auto it = j["INSTANCES"].begin(); it!= j["INSTANCES"].end(); it++) {
+        for (auto it = j["INSTANCES"].begin(); it!= j["INSTANCES"].end(); it++)
+        {
            string instName = it.key();
-           string sockPath = it.value().at("socket");
+           string socket = it.value().at("unix_socket_path");
+           string hostname = it.value().at("hostname");
            int port = it.value().at("port");
-           m_redis_info[instName] = {sockPath, port};
+           m_inst_info[instName] = {socket, {hostname, port}};
         }
 
-        for(auto it = j["DATABASES"].begin(); it!= j["DATABASES"].end(); it++) {
+        for (auto it = j["DATABASES"].begin(); it!= j["DATABASES"].end(); it++)
+        {
            string dbName = it.key();
            string instName = it.value().at("instance");
            int dbId = it.value().at("id");
-           m_db_info[dbId] = {instName, dbName};
+           m_db_info[dbName] = {instName, dbId};
         }
-        return true;
+        m_init = true;
     }
-    return false;
-};
+}
 
-unordered_map<int, pair<string, string>> RedisConfig::m_db_info;
-unordered_map<string, pair<string, int>> RedisConfig::m_redis_info;
-bool RedisConfig::m_init = RedisConfig::parseRedisDBConfig(DB_CONFIG_FILE);
+string SonicDBConfig::getDbInst(const string &dbName)
+{
+    if (!m_init)
+        initialize(DEFAULT_SONIC_DB_CONFIG_FILE);
+    return m_db_info[dbName].first;
+}
+
+int SonicDBConfig::getDbId(const string &dbName)
+{
+    if (!m_init)
+        initialize(DEFAULT_SONIC_DB_CONFIG_FILE);
+    return m_db_info[dbName].second;
+}
+
+string SonicDBConfig::getDbSock(const string &dbName)
+{
+    if (!m_init)
+        initialize(DEFAULT_SONIC_DB_CONFIG_FILE);
+    return m_inst_info[getDbInst(dbName)].first;
+}
+
+string SonicDBConfig::getDbHostname(const string &dbName)
+{
+    if (!m_init)
+        initialize(DEFAULT_SONIC_DB_CONFIG_FILE);
+    return m_inst_info[getDbInst(dbName)].second.first;
+}
+
+int SonicDBConfig::getDbPort(const string &dbName)
+{
+    if (!m_init)
+        initialize(DEFAULT_SONIC_DB_CONFIG_FILE);
+    return m_inst_info[getDbInst(dbName)].second.second;
+}
+
+constexpr const char *SonicDBConfig::DEFAULT_SONIC_DB_CONFIG_FILE;
+unordered_map<string, pair<string, pair<string, int>>> SonicDBConfig::m_inst_info;
+unordered_map<string, pair<string, int>> SonicDBConfig::m_db_info;
+bool SonicDBConfig::m_init = false;
 
 constexpr const char *DBConnector::DEFAULT_UNIXSOCKET;
 
@@ -95,36 +136,29 @@ DBConnector::DBConnector(int dbId, const string& unixPath, unsigned int timeout)
     select(this);
 }
 
-DBConnector::DBConnector(const string& hostname, int dbId, unsigned int timeout) :
-    m_dbId(dbId)
+DBConnector::DBConnector(const string& dbName, unsigned int timeout, bool isTcpConn) :
+    m_dbId(SonicDBConfig::getDbId(dbName))
 {
     struct timeval tv = {0, (suseconds_t)timeout * 1000};
 
     if (timeout)
-        m_conn = redisConnectWithTimeout(hostname.c_str(), RedisConfig::getDbport(dbId), tv);
+    {
+        if (isTcpConn)
+            m_conn = redisConnectWithTimeout(SonicDBConfig::getDbHostname(dbName).c_str(), SonicDBConfig::getDbPort(dbName), tv);
+        else
+            m_conn = redisConnectUnixWithTimeout(SonicDBConfig::getDbSock(dbName).c_str(), tv);
+    }
     else
-        m_conn = redisConnect(hostname.c_str(), RedisConfig::getDbport(dbId));
+    {
+        if (isTcpConn)
+            m_conn = redisConnect(SonicDBConfig::getDbHostname(dbName).c_str(), SonicDBConfig::getDbPort(dbName));
+        else
+            m_conn = redisConnectUnix(SonicDBConfig::getDbSock(dbName).c_str());
+    }
 
     if (m_conn->err)
         throw system_error(make_error_code(errc::address_not_available),
                            "Unable to connect to redis");
-
-    select(this);
-}
-
-DBConnector::DBConnector(int dbId, unsigned int timeout) :
-   m_dbId(dbId)
-{
-    struct timeval tv = {0, (suseconds_t)timeout * 1000};
-
-    if (timeout)
-        m_conn = redisConnectUnixWithTimeout(RedisConfig::getDbsock(dbId).c_str(), tv);
-    else
-        m_conn = redisConnectUnix(RedisConfig::getDbsock(dbId).c_str());
-
-    if (m_conn->err)
-        throw system_error(make_error_code(errc::address_not_available),
-                           "Unable to connect to redis (unixs-socket)");
 
     select(this);
 }

--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -45,6 +45,10 @@ void SonicDBConfig::initialize(const string &file)
             }
             m_init = true;
         }
+        catch (domain_error& e)
+        {
+            throw runtime_error("key doesn't exist in json object, NULL value has no iterator >> " + string(e.what()));
+        }
         catch (exception &e)
         {
             throw runtime_error("Sonic database config file syntax error >> " + string(e.what()));

--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -23,60 +23,67 @@ void SonicDBConfig::initialize(const string &file)
     ifstream i(file);
     if (i.good())
     {
-        json j;
-        i >> j;
-        for (auto it = j["INSTANCES"].begin(); it!= j["INSTANCES"].end(); it++)
+        try
         {
-           string instName = it.key();
-           string socket = it.value().at("unix_socket_path");
-           string hostname = it.value().at("hostname");
-           int port = it.value().at("port");
-           m_inst_info[instName] = {socket, {hostname, port}};
-        }
+            json j;
+            i >> j;
+            for (auto it = j["INSTANCES"].begin(); it!= j["INSTANCES"].end(); it++)
+            {
+               string instName = it.key();
+               string socket = it.value().at("unix_socket_path");
+               string hostname = it.value().at("hostname");
+               int port = it.value().at("port");
+               m_inst_info[instName] = {socket, {hostname, port}};
+            }
 
-        for (auto it = j["DATABASES"].begin(); it!= j["DATABASES"].end(); it++)
-        {
-           string dbName = it.key();
-           string instName = it.value().at("instance");
-           int dbId = it.value().at("id");
-           m_db_info[dbName] = {instName, dbId};
+            for (auto it = j["DATABASES"].begin(); it!= j["DATABASES"].end(); it++)
+            {
+               string dbName = it.key();
+               string instName = it.value().at("instance");
+               int dbId = it.value().at("id");
+               m_db_info[dbName] = {instName, dbId};
+            }
+            m_init = true;
         }
-        m_init = true;
+        catch (exception &e)
+        {
+            throw runtime_error("Sonic database config file syntax error >> " + string(e.what()));
+        }
     }
 }
 
 string SonicDBConfig::getDbInst(const string &dbName)
 {
     if (!m_init)
-        initialize(DEFAULT_SONIC_DB_CONFIG_FILE);
+        initialize();
     return m_db_info[dbName].first;
 }
 
 int SonicDBConfig::getDbId(const string &dbName)
 {
     if (!m_init)
-        initialize(DEFAULT_SONIC_DB_CONFIG_FILE);
+        initialize();
     return m_db_info[dbName].second;
 }
 
 string SonicDBConfig::getDbSock(const string &dbName)
 {
     if (!m_init)
-        initialize(DEFAULT_SONIC_DB_CONFIG_FILE);
+        initialize();
     return m_inst_info[getDbInst(dbName)].first;
 }
 
 string SonicDBConfig::getDbHostname(const string &dbName)
 {
     if (!m_init)
-        initialize(DEFAULT_SONIC_DB_CONFIG_FILE);
+        initialize();
     return m_inst_info[getDbInst(dbName)].second.first;
 }
 
 int SonicDBConfig::getDbPort(const string &dbName)
 {
     if (!m_init)
-        initialize(DEFAULT_SONIC_DB_CONFIG_FILE);
+        initialize();
     return m_inst_info[getDbInst(dbName)].second.second;
 }
 

--- a/common/dbconnector.h
+++ b/common/dbconnector.h
@@ -13,7 +13,7 @@ namespace swss {
 class SonicDBConfig
 {
 public:
-    static void initialize(const std::string &file);
+    static void initialize(const std::string &file = DEFAULT_SONIC_DB_CONFIG_FILE);
     static std::string getDbInst(const std::string &dbName);
     static int getDbId(const std::string &dbName);
     static std::string getDbSock(const std::string &dbName);

--- a/common/dbconnector.h
+++ b/common/dbconnector.h
@@ -3,10 +3,32 @@
 
 #include <string>
 #include <vector>
+#include <unordered_map>
+#include <utility>
 
 #include <hiredis/hiredis.h>
 
 namespace swss {
+
+class RedisConfig
+{
+public:
+    static bool parseRedisDBConfig(std::string file);
+    // updateDBConfigFile is only for vs test / swsscommon test whose db config file doesn't exist
+    static bool updateDBConfigFile(std::string file) { m_init = RedisConfig::parseRedisDBConfig(file); return m_init; };
+    static std::string getDbinst(int dbId) { return m_db_info[dbId].first; };
+    static std::string getDbname(int dbId) { return m_db_info[dbId].second; };
+    static std::string getDbsock(int dbId) { return m_redis_info[m_db_info[dbId].first].first; };
+    static int getDbport(int dbId) { return m_redis_info[m_db_info[dbId].first].second; };
+    static bool isInit() { return m_init; };
+
+private:
+    // { instName, {socker, port} }
+    static std::unordered_map<std::string, std::pair<std::string, int>> m_redis_info;
+    // { dbId, {instName, dbName} }
+    static std::unordered_map<int, std::pair<std::string, std::string>> m_db_info;
+    static bool m_init;
+};
 
 class DBConnector
 {
@@ -22,6 +44,8 @@ public:
      */
     DBConnector(int dbId, const std::string &hostname, int port, unsigned int timeout);
     DBConnector(int dbId, const std::string &unixPath, unsigned int timeout);
+    DBConnector(const std::string &hostname, int dbId, unsigned int timeout); //TCP PORT
+    DBConnector(int dbId, unsigned int timeout); //UNIX SOCKET
 
     ~DBConnector();
 

--- a/common/dbconnector.h
+++ b/common/dbconnector.h
@@ -10,23 +10,23 @@
 
 namespace swss {
 
-class RedisConfig
+class SonicDBConfig
 {
 public:
-    static bool parseRedisDBConfig(std::string file);
-    // updateDBConfigFile is only for vs test / swsscommon test whose db config file doesn't exist
-    static bool updateDBConfigFile(std::string file) { m_init = RedisConfig::parseRedisDBConfig(file); return m_init; };
-    static std::string getDbinst(int dbId) { return m_db_info[dbId].first; };
-    static std::string getDbname(int dbId) { return m_db_info[dbId].second; };
-    static std::string getDbsock(int dbId) { return m_redis_info[m_db_info[dbId].first].first; };
-    static int getDbport(int dbId) { return m_redis_info[m_db_info[dbId].first].second; };
+    static void initialize(const std::string &file);
+    static std::string getDbInst(const std::string &dbName);
+    static int getDbId(const std::string &dbName);
+    static std::string getDbSock(const std::string &dbName);
+    static std::string getDbHostname(const std::string &dbName);
+    static int getDbPort(const std::string &dbName);
     static bool isInit() { return m_init; };
 
 private:
-    // { instName, {socker, port} }
-    static std::unordered_map<std::string, std::pair<std::string, int>> m_redis_info;
-    // { dbId, {instName, dbName} }
-    static std::unordered_map<int, std::pair<std::string, std::string>> m_db_info;
+    static constexpr const char *DEFAULT_SONIC_DB_CONFIG_FILE = "/var/run/redis/sonic-db/database_config.json";
+    // { instName, { unix_socket_path, {hostname, port} } }
+    static std::unordered_map<std::string, std::pair<std::string, std::pair<std::string, int>>> m_inst_info;
+    // { dbName, {instName, dbId} }
+    static std::unordered_map<std::string, std::pair<std::string, int>> m_db_info;
     static bool m_init;
 };
 
@@ -44,8 +44,7 @@ public:
      */
     DBConnector(int dbId, const std::string &hostname, int port, unsigned int timeout);
     DBConnector(int dbId, const std::string &unixPath, unsigned int timeout);
-    DBConnector(const std::string &hostname, int dbId, unsigned int timeout); //TCP PORT
-    DBConnector(int dbId, unsigned int timeout); //UNIX SOCKET
+    DBConnector(const std::string &dbName, unsigned int timeout, bool isTcpConn = false);
 
     ~DBConnector();
 

--- a/common/logger.cpp
+++ b/common/logger.cpp
@@ -91,7 +91,7 @@ void Logger::linkToDbWithOutput(const std::string &dbName, const PriorityChangeN
 
     // Initialize internal DB with observer
     logger.m_settingChangeObservers.insert(std::make_pair(dbName, std::make_pair(prioNotify, outputNotify)));
-    DBConnector db(LOGLEVEL_DB, 0);
+    DBConnector db("LOGLEVEL_DB", 0);
     RedisClient redisClient(&db);
     auto keys = redisClient.keys("*");
 
@@ -169,7 +169,7 @@ Logger::Priority Logger::getMinPrio()
 [[ noreturn ]] void Logger::settingThread()
 {
     Select select;
-    DBConnector db(LOGLEVEL_DB, 0);
+    DBConnector db("LOGLEVEL_DB", 0);
     std::vector<std::shared_ptr<ConsumerStateTable>> selectables(m_settingChangeObservers.size());
 
     for (const auto& i : m_settingChangeObservers)

--- a/common/logger.cpp
+++ b/common/logger.cpp
@@ -91,7 +91,7 @@ void Logger::linkToDbWithOutput(const std::string &dbName, const PriorityChangeN
 
     // Initialize internal DB with observer
     logger.m_settingChangeObservers.insert(std::make_pair(dbName, std::make_pair(prioNotify, outputNotify)));
-    DBConnector db(LOGLEVEL_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
+    DBConnector db(LOGLEVEL_DB, 0);
     RedisClient redisClient(&db);
     auto keys = redisClient.keys("*");
 
@@ -169,7 +169,7 @@ Logger::Priority Logger::getMinPrio()
 [[ noreturn ]] void Logger::settingThread()
 {
     Select select;
-    DBConnector db(LOGLEVEL_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
+    DBConnector db(LOGLEVEL_DB, 0);
     std::vector<std::shared_ptr<ConsumerStateTable>> selectables(m_settingChangeObservers.size());
 
     for (const auto& i : m_settingChangeObservers)

--- a/common/loglevel.cpp
+++ b/common/loglevel.cpp
@@ -107,7 +107,7 @@ int main(int argc, char **argv)
         }
     }
 
-    DBConnector db(LOGLEVEL_DB, 0);
+    DBConnector db("LOGLEVEL_DB", 0);
     RedisClient redisClient(&db);
     auto keys = redisClient.keys("*");
     for (auto& key : keys)

--- a/common/loglevel.cpp
+++ b/common/loglevel.cpp
@@ -107,7 +107,7 @@ int main(int argc, char **argv)
         }
     }
 
-    DBConnector db(LOGLEVEL_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
+    DBConnector db(LOGLEVEL_DB, 0);
     RedisClient redisClient(&db);
     auto keys = redisClient.keys("*");
     for (auto& key : keys)

--- a/common/schema.h
+++ b/common/schema.h
@@ -15,6 +15,8 @@ namespace swss {
 #define STATE_DB        6
 #define SNMP_OVERLAY_DB 7
 
+#define  DB_CONFIG_FILE "/var/run/redis/sonic-db/database_config.json"
+
 /***** APPLICATION DATABASE *****/
 
 #define APP_PORT_TABLE_NAME               "PORT_TABLE"

--- a/common/schema.h
+++ b/common/schema.h
@@ -15,8 +15,6 @@ namespace swss {
 #define STATE_DB        6
 #define SNMP_OVERLAY_DB 7
 
-#define  DB_CONFIG_FILE "/var/run/redis/sonic-db/database_config.json"
-
 /***** APPLICATION DATABASE *****/
 
 #define APP_PORT_TABLE_NAME               "PORT_TABLE"

--- a/common/table.cpp
+++ b/common/table.cpp
@@ -41,8 +41,8 @@ Table::Table(RedisPipeline *pipeline, const string &tableName, bool buffered)
     , m_pipeowned(false)
     , m_pipe(pipeline)
 {
-    std::string m_luaScript = loadLuaScript("table_dump.lua");
-    m_sha = pipeline->loadRedisScript(m_luaScript);
+    std::string luaScript = loadLuaScript("table_dump.lua");
+    m_shaPop = pipeline->loadRedisScript(luaScript);
 }
 
 Table::~Table()
@@ -192,7 +192,7 @@ void Table::dump(TableDump& tableDump)
 
     RedisCommand command;
     command.format("EVALSHA %s 1 %s ''",
-            m_sha.c_str(),
+            m_shaPop.c_str(),
             getTableName().c_str());
 
     RedisReply r = m_pipe->push(command, REDIS_REPLY_STRING);

--- a/common/table.cpp
+++ b/common/table.cpp
@@ -41,6 +41,8 @@ Table::Table(RedisPipeline *pipeline, const string &tableName, bool buffered)
     , m_pipeowned(false)
     , m_pipe(pipeline)
 {
+    std::string m_luaScript = loadLuaScript("table_dump.lua");
+    m_sha = pipeline->loadRedisScript(m_luaScript);
 }
 
 Table::~Table()
@@ -186,15 +188,11 @@ void Table::dump(TableDump& tableDump)
 {
     SWSS_LOG_ENTER();
 
-    static std::string luaScript = loadLuaScript("table_dump.lua");
-
-    static std::string sha = m_pipe->loadRedisScript(luaScript);
-
     SWSS_LOG_TIMER("getting");
 
     RedisCommand command;
     command.format("EVALSHA %s 1 %s ''",
-            sha.c_str(),
+            m_sha.c_str(),
             getTableName().c_str());
 
     RedisReply r = m_pipe->push(command, REDIS_REPLY_STRING);

--- a/common/table.cpp
+++ b/common/table.cpp
@@ -42,7 +42,7 @@ Table::Table(RedisPipeline *pipeline, const string &tableName, bool buffered)
     , m_pipe(pipeline)
 {
     std::string luaScript = loadLuaScript("table_dump.lua");
-    m_shaPop = pipeline->loadRedisScript(luaScript);
+    m_shaDump = pipeline->loadRedisScript(luaScript);
 }
 
 Table::~Table()
@@ -192,7 +192,7 @@ void Table::dump(TableDump& tableDump)
 
     RedisCommand command;
     command.format("EVALSHA %s 1 %s ''",
-            m_shaPop.c_str(),
+            m_shaDump.c_str(),
             getTableName().c_str());
 
     RedisReply r = m_pipe->push(command, REDIS_REPLY_STRING);

--- a/common/table.h
+++ b/common/table.h
@@ -180,6 +180,7 @@ protected:
      * 2) "Ethernet0,Ethernet4,...
      * */
     std::string stripSpecialSym(const std::string &key);
+    std::string m_sha;
 };
 
 class TableName_KeyValueOpQueues {

--- a/common/table.h
+++ b/common/table.h
@@ -180,7 +180,7 @@ protected:
      * 2) "Ethernet0,Ethernet4,...
      * */
     std::string stripSpecialSym(const std::string &key);
-    std::string m_shaPop;
+    std::string m_shaDump;
 };
 
 class TableName_KeyValueOpQueues {

--- a/common/table.h
+++ b/common/table.h
@@ -180,7 +180,7 @@ protected:
      * 2) "Ethernet0,Ethernet4,...
      * */
     std::string stripSpecialSym(const std::string &key);
-    std::string m_sha;
+    std::string m_shaPop;
 };
 
 class TableName_KeyValueOpQueues {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -25,7 +25,8 @@ tests_SOURCES = redis_ut.cpp                \
                 exec_ut.cpp                 \
                 redis_subscriber_state_ut.cpp \
                 selectable_priority.cpp       \
-                warm_restart_ut.cpp
+                warm_restart_ut.cpp         \
+                redis_multi_db_ut.cpp
 
 tests_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(LIBNL_CFLAGS)
 tests_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(LIBNL_CFLAGS)

--- a/tests/redis_multi_db_ut.cpp
+++ b/tests/redis_multi_db_ut.cpp
@@ -13,7 +13,7 @@ using json = nlohmann::json;
 TEST(DBConnector, multi_db_test)
 {
 
-    string file = "./redis_multi_db_ut_config/database_config.json";
+    string file = "./tests/redis_multi_db_ut_config/database_config.json";
     // default config file should not be found
     cout<<"Default : load init db config file, isInit = "<<RedisConfig::isInit()<<endl;
     EXPECT_EQ(RedisConfig::isInit(), false);

--- a/tests/redis_multi_db_ut.cpp
+++ b/tests/redis_multi_db_ut.cpp
@@ -1,0 +1,49 @@
+#include <iostream>
+#include <fstream>
+#include "gtest/gtest.h"
+#include "common/dbconnector.h"
+#include "common/json.hpp"
+#include <unordered_map>
+
+using namespace std;
+using namespace swss;
+using json = nlohmann::json;
+
+
+TEST(DBConnector, multi_db_test)
+{
+
+    string file = "./redis_multi_db_ut_config/database_config.json";
+    // default config file should not be found
+    cout<<"Default : load init db config file, isInit = "<<RedisConfig::isInit()<<endl;
+    EXPECT_EQ(RedisConfig::isInit(), false);
+    // update with local config file, should be found
+    RedisConfig::updateDBConfigFile(file);
+    cout<<"Update : load local db config file, isInit = "<<RedisConfig::isInit()<<endl;
+    EXPECT_EQ(RedisConfig::isInit(), true);
+
+    // parse config file
+    ifstream i(file);
+    if (i.good()) {
+        json j;
+        i >> j;
+        unordered_map<string, pair<string, int>> m_redis_info;
+        for(auto it = j["INSTANCES"].begin(); it!= j["INSTANCES"].end(); it++) {
+           string instName = it.key();
+           string sockPath = it.value().at("socket");
+           int port = it.value().at("port");
+           m_redis_info[instName] = {sockPath, port};
+        }
+
+        for(auto it = j["DATABASES"].begin(); it!= j["DATABASES"].end(); it++) {
+           string instName = it.value().at("instance");
+           int dbId = it.value().at("id");
+           cout<<"JSON file # dbid: "<<dbId<<" ,socket: "<<m_redis_info[instName].first<<" .port: "<<m_redis_info[instName].second<<endl;
+           cout<<"API get   # dbid: "<<dbId<<" ,socket: "<<RedisConfig::getDbsock(dbId)<<" .port: "<<RedisConfig::getDbport(dbId)<<endl;
+           // socket info matches between get api and context in json file
+           EXPECT_EQ(m_redis_info[instName].first, RedisConfig::getDbsock(dbId));
+           // port info matches between get api and context in json file
+           EXPECT_EQ(m_redis_info[instName].second, RedisConfig::getDbport(dbId));
+        }
+    }
+}

--- a/tests/redis_multi_db_ut_config/database_config.json
+++ b/tests/redis_multi_db_ut_config/database_config.json
@@ -1,0 +1,63 @@
+{
+    "INSTANCES": {
+        "redis":{
+            "port": 6379,
+            "socket": "/var/run/redis/redis.sock"
+        },
+        "redis1":{
+            "port": 6380,
+            "socket": "/var/run/redis/redis1.sock"
+        },
+        "redis2":{
+            "port": 6381,
+            "socket": "/var/run/redis/redis2.sock"
+        },
+        "redis3":{
+            "port": 6382,
+            "socket": "/var/run/redis/redis3.sock"
+        },
+        "redis4":{
+            "port": 6383,
+            "socket": "/var/run/redis/redis4.sock"
+        }
+    },
+    "DATABASES" : {
+        "APPL_DB" : {
+            "id" : 0,
+            "instance" : "redis"
+        },
+        "ASIC_DB" : {
+            "id" : 1,
+            "instance" : "redis1"
+        },
+        "COUNTERS_DB" : {
+            "id" : 2,
+            "instance" : "redis1"
+        },
+        "LOGLEVEL_DB" : {
+            "id" : 3,
+            "instance" : "redis2"
+        },
+        "CONFIG_DB" : {
+            "id" : 4,
+            "instance" : "redis2"
+        },
+        "PFC_WD_DB" : {
+            "id" : 5,
+            "instance" : "redis3"
+        },
+        "FLEX_COUNTER_DB" : {
+            "id" : 5,
+            "instance" : "redis3"
+        },
+        "STATE_DB" : {
+            "id" : 6,
+            "instance" : "redis4"
+        },
+        "SNMP_OVERLAY_DB" : {
+            "id" : 7,
+            "instance" : "redis4"
+        }
+    },
+    "VERSION" : "1.0"
+}

--- a/tests/redis_multi_db_ut_config/database_config.json
+++ b/tests/redis_multi_db_ut_config/database_config.json
@@ -1,24 +1,29 @@
 {
     "INSTANCES": {
         "redis":{
+            "hostname" : "127.0.0.1",
             "port": 6379,
-            "socket": "/var/run/redis/redis.sock"
+            "unix_socket_path": "/var/run/redis/redis.sock"
         },
         "redis1":{
+            "hostname" : "127.0.0.1",
             "port": 6380,
-            "socket": "/var/run/redis/redis1.sock"
+            "unix_socket_path": "/var/run/redis/redis1.sock"
         },
         "redis2":{
+            "hostname" : "127.0.0.1",
             "port": 6381,
-            "socket": "/var/run/redis/redis2.sock"
+            "unix_socket_path": "/var/run/redis/redis2.sock"
         },
         "redis3":{
+            "hostname" : "127.0.0.1",
             "port": 6382,
-            "socket": "/var/run/redis/redis3.sock"
+            "unix_socket_path": "/var/run/redis/redis3.sock"
         },
         "redis4":{
+            "hostname" : "127.0.0.1",
             "port": 6383,
-            "socket": "/var/run/redis/redis4.sock"
+            "unix_socket_path": "/var/run/redis/redis4.sock"
         }
     },
     "DATABASES" : {


### PR DESCRIPTION
* add a new RedisConfig class which has static member and func, to parse/store/update/get database info from database_config.json file.

* add new DBConnector() constructor without port and unixsocket parameters. using RedisConfig class get func to get those info dynamically, all other DBConnector logic are same.

* the previous static sha member in tables are not good for multi-db cases, since on each db instance, there should be a SHA value, we cannot reuse only one SHA value, hence remove  the static keyword and keep SHA value as a member for each DBConnector object

* add updateDBConfigFile() to support vs test/ swsscommon test cases where this is no database_config.json at init time, we can point to load the config file.

* adding swsscommon unit test to check the  updateDBConfigFile() func, also check RedisConfig get APIs could return correct db info.

* relpace LOGLEVEL_DB with new DBConnector construct, LOGLEVEL_DB only has three places to changes, they are also in swsscommon repo, hence change here.  Since the database_config.json has only one redis inst for now. LOGLEVEL_DB behaves the same as before , though it is using new DBConnector constructor. All the other DBConnector replacement will be done in other PR.

* swsscommon test result ：
dzhang@343ca72c4bf5:/sonic/src/sonic-swss-common/tests$ ./tests --gtest_filter=DBConnector.multi_db_test
Running main() from gtest_main.cc
Note: Google Test filter = DBConnector.multi_db_test
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from DBConnector
[ RUN      ] DBConnector.multi_db_test
Default : load init db config file, isInit = 0
Update : load local db config file, isInit = 1
JSON file # dbid: 0 ,socket: /var/run/redis/redis.sock .port: 6379
API get   # dbid: 0 ,socket: /var/run/redis/redis.sock .port: 6379
JSON file # dbid: 1 ,socket: /var/run/redis/redis1.sock .port: 6380
API get   # dbid: 1 ,socket: /var/run/redis/redis1.sock .port: 6380
JSON file # dbid: 4 ,socket: /var/run/redis/redis2.sock .port: 6381
API get   # dbid: 4 ,socket: /var/run/redis/redis2.sock .port: 6381
JSON file # dbid: 2 ,socket: /var/run/redis/redis1.sock .port: 6380
API get   # dbid: 2 ,socket: /var/run/redis/redis1.sock .port: 6380
JSON file # dbid: 5 ,socket: /var/run/redis/redis3.sock .port: 6382
API get   # dbid: 5 ,socket: /var/run/redis/redis3.sock .port: 6382
JSON file # dbid: 3 ,socket: /var/run/redis/redis2.sock .port: 6381
API get   # dbid: 3 ,socket: /var/run/redis/redis2.sock .port: 6381
JSON file # dbid: 5 ,socket: /var/run/redis/redis3.sock .port: 6382
API get   # dbid: 5 ,socket: /var/run/redis/redis3.sock .port: 6382
JSON file # dbid: 7 ,socket: /var/run/redis/redis4.sock .port: 6383
API get   # dbid: 7 ,socket: /var/run/redis/redis4.sock .port: 6383
JSON file # dbid: 6 ,socket: /var/run/redis/redis4.sock .port: 6383
API get   # dbid: 6 ,socket: /var/run/redis/redis4.sock .port: 6383
[       OK ] DBConnector.multi_db_test (0 ms)
[----------] 1 test from DBConnector (0 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (0 ms total)
[  PASSED  ] 1 test.


