### PR TITLE
[DBConnector] Add methods to set/get Redis client name

### DIFF
--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -224,8 +224,20 @@ string DBConnector::getClientName()
 {
     string command("CLIENT GETNAME");
 
-    RedisReply r(this, command, REDIS_REPLY_STATUS);
-    return r.getReply<std::string>();
+    RedisReply r(this, command);
+
+    auto ctx = r.getContext();
+    if (ctx->type == REDIS_REPLY_STRING)
+    {
+        return r.getReply<std::string>();
+    }
+    else
+    {
+        if (ctx->type != REDIS_REPLY_NIL)
+            SWSS_LOG_ERROR("DBConnector::getClientName(): Unable to obtain client name");
+
+        return "";
+    }
 }
 
 }

--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -234,7 +234,7 @@ string DBConnector::getClientName()
     else
     {
         if (ctx->type != REDIS_REPLY_NIL)
-            SWSS_LOG_ERROR("DBConnector::getClientName(): Unable to obtain client name");
+            SWSS_LOG_ERROR("Unable to obtain Redis client name");
 
         return "";
     }

--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -211,4 +211,21 @@ DBConnector *DBConnector::newConnector(unsigned int timeout) const
                                timeout);
 }
 
+void DBConnector::setClientName(const string& clientName)
+{
+    string command("CLIENT SETNAME ");
+    command += clientName;
+
+    RedisReply r(this, command, REDIS_REPLY_STATUS);
+    r.checkStatusOK();
+}
+
+string DBConnector::getClientName()
+{
+    string command("CLIENT GETNAME");
+
+    RedisReply r(this, command, REDIS_REPLY_STATUS);
+    return r.getReply<std::string>();
+}
+
 }

--- a/common/dbconnector.h
+++ b/common/dbconnector.h
@@ -56,6 +56,14 @@ public:
     /* Create new context to DB */
     DBConnector *newConnector(unsigned int timeout) const;
 
+    /*
+     * Assign a name to the Redis client used for this connection
+     * This is helpful when debugging Redis clients using `redis-cli client list`
+     */
+    void setClientName(const string& clientName);
+
+    std::string getClientName();
+
 private:
     redisContext *m_conn;
     int m_dbId;

--- a/common/dbconnector.h
+++ b/common/dbconnector.h
@@ -60,7 +60,7 @@ public:
      * Assign a name to the Redis client used for this connection
      * This is helpful when debugging Redis clients using `redis-cli client list`
      */
-    void setClientName(const string& clientName);
+    void setClientName(const std::string& clientName);
 
     std::string getClientName();
 

--- a/tests/redis_ut.cpp
+++ b/tests/redis_ut.cpp
@@ -269,6 +269,27 @@ void TableBasicTest(string tableName)
     cout << "Done." << endl;
 }
 
+TEST(DBConnector, ClientName)
+{
+    DBConnector db("TEST_DB", 0, true);
+
+    RedisReply r1(&db, "CLIENT GETNAME", REDIS_REPLY_STATUS);
+    r1.checkStatus("");
+    EXPECT_EQ(db.getClientName(), "");
+
+    string client_name = "test_client_1";
+    db.setClientName(client_name);
+    RedisReply r2(&db, "CLIENT GETNAME", REDIS_REPLY_STATUS);
+    r2.checkStatus(client_name.c_str());
+    EXPECT_EQ(db.getClientName(), client_name);
+
+    client_name = "test_client_2";
+    db.setClientName(client_name);
+    RedisReply r3(&db, "CLIENT GETNAME", REDIS_REPLY_STATUS);
+    r3.checkStatus(client_name.c_str());
+    EXPECT_EQ(db.getClientName(), client_name);
+}
+
 TEST(DBConnector, RedisClient)
 {
     DBConnector db("TEST_DB", 0, true);

--- a/tests/redis_ut.cpp
+++ b/tests/redis_ut.cpp
@@ -269,21 +269,28 @@ void TableBasicTest(string tableName)
     cout << "Done." << endl;
 }
 
-TEST(DBConnector, ClientName)
+TEST(DBConnector, RedisClientName)
 {
     DBConnector db("TEST_DB", 0, true);
 
-    //EXPECT_EQ(db.getClientName(), "");
+    string client_name = "";
+    sleep(1);
+    EXPECT_EQ(db.getClientName(), client_name);
 
-    string client_name = "test_client_1";
+    client_name = "foo";
     db.setClientName(client_name);
     sleep(1);
-    //EXPECT_EQ(db.getClientName(), client_name);
+    EXPECT_EQ(db.getClientName(), client_name);
 
-    client_name = "test_client_2";
+    client_name = "bar";
     db.setClientName(client_name);
     sleep(1);
-    //EXPECT_EQ(db.getClientName(), client_name);
+    EXPECT_EQ(db.getClientName(), client_name);
+
+    client_name = "foobar";
+    db.setClientName(client_name);
+    sleep(1);
+    EXPECT_EQ(db.getClientName(), client_name);
 }
 
 TEST(DBConnector, RedisClient)

--- a/tests/redis_ut.cpp
+++ b/tests/redis_ut.cpp
@@ -273,15 +273,17 @@ TEST(DBConnector, ClientName)
 {
     DBConnector db("TEST_DB", 0, true);
 
-    EXPECT_EQ(db.getClientName(), "");
+    //EXPECT_EQ(db.getClientName(), "");
 
     string client_name = "test_client_1";
     db.setClientName(client_name);
-    EXPECT_EQ(db.getClientName(), client_name);
+    sleep(1);
+    //EXPECT_EQ(db.getClientName(), client_name);
 
     client_name = "test_client_2";
     db.setClientName(client_name);
-    EXPECT_EQ(db.getClientName(), client_name);
+    sleep(1);
+    //EXPECT_EQ(db.getClientName(), client_name);
 }
 
 TEST(DBConnector, RedisClient)

--- a/tests/redis_ut.cpp
+++ b/tests/redis_ut.cpp
@@ -273,20 +273,14 @@ TEST(DBConnector, ClientName)
 {
     DBConnector db("TEST_DB", 0, true);
 
-    RedisReply r1(&db, "CLIENT GETNAME", REDIS_REPLY_STATUS);
-    r1.checkStatus("");
     EXPECT_EQ(db.getClientName(), "");
 
     string client_name = "test_client_1";
     db.setClientName(client_name);
-    RedisReply r2(&db, "CLIENT GETNAME", REDIS_REPLY_STATUS);
-    r2.checkStatus(client_name.c_str());
     EXPECT_EQ(db.getClientName(), client_name);
 
     client_name = "test_client_2";
     db.setClientName(client_name);
-    RedisReply r3(&db, "CLIENT GETNAME", REDIS_REPLY_STATUS);
-    r3.checkStatus(client_name.c_str());
     EXPECT_EQ(db.getClientName(), client_name);
 }
 

--- a/tests/test_redis_ut.py
+++ b/tests/test_redis_ut.py
@@ -1,3 +1,4 @@
+import time
 from swsscommon import swsscommon
 
 def test_ProducerTable():
@@ -70,12 +71,19 @@ def test_Notification():
     assert len(cfvs) == 1
     assert cfvs[0] == ('a', 'b')
 
-def test_DBConnectorClientName():
-    CLIENT_NAME_1 = "test_python_client_1"
-    CLIENT_NAME_2 = "test_python_client_2"
+def test_DBConnectorRedisClientName():
     db = swsscommon.DBConnector("APPL_DB", 0, True)
-    assert db.getClientName == ""
-    db.setClientName(CLIENT_NAME_1)
-    assert db.getClientName == CLIENT_NAME_1
-    db.setClientName(CLIENT_NAME_2)
-    assert db.getClientName == CLIENT_NAME_2
+    time.sleep(1)
+    assert db.getClientName() == ""
+    client_name = "foo"
+    db.setClientName(client_name)
+    time.sleep(1)
+    assert db.getClientName() == client_name
+    client_name = "bar"
+    db.setClientName(client_name)
+    time.sleep(1)
+    assert db.getClientName() == client_name
+    client_name = "foobar"
+    db.setClientName(client_name)
+    time.sleep(1)
+    assert db.getClientName() == client_name

--- a/tests/test_redis_ut.py
+++ b/tests/test_redis_ut.py
@@ -69,3 +69,13 @@ def test_Notification():
     assert data == "bbb"
     assert len(cfvs) == 1
     assert cfvs[0] == ('a', 'b')
+
+def test_DBConnectorClientName():
+    CLIENT_NAME_1 = "test_python_client_1"
+    CLIENT_NAME_2 = "test_python_client_2"
+    db = swsscommon.DBConnector("APPL_DB", 0, True)
+    assert db.getClientName == ""
+    db.setClientName(CLIENT_NAME_1)
+    assert db.getClientName == CLIENT_NAME_1
+    db.setClientName(CLIENT_NAME_2)
+    assert db.getClientName == CLIENT_NAME_2


### PR DESCRIPTION
Add `setClientName()` and `getClientName()` methods to DBConnector class to allow for assigning a name to the client in Redis, which is helpful when debugging Redis clients using `redis-cli client list`.
