### PR TITLE
timerfd return 0 with errno =0 -  handle as False alarm.

### DIFF
--- a/common/netlink.cpp
+++ b/common/netlink.cpp
@@ -76,7 +76,7 @@ int NetLink::getFd()
     return nl_socket_get_fd(m_socket);
 }
 
-void NetLink::readData()
+uint64_t NetLink::readData()
 {
     int err;
 
@@ -95,6 +95,7 @@ void NetLink::readData()
         else
             SWSS_LOG_ERROR("netlink reports an error=%d on reading a netlink socket", err);
     }
+    return 0;
 }
 
 int NetLink::onNetlinkMsg(struct nl_msg *msg, void *arg)

--- a/common/netlink.h
+++ b/common/netlink.h
@@ -16,7 +16,7 @@ public:
     void dumpRequest(int rtmGetCommand);
 
     int getFd() override;
-    void readData() override;
+    uint64_t readData() override;
 
 private:
     static int onNetlinkMsg(struct nl_msg *msg, void *arg);

--- a/common/notificationconsumer.cpp
+++ b/common/notificationconsumer.cpp
@@ -65,7 +65,7 @@ int swss::NotificationConsumer::getFd()
     return m_subscribe->getContext()->fd;
 }
 
-void swss::NotificationConsumer::readData()
+uint64_t swss::NotificationConsumer::readData()
 {
     SWSS_LOG_ENTER();
 
@@ -100,6 +100,7 @@ void swss::NotificationConsumer::readData()
     {
         throw std::runtime_error("Unable to read redis reply");
     }
+    return 0;
 }
 
 bool swss::NotificationConsumer::hasData()

--- a/common/notificationconsumer.h
+++ b/common/notificationconsumer.h
@@ -39,7 +39,7 @@ public:
     ~NotificationConsumer() override;
 
     int getFd() override;
-    void readData() override;
+    uint64_t readData() override;
     bool hasData() override;
     bool hasCachedData() override;
     const size_t POP_BATCH_SIZE;

--- a/common/redisselect.cpp
+++ b/common/redisselect.cpp
@@ -17,7 +17,7 @@ int RedisSelect::getFd()
     return m_subscribe->getContext()->fd;
 }
 
-void RedisSelect::readData()
+uint64_t RedisSelect::readData()
 {
     redisReply *reply = nullptr;
 
@@ -44,6 +44,7 @@ void RedisSelect::readData()
     {
         throw std::runtime_error("Unable to read redis reply");
     }
+    return 0;
 }
 
 bool RedisSelect::hasData()

--- a/common/redisselect.h
+++ b/common/redisselect.h
@@ -15,7 +15,7 @@ public:
     RedisSelect(int pri = 0);
 
     int getFd() override;
-    void readData() override;
+    uint64_t readData() override;
     bool hasData() override;
     bool hasCachedData() override;
     bool initializedWithData() override;

--- a/common/selectable.h
+++ b/common/selectable.h
@@ -21,7 +21,7 @@ public:
     virtual int getFd() = 0;
 
     /* Read all data from the fd assicaited with Selectable */
-    virtual void readData() = 0;
+    virtual uint64_t readData() = 0;
 
     /*
        true if Selectable has data in it for immediate read

--- a/common/selectableevent.cpp
+++ b/common/selectableevent.cpp
@@ -40,7 +40,7 @@ int SelectableEvent::getFd()
     return m_efd;
 }
 
-void SelectableEvent::readData()
+uint64_t SelectableEvent::readData()
 {
     uint64_t r;
 
@@ -56,6 +56,7 @@ void SelectableEvent::readData()
         SWSS_LOG_THROW("SelectableEvent read failed, s:%zd errno: %s",
                 s, strerror(errno));
     }
+    return 0;
 }
 
 void SelectableEvent::notify()

--- a/common/selectableevent.h
+++ b/common/selectableevent.h
@@ -18,7 +18,7 @@ public:
     void notify();
 
     int getFd() override;
-    void readData() override;
+    uint64_t readData() override;
 
 private:
     int m_efd;

--- a/common/selectabletimer.cpp
+++ b/common/selectabletimer.cpp
@@ -87,7 +87,7 @@ void SelectableTimer::readData()
              * case errno should be EAGAIN.
              *
              * Due to a kernel bug, exposed only in S6100 HW platform,
-             * this could be true.
+             * we could see s == 0 and errno == 0.
              *
              * In this case, the timer is fired, but not adanced, hence
              * another read is expected to fix it per DELL.

--- a/common/selectabletimer.cpp
+++ b/common/selectabletimer.cpp
@@ -72,38 +72,22 @@ int SelectableTimer::getFd()
     return m_tfd;
 }
 
-void SelectableTimer::readData()
+int SelectableTimer::readData()
 {
-    uint64_t r = UINT64_MAX;
+    uint64_t r = 0;
 
     ssize_t s;
     errno = 0;
     do
     {
         s = read(m_tfd, &r, sizeof(uint64_t));
-        if ((s == 0) && (errno == 0)) {
-            /*
-             * s == 0 is expected only for non-blocking fd, in which
-             * case errno should be EAGAIN.
-             *
-             * Due to a kernel bug, exposed only in S6100 HW platform,
-             * we could see s == 0 and errno == 0.
-             *
-             * In this case, the timer is fired, but not advanced, hence
-             * another read is expected to fix it per DELL.
-             *
-             * Log an error and continue to read.
-             *
-             */
-            SWSS_LOG_ERROR("Benign failure to read from timerfd return=0 && errno=0. Expect: return=%zd",
-                    sizeof(uint64_t));
-        }
     }
-    while((s == -1 && errno == EINTR) || ((s == 0) && (errno == 0)));
+    while(s == -1 && errno == EINTR);
 
-    ABORT_IF_NOT(s == sizeof(uint64_t), "Failed to read timerfd. s=%zd", s);
+    ABORT_IF_NOT((s == 0) || (s == sizeof(uint64_t), "Failed to read timerfd. s=%zd", s);
 
     // r = count of timer events happened since last read.
+    return r;
 }
 
 }

--- a/common/selectabletimer.cpp
+++ b/common/selectabletimer.cpp
@@ -89,7 +89,7 @@ void SelectableTimer::readData()
              * Due to a kernel bug, exposed only in S6100 HW platform,
              * we could see s == 0 and errno == 0.
              *
-             * In this case, the timer is fired, but not adanced, hence
+             * In this case, the timer is fired, but not advanced, hence
              * another read is expected to fix it per DELL.
              *
              * Log an error and continue to read.

--- a/common/selectabletimer.cpp
+++ b/common/selectabletimer.cpp
@@ -84,7 +84,7 @@ uint64_t SelectableTimer::readData()
     }
     while(ret == -1 && errno == EINTR);
 
-    ABORT_IF_NOT((ret == 0) || (ret == sizeof(uint64_t), "Failed to read timerfd. ret=%zd", ret);
+    ABORT_IF_NOT((ret == 0) || (ret == sizeof(uint64_t)), "Failed to read timerfd. ret=%zd", ret);
 
     // cnt = count of timer events happened since last read.
     return cnt;

--- a/common/selectabletimer.cpp
+++ b/common/selectabletimer.cpp
@@ -72,22 +72,22 @@ int SelectableTimer::getFd()
     return m_tfd;
 }
 
-int SelectableTimer::readData()
+uint64_t SelectableTimer::readData()
 {
-    uint64_t r = 0;
+    uint64_t cnt = 0;
 
-    ssize_t s;
+    ssize_t ret;
     errno = 0;
     do
     {
-        s = read(m_tfd, &r, sizeof(uint64_t));
+        ret = read(m_tfd, &cnt, sizeof(uint64_t));
     }
-    while(s == -1 && errno == EINTR);
+    while(ret == -1 && errno == EINTR);
 
-    ABORT_IF_NOT((s == 0) || (s == sizeof(uint64_t), "Failed to read timerfd. s=%zd", s);
+    ABORT_IF_NOT((ret == 0) || (ret == sizeof(uint64_t), "Failed to read timerfd. ret=%zd", ret);
 
-    // r = count of timer events happened since last read.
-    return r;
+    // cnt = count of timer events happened since last read.
+    return cnt;
 }
 
 }

--- a/common/selectabletimer.h
+++ b/common/selectabletimer.h
@@ -19,7 +19,7 @@ public:
     void setInterval(const timespec& interval);
 
     int getFd() override;
-    int readData() override;
+    uint64_t readData() override;
 
 private:
     int m_tfd;

--- a/common/selectabletimer.h
+++ b/common/selectabletimer.h
@@ -19,7 +19,7 @@ public:
     void setInterval(const timespec& interval);
 
     int getFd() override;
-    void readData() override;
+    int readData() override;
 
 private:
     int m_tfd;

--- a/common/subscriberstatetable.cpp
+++ b/common/subscriberstatetable.cpp
@@ -42,7 +42,7 @@ SubscriberStateTable::SubscriberStateTable(DBConnector *db, const string &tableN
     }
 }
 
-void SubscriberStateTable::readData()
+uint64_t SubscriberStateTable::readData()
 {
     redisReply *reply = nullptr;
 
@@ -79,6 +79,7 @@ void SubscriberStateTable::readData()
     {
         throw std::runtime_error("Unable to read redis reply");
     }
+    return 0;
 }
 
 bool SubscriberStateTable::hasData()

--- a/common/subscriberstatetable.h
+++ b/common/subscriberstatetable.h
@@ -17,7 +17,7 @@ public:
     void pops(std::deque<KeyOpFieldsValuesTuple> &vkco, const std::string &prefix = EMPTY_PREFIX);
 
     /* Read keyspace event from redis */
-    void readData() override;
+    uint64_t readData() override;
     bool hasData() override;
     bool hasCachedData() override;
     bool initializedWithData() override


### PR DESCRIPTION
timerfd read is expected to return 8 or for any other value appropriate
non-zero errno is expected. But due to a kernel bug, that is found to
occur in S6100 platform, there could be a return value of 0, with errno=0.

Per DELL, this implies timer fired but not forwarded, so take it as
false alarm, and next immediate read is expected to succeed.

Made the fix to meet it.