### PR TITLE
[MultiDB]:swsscommon replace old API with new APIs including tests

### DIFF
--- a/common/logger.cpp
+++ b/common/logger.cpp
@@ -91,7 +91,7 @@ void Logger::linkToDbWithOutput(const std::string &dbName, const PriorityChangeN
 
     // Initialize internal DB with observer
     logger.m_settingChangeObservers.insert(std::make_pair(dbName, std::make_pair(prioNotify, outputNotify)));
-    DBConnector db(LOGLEVEL_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
+    DBConnector db("LOGLEVEL_DB", 0);
     RedisClient redisClient(&db);
     auto keys = redisClient.keys("*");
 
@@ -169,7 +169,7 @@ Logger::Priority Logger::getMinPrio()
 [[ noreturn ]] void Logger::settingThread()
 {
     Select select;
-    DBConnector db(LOGLEVEL_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
+    DBConnector db("LOGLEVEL_DB", 0);
     std::vector<std::shared_ptr<ConsumerStateTable>> selectables(m_settingChangeObservers.size());
 
     for (const auto& i : m_settingChangeObservers)

--- a/common/loglevel.cpp
+++ b/common/loglevel.cpp
@@ -107,7 +107,7 @@ int main(int argc, char **argv)
         }
     }
 
-    DBConnector db(LOGLEVEL_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
+    DBConnector db("LOGLEVEL_DB", 0);
     RedisClient redisClient(&db);
     auto keys = redisClient.keys("*");
     for (auto& key : keys)

--- a/common/warm_restart.cpp
+++ b/common/warm_restart.cpp
@@ -32,8 +32,7 @@ WarmStart &WarmStart::getInstance(void)
 void WarmStart::initialize(const std::string &app_name,
                            const std::string &docker_name,
                            unsigned int db_timeout,
-                           const std::string &db_hostname,
-                           int db_port)
+                           bool isTcpConn)
 {
     auto& warmStart = getInstance();
 
@@ -43,20 +42,10 @@ void WarmStart::initialize(const std::string &app_name,
     }
 
     /* Use unix socket for db connection by default */
-    if(db_hostname.empty())
-    {
-        warmStart.m_stateDb =
-            std::make_shared<swss::DBConnector>(STATE_DB, swss::DBConnector::DEFAULT_UNIXSOCKET, db_timeout);
-        warmStart.m_cfgDb =
-            std::make_shared<swss::DBConnector>(CONFIG_DB, swss::DBConnector::DEFAULT_UNIXSOCKET, db_timeout);
-    }
-    else
-    {
-        warmStart.m_stateDb =
-            std::make_shared<swss::DBConnector>(STATE_DB, db_hostname, db_port, db_timeout);
-        warmStart.m_cfgDb =
-            std::make_shared<swss::DBConnector>(CONFIG_DB, db_hostname, db_port, db_timeout);
-    }
+    warmStart.m_stateDb =
+        std::make_shared<swss::DBConnector>("STATE_DB", db_timeout, isTcpConn);
+    warmStart.m_cfgDb =
+        std::make_shared<swss::DBConnector>("CONFIG_DB", db_timeout, isTcpConn);
 
     warmStart.m_stateWarmRestartEnableTable =
             std::unique_ptr<Table>(new Table(warmStart.m_stateDb.get(), STATE_WARM_RESTART_ENABLE_TABLE_NAME));

--- a/common/warm_restart.h
+++ b/common/warm_restart.h
@@ -43,8 +43,7 @@ public:
     static void initialize(const std::string &app_name,
                            const std::string &docker_name,
                            unsigned int db_timeout = 0,
-                           const std::string &db_hostname = "",
-                           int db_port = 6379);
+                           bool isTcpConn = false);
 
     static bool checkWarmStart(const std::string &app_name,
                                const std::string &docker_name,

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -26,7 +26,8 @@ tests_SOURCES = redis_ut.cpp                \
                 redis_subscriber_state_ut.cpp \
                 selectable_priority.cpp       \
                 warm_restart_ut.cpp         \
-                redis_multi_db_ut.cpp
+                redis_multi_db_ut.cpp       \
+                main.cpp
 
 tests_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(LIBNL_CFLAGS)
 tests_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(LIBNL_CFLAGS)

--- a/tests/json_ut.cpp
+++ b/tests/json_ut.cpp
@@ -6,13 +6,12 @@ using namespace std;
 using namespace swss;
 using json = nlohmann::json;
 
-#define TEST_DB         (15) // Default Redis config supports 16 databases, max DB ID is 15
 #define TEST_DUMP_FILE  "ut_dump_file.txt"
 
 TEST(JSON, test)
 {
     /* Construct the file */
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db("TEST_DB", 0, true);
     ProducerTable *p;
     p = new ProducerTable(&db, "UT_REDIS", TEST_DUMP_FILE);
     string separator = p->getTableNameSeparator();

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,0 +1,12 @@
+#include "gtest/gtest.h"
+
+int main(int argc, char* argv[])
+{
+  testing::InitGoogleTest(&argc, argv);
+  //run multiDB test first, which init the db config
+  ::testing::GTEST_FLAG(filter) = "DBConnector.multi_db_test";
+  EXPECT_EQ(RUN_ALL_TESTS(), 0);
+  //run all other test cases
+  ::testing::GTEST_FLAG(filter) = "*.*-DBConnector.multi_db_test";
+  return RUN_ALL_TESTS();
+}

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,12 +1,46 @@
 #include "gtest/gtest.h"
+#include "common/dbconnector.h"
+#include <iostream>
+
+using namespace std;
+using namespace swss;
+
+string existing_file = "./tests/redis_multi_db_ut_config/database_config.json";
+string nonexisting_file = "./tests/redis_multi_db_ut_config/database_config_nonexisting.json";
+
+class SwsscommonEnvironment : public ::testing::Environment {
+public:
+    // Override this to define how to set up the environment.
+    void SetUp() override {
+        // by default , init should be false
+        cout<<"Default : isInit = "<<SonicDBConfig::isInit()<<endl;
+        EXPECT_FALSE(SonicDBConfig::isInit());
+
+        // load nonexisting file, should throw exception with NO file existing
+        try
+        {
+            cout<<"INIT: loading nonexisting db config file"<<endl;
+            SonicDBConfig::initialize(nonexisting_file);
+        }
+        catch (exception &e)
+        {
+            EXPECT_TRUE(strstr(e.what(), "Sonic database config file doesn't exist"));
+        }
+        EXPECT_FALSE(SonicDBConfig::isInit());
+
+        // load local config file, init should be true
+        SonicDBConfig::initialize(existing_file);
+        cout<<"INIT: load local db config file, isInit = "<<SonicDBConfig::isInit()<<endl;
+        EXPECT_TRUE(SonicDBConfig::isInit());
+    }
+};
 
 int main(int argc, char* argv[])
 {
     testing::InitGoogleTest(&argc, argv);
-    //run multiDB test first, which init the db config
-    ::testing::GTEST_FLAG(filter) = "DBConnector.multi_db_test";
-    EXPECT_EQ(RUN_ALL_TESTS(), 0);
-    //run all other test cases
-    ::testing::GTEST_FLAG(filter) = "*.*-DBConnector.multi_db_test";
+    // Registers a global test environment, and verifies that the
+    // registration function returns its argument.
+    SwsscommonEnvironment* const env = new SwsscommonEnvironment;
+    testing::AddGlobalTestEnvironment(env);
     return RUN_ALL_TESTS();
 }

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -2,11 +2,11 @@
 
 int main(int argc, char* argv[])
 {
-  testing::InitGoogleTest(&argc, argv);
-  //run multiDB test first, which init the db config
-  ::testing::GTEST_FLAG(filter) = "DBConnector.multi_db_test";
-  EXPECT_EQ(RUN_ALL_TESTS(), 0);
-  //run all other test cases
-  ::testing::GTEST_FLAG(filter) = "*.*-DBConnector.multi_db_test";
-  return RUN_ALL_TESTS();
+    testing::InitGoogleTest(&argc, argv);
+    //run multiDB test first, which init the db config
+    ::testing::GTEST_FLAG(filter) = "DBConnector.multi_db_test";
+    EXPECT_EQ(RUN_ALL_TESTS(), 0);
+    //run all other test cases
+    ::testing::GTEST_FLAG(filter) = "*.*-DBConnector.multi_db_test";
+    return RUN_ALL_TESTS();
 }

--- a/tests/ntf_ut.cpp
+++ b/tests/ntf_ut.cpp
@@ -58,7 +58,7 @@ TEST(Notifications, test)
 {
     SWSS_LOG_ENTER();
 
-    swss::DBConnector dbNtf(ASIC_DB, "localhost", 6379, 0);
+    swss::DBConnector dbNtf("ASIC_DB", 0, true);
     swss::NotificationConsumer nc(&dbNtf, "NOTIFICATIONS");
     notification_thread = std::make_shared<std::thread>(std::thread(ntf_thread, std::ref(nc)));
 
@@ -81,7 +81,7 @@ TEST(Notifications, pops)
 {
     SWSS_LOG_ENTER();
 
-    swss::DBConnector dbNtf(ASIC_DB, "localhost", 6379, 0);
+    swss::DBConnector dbNtf("ASIC_DB", 0, true);
     swss::NotificationConsumer nc(&dbNtf, "NOTIFICATIONS", 100, (size_t)messages);
     swss::NotificationProducer notifications(&dbNtf, "NOTIFICATIONS");
 
@@ -125,7 +125,7 @@ TEST(Notifications, peek)
 {
     SWSS_LOG_ENTER();
 
-    swss::DBConnector dbNtf(ASIC_DB, "localhost", 6379, 0);
+    swss::DBConnector dbNtf("ASIC_DB", 0, true);
     swss::NotificationConsumer nc(&dbNtf, "NOTIFICATIONS", 100, (size_t)10);
     swss::NotificationProducer notifications(&dbNtf, "NOTIFICATIONS");
 

--- a/tests/redis_multi_db_ut.cpp
+++ b/tests/redis_multi_db_ut.cpp
@@ -9,39 +9,15 @@ using namespace std;
 using namespace swss;
 using json = nlohmann::json;
 
+extern string existing_file;
 
 TEST(DBConnector, multi_db_test)
 {
-    string file = "./tests/redis_multi_db_ut_config/database_config.json";
-    string nonexisting_file = "./tests/redis_multi_db_ut_config/database_config_nonexisting.json";
-
-    // by default , init should be false
-    cout<<"Default : isInit = "<<SonicDBConfig::isInit()<<endl;
-    EXPECT_FALSE(SonicDBConfig::isInit());
-
-
-    // load nonexisting file, should throw exception with NO file existing
-    try
-    {
-        cout<<"INIT: loading nonexisting db config file"<<endl;
-        SonicDBConfig::initialize(nonexisting_file);
-    }
-    catch (exception &e)
-    {
-        EXPECT_TRUE(strstr(e.what(), "Sonic database config file doesn't exist"));
-    }
-    EXPECT_FALSE(SonicDBConfig::isInit());
-
-    // load local config file, init should be true
-    SonicDBConfig::initialize(file);
-    cout<<"INIT: load local db config file, isInit = "<<SonicDBConfig::isInit()<<endl;
-    EXPECT_TRUE(SonicDBConfig::isInit());
-
     // load local config file again, should throw exception with init already done
     try
     {
         cout<<"INIT: loading local config file again"<<endl;
-        SonicDBConfig::initialize(file);
+        SonicDBConfig::initialize(existing_file);
     }
     catch (exception &e)
     {
@@ -65,7 +41,7 @@ TEST(DBConnector, multi_db_test)
     EXPECT_THROW(SonicDBConfig::getDbPort("INVALID_DBNAME"), out_of_range);
 
     // parse config file
-    ifstream i(file);
+    ifstream i(existing_file);
     if (i.good())
     {
         json j;

--- a/tests/redis_multi_db_ut_config/database_config.json
+++ b/tests/redis_multi_db_ut_config/database_config.json
@@ -29,39 +29,53 @@
     "DATABASES" : {
         "APPL_DB" : {
             "id" : 0,
+            "separator": ":",
             "instance" : "redis"
         },
         "ASIC_DB" : {
             "id" : 1,
-            "instance" : "redis1"
+            "separator": ":",
+            "instance" : "redis"
         },
         "COUNTERS_DB" : {
             "id" : 2,
-            "instance" : "redis1"
+            "separator": ":",
+            "instance" : "redis"
         },
         "LOGLEVEL_DB" : {
             "id" : 3,
-            "instance" : "redis2"
+            "separator": ":",
+            "instance" : "redis"
         },
         "CONFIG_DB" : {
             "id" : 4,
-            "instance" : "redis2"
+            "separator": "|",
+            "instance" : "redis"
         },
         "PFC_WD_DB" : {
             "id" : 5,
-            "instance" : "redis3"
+            "separator": ":",
+            "instance" : "redis"
         },
         "FLEX_COUNTER_DB" : {
             "id" : 5,
-            "instance" : "redis3"
+            "separator": ":",
+            "instance" : "redis"
         },
         "STATE_DB" : {
             "id" : 6,
-            "instance" : "redis4"
+            "separator": "|",
+            "instance" : "redis"
         },
         "SNMP_OVERLAY_DB" : {
             "id" : 7,
-            "instance" : "redis4"
+            "separator": "|",
+            "instance" : "redis"
+        },
+        "TEST_DB" : {
+            "id" : 15,
+            "separator": ":",
+            "instance" : "redis"
         }
     },
     "VERSION" : "1.0"

--- a/tests/redis_piped_state_ut.cpp
+++ b/tests/redis_piped_state_ut.cpp
@@ -16,7 +16,7 @@
 using namespace std;
 using namespace swss;
 
-#define TEST_DB           APPL_DB // Need to test against a DB which uses a colon table name separator due to hardcoding in consumer_table_pops.lua
+#define TEST_DB           "APPL_DB" // Need to test against a DB which uses a colon table name separator due to hardcoding in consumer_table_pops.lua
 #define NUMBER_OF_THREADS    (64) // Spawning more than 256 threads causes libc++ to except
 #define NUMBER_OF_OPS      (1000)
 #define MAX_FIELDS_DIV       (30) // Testing up to 30 fields objects
@@ -76,7 +76,7 @@ static inline void validateFields(const string& key, const vector<FieldValueTupl
 static void producerWorker(int index)
 {
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, 0, true);
     RedisPipeline pipeline(&db);
     ProducerStateTable p(&pipeline, tableName, true);
 
@@ -104,7 +104,7 @@ static void producerWorker(int index)
 static void consumerWorker(int index)
 {
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, 0, true);
     ConsumerStateTable c(&db, tableName);
     Select cs;
     Selectable *selectcs;
@@ -139,7 +139,7 @@ static void consumerWorker(int index)
 
 static inline void clearDB()
 {
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, 0, true);
     RedisReply r(&db, "FLUSHALL", REDIS_REPLY_STATUS);
     r.checkStatusOK();
 }
@@ -151,7 +151,7 @@ TEST(ConsumerStateTable, async_double_set)
     /* Prepare producer */
     int index = 0;
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, 0, true);
     RedisPipeline pipeline(&db);
     ProducerStateTable p(&pipeline, tableName, true);
     string key = "TheKey";
@@ -228,7 +228,7 @@ TEST(ConsumerStateTable, async_set_del)
     /* Prepare producer */
     int index = 0;
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, 0, true);
     RedisPipeline pipeline(&db);
     ProducerStateTable p(&pipeline, tableName, true);
     string key = "TheKey";
@@ -282,7 +282,7 @@ TEST(ConsumerStateTable, async_set_del_set)
     /* Prepare producer */
     int index = 0;
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, 0, true);
     RedisPipeline pipeline(&db);
     ProducerStateTable p(&pipeline, tableName, true);
     string key = "TheKey";
@@ -357,7 +357,7 @@ TEST(ConsumerStateTable, async_singlethread)
 
     int index = 0;
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, 0, true);
     RedisPipeline pipeline(&db);
     ProducerStateTable p(&pipeline, tableName, true);
 
@@ -521,7 +521,7 @@ TEST(ConsumerStateTable, async_test)
 
 TEST(ConsumerStateTable, async_multitable)
 {
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, 0, true);
     ConsumerStateTable *consumers[NUMBER_OF_THREADS];
     thread *producerThreads[NUMBER_OF_THREADS];
     KeyOpFieldsValuesTuple kco;

--- a/tests/redis_piped_ut.cpp
+++ b/tests/redis_piped_ut.cpp
@@ -15,7 +15,6 @@
 using namespace std;
 using namespace swss;
 
-#define TEST_DB             (15) // Default Redis config supports 16 databases, max DB ID is 15
 #define NUMBER_OF_THREADS   (64) // Spawning more than 256 threads causes libc++ to except
 #define NUMBER_OF_OPS     (1000)
 #define MAX_FIELDS_DIV      (30) // Testing up to 30 fields objects
@@ -73,7 +72,7 @@ static void validateFields(const string& key, const vector<FieldValueTuple>& f)
 static void producerWorker(int index)
 {
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db("TEST_DB", 0, true);
     RedisPipeline pipeline(&db);
     ProducerTable p(&pipeline, tableName, true);
 
@@ -102,7 +101,7 @@ static void producerWorker(int index)
 static void consumerWorker(int index)
 {
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db("TEST_DB", 0, true);
     ConsumerTable c(&db, tableName);
     Select cs;
     Selectable *selectcs;
@@ -137,7 +136,7 @@ static void consumerWorker(int index)
 
 static void clearDB()
 {
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db("TEST_DB", 0, true);
     RedisReply r(&db, "FLUSHALL", REDIS_REPLY_STATUS);
     r.checkStatusOK();
 }
@@ -171,7 +170,7 @@ TEST(DBConnector, piped_test)
 
 TEST(DBConnector, piped_multitable)
 {
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db("TEST_DB", 0, true);
     ConsumerTable *consumers[NUMBER_OF_THREADS];
     thread *producerThreads[NUMBER_OF_THREADS];
     KeyOpFieldsValuesTuple kco;
@@ -235,7 +234,7 @@ static void notificationProducer()
 {
     sleep(1);
 
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db("TEST_DB", 0, true);
     NotificationProducer np(&db, "UT_REDIS_CHANNEL");
 
     vector<FieldValueTuple> values;
@@ -248,7 +247,7 @@ static void notificationProducer()
 
 TEST(DBConnector, piped_notifications)
 {
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db("TEST_DB", 0, true);
     NotificationConsumer nc(&db, "UT_REDIS_CHANNEL");
     Select s;
     s.addSelectable(&nc);
@@ -322,7 +321,7 @@ TEST(DBConnector, piped_selectableevent)
 TEST(Table, piped_test)
 {
     string tableName = "TABLE_UT_TEST";
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db("TEST_DB", 0, true);
     RedisPipeline pipeline(&db);
     Table t(&pipeline, tableName, true);
 
@@ -415,7 +414,7 @@ TEST(ProducerConsumer, piped_Prefix)
 {
     string tableName = "tableName";
 
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db("TEST_DB", 0, true);
     RedisPipeline pipeline(&db);
     ProducerTable p(&pipeline, tableName, true);
 

--- a/tests/redis_state_ut.cpp
+++ b/tests/redis_state_ut.cpp
@@ -16,7 +16,7 @@
 using namespace std;
 using namespace swss;
 
-#define TEST_DB           APPL_DB // Need to test against a DB which uses a colon table name separator due to hardcoding in consumer_table_pops.lua
+#define TEST_DB           "APPL_DB" // Need to test against a DB which uses a colon table name separator due to hardcoding in consumer_table_pops.lua
 #define NUMBER_OF_THREADS    (64) // Spawning more than 256 threads causes libc++ to except
 #define NUMBER_OF_OPS      (1000)
 #define MAX_FIELDS_DIV       (30) // Testing up to 30 fields objects
@@ -76,7 +76,7 @@ static inline void validateFields(const string& key, const vector<FieldValueTupl
 static void producerWorker(int index)
 {
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, 0, true);
     ProducerStateTable p(&db, tableName);
 
     for (int i = 0; i < NUMBER_OF_OPS; i++)
@@ -103,7 +103,7 @@ static void producerWorker(int index)
 static void consumerWorker(int index)
 {
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, 0, true);
     RedisClient redisClient(&db);
     ConsumerStateTable c(&db, tableName);
     Select cs;
@@ -147,7 +147,7 @@ static void consumerWorker(int index)
 
 static inline void clearDB()
 {
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, 0, true);
     RedisReply r(&db, "FLUSHALL", REDIS_REPLY_STATUS);
     r.checkStatusOK();
 }
@@ -159,7 +159,7 @@ TEST(ConsumerStateTable, double_set)
     /* Prepare producer */
     int index = 0;
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, 0, true);
     ProducerStateTable p(&db, tableName);
     string key = "TheKey";
     int maxNumOfFields = 2;
@@ -241,7 +241,7 @@ TEST(ConsumerStateTable, set_del)
     /* Prepare producer */
     int index = 0;
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, 0, true);
     ProducerStateTable p(&db, tableName);
     string key = "TheKey";
     int maxNumOfFields = 2;
@@ -300,7 +300,7 @@ TEST(ConsumerStateTable, set_del_set)
     /* Prepare producer */
     int index = 0;
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, 0, true);
     ProducerStateTable p(&db, tableName);
     string key = "TheKey";
     int maxNumOfFields = 2;
@@ -381,7 +381,7 @@ TEST(ConsumerStateTable, set_pop_del_set_pop_get)
     /* Prepare producer */
     int index = 0;
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, 0, true);
     ProducerStateTable p(&db, tableName);
     string key = "TheKey";
     int maxNumOfFields = 2;
@@ -518,7 +518,7 @@ TEST(ConsumerStateTable, view_switch)
     // Prepare producer
     int index = 0;
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, 0, true);
     ProducerStateTable p(&db, tableName);
     Table table(&db, tableName);
 
@@ -646,7 +646,7 @@ TEST(ConsumerStateTable, view_switch_abnormal_sequence)
     // Prepare producer
     int index = 0;
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, 0, true);
     ProducerStateTable p(&db, tableName);
     Table table(&db, tableName);
 
@@ -700,7 +700,7 @@ TEST(ConsumerStateTable, view_switch_with_consumer)
     // Prepare producer
     int index = 0;
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, 0, true);
     ProducerStateTable p(&db, tableName);
     Table table(&db, tableName);
 
@@ -796,7 +796,7 @@ TEST(ConsumerStateTable, view_switch_delete_with_consumer)
     // Prepare producer
     int index = 0;
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, 0, true);
     ProducerStateTable p(&db, tableName);
     Table table(&db, tableName);
 
@@ -878,7 +878,7 @@ TEST(ConsumerStateTable, view_switch_delete_with_consumer_2)
     // Prepare producer
     int index = 0;
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, 0, true);
     ProducerStateTable p(&db, tableName);
     Table table(&db, tableName);
 
@@ -961,7 +961,7 @@ TEST(ConsumerStateTable, singlethread)
 
     int index = 0;
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, 0, true);
     ProducerStateTable p(&db, tableName);
 
     for (int i = 0; i < NUMBER_OF_OPS; i++)
@@ -1067,7 +1067,7 @@ TEST(ConsumerStateTable, test)
 
 TEST(ConsumerStateTable, multitable)
 {
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db(TEST_DB, 0, true);
     ConsumerStateTable *consumers[NUMBER_OF_THREADS];
     vector<string> tablenames(NUMBER_OF_THREADS);
     thread *producerThreads[NUMBER_OF_THREADS];

--- a/tests/redis_subscriber_state_ut.cpp
+++ b/tests/redis_subscriber_state_ut.cpp
@@ -12,14 +12,11 @@
 using namespace std;
 using namespace swss;
 
-#define TEST_DB             (15) // Default Redis config supports 16 databases, max DB ID is 15
 #define NUMBER_OF_THREADS   (64) // Spawning more than 256 threads causes libc++ to except
 #define NUMBER_OF_OPS     (1000)
 #define MAX_FIELDS_DIV      (30) // Testing up to 30 fields objects
 #define PRINT_SKIP          (10) // Print + for Producer and - for Subscriber for every 100 ops
 
-static const string dbhost = "localhost";
-static const int dbport = 6379;
 static const string testTableName = "UT_REDIS_TABLE";
 static const string testTableName2 = "UT_REDIS_TABLE2";
 
@@ -88,14 +85,14 @@ static inline void validateFields(const string& key, const vector<FieldValueTupl
 
 static inline void clearDB()
 {
-    DBConnector db(TEST_DB, dbhost, dbport, 0);
+    DBConnector db("TEST_DB", 0, true);
     RedisReply r(&db, "FLUSHALL", REDIS_REPLY_STATUS);
     r.checkStatusOK();
 }
 
 static void producerWorker(int index)
 {
-    DBConnector db(TEST_DB, dbhost, dbport, 0);
+    DBConnector db("TEST_DB", 0, true);
     Table p(&db, testTableName);
 
     for (int i = 0; i < NUMBER_OF_OPS; i++)
@@ -125,7 +122,7 @@ static void producerWorker(int index)
 
 static void subscriberWorker(int index, int *status)
 {
-    DBConnector db(TEST_DB, dbhost, dbport, 0);
+    DBConnector db("TEST_DB", 0, true);
     SubscriberStateTable c(&db, testTableName);
     Select cs;
     Selectable *selectcs;
@@ -178,7 +175,7 @@ TEST(SubscriberStateTable, set)
 
     /* Prepare producer */
     int index = 0;
-    DBConnector db(TEST_DB, dbhost, dbport, 0);
+    DBConnector db("TEST_DB", 0, true);
     Table p(&db, testTableName);
     string key = "TheKey";
     int maxNumOfFields = 2;
@@ -231,7 +228,7 @@ TEST(SubscriberStateTable, pops_intial)
 
     /* Prepare producer */
     int index = 0;
-    DBConnector db(TEST_DB, dbhost, dbport, 0);
+    DBConnector db("TEST_DB", 0, true);
     Table p(&db, testTableName);
     string key = "TheKey";
     int maxNumOfFields = 2;
@@ -287,7 +284,7 @@ TEST(SubscriberStateTable, del)
 
     /* Prepare producer */
     int index = 0;
-    DBConnector db(TEST_DB, dbhost, dbport, 0);
+    DBConnector db("TEST_DB", 0, true);
     Table p(&db, testTableName);
     string key = "TheKey";
     int maxNumOfFields = 2;
@@ -338,7 +335,7 @@ TEST(SubscriberStateTable, table_state)
 
     /* Prepare producer */
     int index = 0;
-    DBConnector db(TEST_DB, dbhost, dbport, 0);
+    DBConnector db("TEST_DB", 0, true);
     Table p(&db, testTableName);
 
     for (int i = 0; i < NUMBER_OF_OPS; i++)
@@ -440,7 +437,7 @@ TEST(SubscriberStateTable, cachedData)
     int index = 0;
     int maxNumOfFields = 2;
 
-    DBConnector db(TEST_DB, dbhost, dbport, 0);
+    DBConnector db("TEST_DB", 0, true);
     Table p(&db, testTableName);
     string key1 = "TheKey1";
     /* Set operation */

--- a/tests/redis_ut.cpp
+++ b/tests/redis_ut.cpp
@@ -17,7 +17,6 @@
 using namespace std;
 using namespace swss;
 
-#define TEST_DB             (15) // Default Redis config supports 16 databases, max DB ID is 15
 #define NUMBER_OF_THREADS   (64) // Spawning more than 256 threads causes libc++ to except
 #define NUMBER_OF_OPS     (1000)
 #define MAX_FIELDS_DIV      (30) // Testing up to 30 fields objects
@@ -75,7 +74,7 @@ void validateFields(const string& key, const vector<FieldValueTuple>& f)
 void producerWorker(int index)
 {
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db("TEST_DB", 0, true);
     ProducerTable p(&db, tableName);
 
     for (int i = 0; i < NUMBER_OF_OPS; i++)
@@ -103,7 +102,7 @@ void producerWorker(int index)
 void consumerWorker(int index)
 {
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db("TEST_DB", 0, true);
     ConsumerTable c(&db, tableName);
     Select cs;
     Selectable *selectcs;
@@ -138,14 +137,14 @@ void consumerWorker(int index)
 
 void clearDB()
 {
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db("TEST_DB", 0, true);
     RedisReply r(&db, "FLUSHALL", REDIS_REPLY_STATUS);
     r.checkStatusOK();
 }
 
 void TableBasicTest(string tableName)
 {
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db("TEST_DB", 0, true);
 
     Table t(&db, tableName);
 
@@ -272,7 +271,7 @@ void TableBasicTest(string tableName)
 
 TEST(DBConnector, RedisClient)
 {
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db("TEST_DB", 0, true);
 
     RedisClient redic(&db);
 
@@ -441,7 +440,7 @@ TEST(DBConnector, test)
 
 TEST(DBConnector, multitable)
 {
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db("TEST_DB", 0, true);
     ConsumerTable *consumers[NUMBER_OF_THREADS];
     thread *producerThreads[NUMBER_OF_THREADS];
     KeyOpFieldsValuesTuple kco;
@@ -505,7 +504,7 @@ void notificationProducer()
 {
     sleep(1);
 
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db("TEST_DB", 0, true);
     NotificationProducer np(&db, "UT_REDIS_CHANNEL");
 
     vector<FieldValueTuple> values;
@@ -518,7 +517,7 @@ void notificationProducer()
 
 TEST(DBConnector, notifications)
 {
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db("TEST_DB", 0, true);
     NotificationConsumer nc(&db, "UT_REDIS_CHANNEL");
     Select s;
     s.addSelectable(&nc);
@@ -646,7 +645,7 @@ TEST(ProducerConsumer, Prefix)
 {
     std::string tableName = "tableName";
 
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db("TEST_DB", 0, true);
     ProducerTable p(&db, tableName);
 
     std::vector<FieldValueTuple> values;
@@ -675,7 +674,7 @@ TEST(ProducerConsumer, Pop)
 {
     std::string tableName = "tableName";
 
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db("TEST_DB", 0, true);
     ProducerTable p(&db, tableName);
 
     std::vector<FieldValueTuple> values;
@@ -703,7 +702,7 @@ TEST(ProducerConsumer, Pop2)
 {
     std::string tableName = "tableName";
 
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db("TEST_DB", 0, true);
     ProducerTable p(&db, tableName);
 
     std::vector<FieldValueTuple> values;
@@ -742,7 +741,7 @@ TEST(ProducerConsumer, PopEmpty)
 {
     std::string tableName = "tableName";
 
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db("TEST_DB", 0, true);
 
     ConsumerTable c(&db, tableName);
 
@@ -762,7 +761,7 @@ TEST(ProducerConsumer, ConsumerSelectWithInitData)
     clearDB();
 
     string tableName = "tableName";
-    DBConnector db(TEST_DB, "localhost", 6379, 0);
+    DBConnector db("TEST_DB", 0, true);
     ProducerTable p(&db, tableName);
 
     for (int i = 0; i < NUMBER_OF_OPS; i++)

--- a/tests/selectable_priority.cpp
+++ b/tests/selectable_priority.cpp
@@ -14,7 +14,6 @@ using namespace std;
 using namespace swss;
 
 
-#define TEST_VIEW            (7)
 #define DEFAULT_POP_BATCH_SIZE (10)
 
 
@@ -22,7 +21,7 @@ TEST(Priority, default_pri_values)
 {
     std::string tableName = "tableName";
 
-    DBConnector db(TEST_VIEW, "localhost", 6379, 0);
+    DBConnector db("TEST_DB", 0, true);
 
     timespec interval = { .tv_sec = 1, .tv_nsec = 0 };
 
@@ -49,7 +48,7 @@ TEST(Priority, set_pri_values)
 {
     std::string tableName = "tableName";
 
-    DBConnector db(TEST_VIEW, "localhost", 6379, 0);
+    DBConnector db("TEST_DB", 0, true);
 
     timespec interval = { .tv_sec = 1, .tv_nsec = 0 };
 

--- a/tests/test_redis_ut.py
+++ b/tests/test_redis_ut.py
@@ -1,7 +1,7 @@
 from swsscommon import swsscommon
 
 def test_ProducerTable():
-    db = swsscommon.DBConnector(0, "localhost", 6379, 0)
+    db = swsscommon.DBConnector("APPL_DB", 0, True)
     ps = swsscommon.ProducerTable(db, "abc")
     cs = swsscommon.ConsumerTable(db, "abc")
     fvs = swsscommon.FieldValuePairs([('a','b')])
@@ -13,7 +13,7 @@ def test_ProducerTable():
     assert cfvs[0] == ('a', 'b')
 
 def test_ProducerStateTable():
-    db = swsscommon.DBConnector(0, "localhost", 6379, 0)
+    db = swsscommon.DBConnector("APPL_DB", 0, True)
     ps = swsscommon.ProducerStateTable(db, "abc")
     cs = swsscommon.ConsumerStateTable(db, "abc")
     fvs = swsscommon.FieldValuePairs([('a','b')])
@@ -25,7 +25,7 @@ def test_ProducerStateTable():
     assert cfvs[0] == ('a', 'b')
 
 def test_Table():
-    db = swsscommon.DBConnector(0, "localhost", 6379, 0)
+    db = swsscommon.DBConnector("APPL_DB", 0, True)
     tbl = swsscommon.Table(db, "test_TABLE")
     fvs = swsscommon.FieldValuePairs([('a','b'), ('c', 'd')])
     tbl.set("aaa", fvs)
@@ -39,7 +39,7 @@ def test_Table():
     assert fvs[1] == ('c', 'd')
 
 def test_SubscriberStateTable():
-    db = swsscommon.DBConnector(0, "localhost", 6379, 0)
+    db = swsscommon.DBConnector("APPL_DB", 0, True)
     t = swsscommon.Table(db, "testsst")
     sel = swsscommon.Select()
     cst = swsscommon.SubscriberStateTable(db, "testsst")
@@ -55,7 +55,7 @@ def test_SubscriberStateTable():
     assert cfvs[0] == ('a', 'b')
 
 def test_Notification():
-    db = swsscommon.DBConnector(0, "localhost", 6379, 0)
+    db = swsscommon.DBConnector("APPL_DB", 0, True)
     ntfc = swsscommon.NotificationConsumer(db, "testntf")
     sel = swsscommon.Select()
     sel.addSelectable(ntfc)

--- a/tests/warm_restart_ut.cpp
+++ b/tests/warm_restart_ut.cpp
@@ -13,11 +13,11 @@ static const string testDockerName = "TestDocker";
 
 TEST(WarmRestart, checkWarmStart_and_State)
 {
-    DBConnector stateDb(STATE_DB, "localhost", 6379, 0);
+    DBConnector stateDb("STATE_DB", 0, true);
     Table stateWarmRestartTable(&stateDb, STATE_WARM_RESTART_TABLE_NAME);
     Table stateWarmRestartEnableTable(&stateDb, STATE_WARM_RESTART_ENABLE_TABLE_NAME);
 
-    DBConnector configDb(CONFIG_DB, "localhost", 6379, 0);
+    DBConnector configDb("CONFIG_DB", 0, true);
     Table cfgWarmRestartTable(&configDb, CFG_WARM_RESTART_TABLE_NAME);
 
     //Clean up warm restart state for testAppName and warm restart config for testDockerName
@@ -26,7 +26,7 @@ TEST(WarmRestart, checkWarmStart_and_State)
 
 
     //Initialize WarmStart class for TestApp
-    WarmStart::initialize(testAppName, testDockerName, 0, "localhost", 6379);
+    WarmStart::initialize(testAppName, testDockerName, 0, true);
 
     // Application is supposed to set the warm start state explicitly based on
     // its progress of state restore.
@@ -140,11 +140,11 @@ TEST(WarmRestart, checkWarmStart_and_State)
 
 TEST(WarmRestart, getWarmStartTimer)
 {
-    DBConnector configDb(CONFIG_DB, "localhost", 6379, 0);
+    DBConnector configDb("CONFIG_DB", 0, true);
     Table cfgWarmRestartTable(&configDb, CFG_WARM_RESTART_TABLE_NAME);
 
     //Initialize WarmStart class for TestApp
-    WarmStart::initialize(testAppName, testDockerName, 0, "localhost", 6379);
+    WarmStart::initialize(testAppName, testDockerName, 0, true);
 
     uint32_t timer;
     // By default, no default warm start timer exists in configDB for any application
@@ -162,14 +162,14 @@ TEST(WarmRestart, getWarmStartTimer)
 
 TEST(WarmRestart, set_get_DataCheckState)
 {
-    DBConnector stateDb(STATE_DB, "localhost", 6379, 0);
+    DBConnector stateDb("STATE_DB", 0, true);
     Table stateWarmRestartTable(&stateDb, STATE_WARM_RESTART_TABLE_NAME);
 
     //Clean up warm restart state for testAppName
     stateWarmRestartTable.del(testAppName);
 
     //Initialize WarmStart class for TestApp
-    WarmStart::initialize(testAppName, testDockerName, 0, "localhost", 6379);
+    WarmStart::initialize(testAppName, testDockerName, 0, true);
 
     WarmStart::DataCheckState state;
     // basic state set check for shutdown stage


### PR DESCRIPTION
* replacing swsscommon old APIs with new APIs, including logger, WarmStart and Unit tests
    * redisign WarmStart::init() signature, reuse new DBConnector API flag to choose SOCKET or TCP connection.
    * unit test adding main() entry function to run multiDB tests first which will init all the db config data once, all other tests will reuse these data.
* update db config file to the latest version which include the separator.
* VS tests all passed.
* swsscommon UT all passed. 

Signed-off-by: Dong Zhang d.zhang@alibaba-inc.com