### PR TITLE
[MultiDB]: install default db config file when installing libswsscommon if there is no such a file

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -7,7 +7,8 @@ EXTRA_DIST = \
     consumer_table_pops.lua \
     producer_state_table_apply_view.lua \
     table_dump.lua \
-    fdb_flush.lua
+    fdb_flush.lua \
+    database_config.json
 
 swssdir = $(datadir)/swss
 

--- a/common/database_config.json
+++ b/common/database_config.json
@@ -1,0 +1,57 @@
+{
+    "INSTANCES": {
+        "redis":{
+            "hostname" : "127.0.0.1",
+            "port" : 6379,
+            "unix_socket_path" : "/var/run/redis/redis.sock"
+        }
+    },
+    "DATABASES" : {
+        "APPL_DB" : {
+            "id" : 0,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "ASIC_DB" : {
+            "id" : 1,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "COUNTERS_DB" : {
+            "id" : 2,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "LOGLEVEL_DB" : {
+            "id" : 3,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "CONFIG_DB" : {
+            "id" : 4,
+            "separator": "|",
+            "instance" : "redis"
+        },
+        "PFC_WD_DB" : {
+            "id" : 5,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "FLEX_COUNTER_DB" : {
+            "id" : 5,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "STATE_DB" : {
+            "id" : 6,
+            "separator": "|",
+            "instance" : "redis"
+        },
+        "SNMP_OVERLAY_DB" : {
+            "id" : 7,
+            "separator": "|",
+            "instance" : "redis"
+        }
+    },
+    "VERSION" : "1.0"
+}

--- a/debian/libswsscommon.install
+++ b/debian/libswsscommon.install
@@ -1,3 +1,4 @@
 usr/lib/*/lib*.so.*
 usr/share/swss/*.lua
+usr/share/swss/*.json
 usr/bin/swssloglevel

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,0 +1,11 @@
+#!/bin/bash
+# This `DEBIAN/postinst` script is run post-installation
+DST_PATH="/var/run/redis/sonic-db"
+DST_FILE="database_config.json"
+SRC_PATH="/usr/share/swss"
+
+# if there is no $DST_FILE, it is needed to copy one default to $DST_FILE
+if [ ! -e $DST_PATH/$DST_FILE ]; then
+    mkdir -p $DST_PATH
+    cp $SRC_PATH/$DST_FILE $DST_PATH/$DST_FILE
+fi


### PR DESCRIPTION
* distribute  database_config.json into /var/run/redis/sonic-db/ when installing libswsscommon.deb in postinst script

Signed-off-by: Dong Zhang d.zhang@alibaba-inc.com