### PR TITLE
timerfd fix: Pass false alarm to caller.

### DIFF
--- a/common/netlink.cpp
+++ b/common/netlink.cpp
@@ -76,7 +76,7 @@ int NetLink::getFd()
     return nl_socket_get_fd(m_socket);
 }
 
-void NetLink::readData()
+uint64_t NetLink::readData()
 {
     int err;
 
@@ -95,6 +95,7 @@ void NetLink::readData()
         else
             SWSS_LOG_ERROR("netlink reports an error=%d on reading a netlink socket", err);
     }
+    return 0;
 }
 
 int NetLink::onNetlinkMsg(struct nl_msg *msg, void *arg)

--- a/common/netlink.h
+++ b/common/netlink.h
@@ -16,7 +16,7 @@ public:
     void dumpRequest(int rtmGetCommand);
 
     int getFd() override;
-    void readData() override;
+    uint64_t readData() override;
 
 private:
     static int onNetlinkMsg(struct nl_msg *msg, void *arg);

--- a/common/notificationconsumer.cpp
+++ b/common/notificationconsumer.cpp
@@ -65,7 +65,7 @@ int swss::NotificationConsumer::getFd()
     return m_subscribe->getContext()->fd;
 }
 
-void swss::NotificationConsumer::readData()
+uint64_t swss::NotificationConsumer::readData()
 {
     SWSS_LOG_ENTER();
 
@@ -100,6 +100,7 @@ void swss::NotificationConsumer::readData()
     {
         throw std::runtime_error("Unable to read redis reply");
     }
+    return 0;
 }
 
 bool swss::NotificationConsumer::hasCachedData()

--- a/common/notificationconsumer.h
+++ b/common/notificationconsumer.h
@@ -39,7 +39,7 @@ public:
     ~NotificationConsumer() override;
 
     int getFd() override;
-    void readData() override;
+    uint64_t readData() override;
     bool hasCachedData() override;
     const size_t POP_BATCH_SIZE;
 

--- a/common/redisselect.cpp
+++ b/common/redisselect.cpp
@@ -17,7 +17,7 @@ int RedisSelect::getFd()
     return m_subscribe->getContext()->fd;
 }
 
-void RedisSelect::readData()
+uint64_t RedisSelect::readData()
 {
     redisReply *reply = nullptr;
 
@@ -44,6 +44,7 @@ void RedisSelect::readData()
     {
         throw std::runtime_error("Unable to read redis reply");
     }
+    return 0;
 }
 
 bool RedisSelect::hasCachedData()

--- a/common/redisselect.h
+++ b/common/redisselect.h
@@ -15,7 +15,7 @@ public:
     RedisSelect(int pri = 0);
 
     int getFd() override;
-    void readData() override;
+    uint64_t readData() override;
     bool hasCachedData() override;
     bool initializedWithData() override;
     void updateAfterRead() override;

--- a/common/selectable.h
+++ b/common/selectable.h
@@ -21,7 +21,7 @@ public:
     virtual int getFd() = 0;
 
     /* Read all data from the fd assicaited with Selectable */
-    virtual void readData() = 0;
+    virtual uint64_t readData() = 0;
 
     /* true if Selectable has data in its cache */
     virtual bool hasCachedData()

--- a/common/selectableevent.cpp
+++ b/common/selectableevent.cpp
@@ -40,7 +40,7 @@ int SelectableEvent::getFd()
     return m_efd;
 }
 
-void SelectableEvent::readData()
+uint64_t SelectableEvent::readData()
 {
     uint64_t r;
 
@@ -56,6 +56,7 @@ void SelectableEvent::readData()
         SWSS_LOG_THROW("SelectableEvent read failed, s:%zd errno: %s",
                 s, strerror(errno));
     }
+    return 0;
 }
 
 void SelectableEvent::notify()

--- a/common/selectableevent.h
+++ b/common/selectableevent.h
@@ -18,7 +18,7 @@ public:
     void notify();
 
     int getFd() override;
-    void readData() override;
+    uint64_t readData() override;
 
 private:
     int m_efd;

--- a/common/selectabletimer.cpp
+++ b/common/selectabletimer.cpp
@@ -72,46 +72,23 @@ int SelectableTimer::getFd()
     return m_tfd;
 }
 
-void SelectableTimer::readData()
+uint64_t SelectableTimer::readData()
 {
-    uint64_t r = UINT64_MAX;
+    uint64_t cnt = 0;
 
-    ssize_t s;
+    ssize_t ret;
     errno = 0;
     do
     {
-        s = read(m_tfd, &r, sizeof(uint64_t));
+        ret = read(m_tfd, &cnt, sizeof(uint64_t));
     }
-    while(s == -1 && errno == EINTR);
+    while(ret == -1 && errno == EINTR);
 
-    if (s != sizeof(uint64_t)) {
-        /*
-         * By right or most likely s = 8 here.
-         * Else in failure case, s = -1 with errno != 0
-         * But due to a (HW influenced) Kernel bug, it could be s=0 & errno=0
-         *
-         * This bug has been observed in S6100 only.
-         * The bug incidence is pretty seldom.
-         *
-         * A short note on kernel bug:
-         *  timerfd_read, upon asserting that underlying hrtimer has triggered once,
-         *  calls hrtimer_forward_now, to get total count of expiries since timer start
-         *  to now, as read gets called asynchronously at a time later than the time
-         *  point of trigger.
-         *  The hrtimer_forward_now is expected to return >= 1, as it is certain
-         *  that one trigger/expiry is confirmed to have occurred.
-         *  But in the buggy case, the hrtimer_forward_now returned 0, that results
-         *  in read call to return 0.
-         *  
-         *  The behavior of read returning 0, with errno=0 is an unexpected behavior.
-         */
-        ABORT_IF_NOT(s == 0, "Failed to read timerfd. s=%ld", s);
+    ABORT_IF_NOT((ret == 0) || (ret == sizeof(uint64_t)), "Failed to read timerfd. ret=%zd", ret);
 
-        SWSS_LOG_ERROR("Benign failure to read from timerfd return=%zd Expect: %zd",
-                        s, sizeof(uint64_t));
-    }
-
-    // r = count of timer events happened since last read.
+    // cnt = count of timer events happened since last read.
+    return cnt;
 }
 
 }
+

--- a/common/selectabletimer.h
+++ b/common/selectabletimer.h
@@ -19,7 +19,7 @@ public:
     void setInterval(const timespec& interval);
 
     int getFd() override;
-    void readData() override;
+    uint64_t readData() override;
 
 private:
     int m_tfd;

--- a/common/subscriberstatetable.cpp
+++ b/common/subscriberstatetable.cpp
@@ -42,7 +42,7 @@ SubscriberStateTable::SubscriberStateTable(DBConnector *db, const string &tableN
     }
 }
 
-void SubscriberStateTable::readData()
+uint64_t SubscriberStateTable::readData()
 {
     redisReply *reply = nullptr;
 
@@ -79,6 +79,7 @@ void SubscriberStateTable::readData()
     {
         throw std::runtime_error("Unable to read redis reply");
     }
+    return 0;
 }
 
 bool SubscriberStateTable::hasCachedData()

--- a/common/subscriberstatetable.h
+++ b/common/subscriberstatetable.h
@@ -17,7 +17,7 @@ public:
     void pops(std::deque<KeyOpFieldsValuesTuple> &vkco, const std::string &prefix = EMPTY_PREFIX);
 
     /* Read keyspace event from redis */
-    void readData() override;
+    uint64_t readData() override;
     bool hasCachedData() override;
     bool initializedWithData() override
     {


### PR DESCRIPTION
Due to conflict, a separate PR Is created.

Ref: https://github.com/Azure/sonic-swss-common/pull/302