### PR TITLE
fix vs test, should NOT replace old DBConnector API with new DBConnector API at this moment

### DIFF
--- a/common/logger.cpp
+++ b/common/logger.cpp
@@ -91,7 +91,7 @@ void Logger::linkToDbWithOutput(const std::string &dbName, const PriorityChangeN
 
     // Initialize internal DB with observer
     logger.m_settingChangeObservers.insert(std::make_pair(dbName, std::make_pair(prioNotify, outputNotify)));
-    DBConnector db("LOGLEVEL_DB", 0);
+    DBConnector db(LOGLEVEL_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
     RedisClient redisClient(&db);
     auto keys = redisClient.keys("*");
 
@@ -169,7 +169,7 @@ Logger::Priority Logger::getMinPrio()
 [[ noreturn ]] void Logger::settingThread()
 {
     Select select;
-    DBConnector db("LOGLEVEL_DB", 0);
+    DBConnector db(LOGLEVEL_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
     std::vector<std::shared_ptr<ConsumerStateTable>> selectables(m_settingChangeObservers.size());
 
     for (const auto& i : m_settingChangeObservers)

--- a/common/loglevel.cpp
+++ b/common/loglevel.cpp
@@ -107,7 +107,7 @@ int main(int argc, char **argv)
         }
     }
 
-    DBConnector db("LOGLEVEL_DB", 0);
+    DBConnector db(LOGLEVEL_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
     RedisClient redisClient(&db);
     auto keys = redisClient.keys("*");
     for (auto& key : keys)


### PR DESCRIPTION
* Last multiDB commit, We tried to replace old DBConnector API with  new DBConnector API in logger/loglevel feature, this is fine on DUT  

* In vs Docker, it has no database_config.json file at /var/run/redis/sonic-db/, so all processes which are using logger/loglevel cannot connect to a DB, which cause VS test init failed

* the fix is to still use the old DBConnector API until the vs docker/testcase are modified based on the multiDB changes

* The lessons learnt :  please don't do the replacement between new API and old API at this moment, we need to add these new interfaces first and then do the vs test cases modification, and then do the replacement.

Below is vs test results:

dzhang@dzhang:~/MS_VS/sonic-buildimage/src/sonic-swss/tests$ sudo pytest -v
[sudo] password for dzhang: 
============================================================= test session starts ==============================================================
platform linux2 -- Python 2.7.15+, pytest-3.3.0, py-1.8.0, pluggy-0.6.0 -- /usr/bin/python
cachedir: .cache
rootdir: /home/dzhang/MS_VS/sonic-buildimage/src/sonic-swss/tests, inifile:
collected 169 items                                                                                                                            

test_acl.py::TestAcl::test_AclTableCreation PASSED                          [  0%]
test_acl.py::TestAcl::test_AclRuleL4SrcPort PASSED                          [  1%]
test_acl.py::TestAcl::test_AclRuleInOutPorts PASSED                         [  1%]
test_acl.py::TestAcl::test_AclTableDeletion PASSED                            [  2%]
test_acl.py::TestAcl::test_V6AclTableCreation PASSED                        [  2%]
test_acl.py::TestAcl::test_V6AclRuleIPv6Any PASSED                           [  3%]
test_acl.py::TestAcl::test_V6AclRuleIPv6AnyDrop PASSED                 [  4%]

...
...

test_watermark.py::TestWatermark::test_telemetry_period PASSED      [ 98%]
test_watermark.py::TestWatermark::test_lua_plugins SKIPPED               [ 99%]
test_watermark.py::TestWatermark::test_clear SKIPPED                           [100%]





Signed-off-by: Dong Zhang d.zhang@alibaba-inc.com   