### PR TITLE
Revert "[MultiDB]: apply new APIs in swss-common"

### DIFF
--- a/common/logger.cpp
+++ b/common/logger.cpp
@@ -91,7 +91,7 @@ void Logger::linkToDbWithOutput(const std::string &dbName, const PriorityChangeN
 
     // Initialize internal DB with observer
     logger.m_settingChangeObservers.insert(std::make_pair(dbName, std::make_pair(prioNotify, outputNotify)));
-    DBConnector db("LOGLEVEL_DB", 0);
+    DBConnector db(LOGLEVEL_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
     RedisClient redisClient(&db);
     auto keys = redisClient.keys("*");
 
@@ -169,7 +169,7 @@ Logger::Priority Logger::getMinPrio()
 [[ noreturn ]] void Logger::settingThread()
 {
     Select select;
-    DBConnector db("LOGLEVEL_DB", 0);
+    DBConnector db(LOGLEVEL_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
     std::vector<std::shared_ptr<ConsumerStateTable>> selectables(m_settingChangeObservers.size());
 
     for (const auto& i : m_settingChangeObservers)

--- a/common/loglevel.cpp
+++ b/common/loglevel.cpp
@@ -107,7 +107,7 @@ int main(int argc, char **argv)
         }
     }
 
-    DBConnector db("LOGLEVEL_DB", 0);
+    DBConnector db(LOGLEVEL_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
     RedisClient redisClient(&db);
     auto keys = redisClient.keys("*");
     for (auto& key : keys)


### PR DESCRIPTION
Reverts Azure/sonic-swss-common#316
sairedis is using logger.cpp, and it was broken in runtime.