### PR TITLE
Fix backward compatible for a DBConnector without a dbName

### DIFF
--- a/common/consumertablebase.cpp
+++ b/common/consumertablebase.cpp
@@ -3,7 +3,7 @@
 namespace swss {
 
 ConsumerTableBase::ConsumerTableBase(DBConnector *db, const std::string &tableName, int popBatchSize, int pri):
-        TableConsumable(tableName, SonicDBConfig::getSeparator(db->getDbName()), pri),
+        TableConsumable(tableName, SonicDBConfig::getSeparator(db), pri),
         RedisTransactioner(db),
         POP_BATCH_SIZE(popBatchSize)
 {

--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -50,6 +50,8 @@ void SonicDBConfig::initialize(const string &file)
                int dbId = it.value().at("id");
                string separator = it.value().at("separator");
                m_db_info[dbName] = {instName, dbId, separator};
+
+               m_db_separator.emplace(dbId, separator);
             }
             m_init = true;
         }
@@ -92,6 +94,31 @@ string SonicDBConfig::getSeparator(const string &dbName)
     return m_db_info.at(dbName).separator;
 }
 
+string SonicDBConfig::getSeparator(int dbId)
+{
+    if (!m_init)
+        initialize();
+    return m_db_separator.at(dbId);
+}
+
+string SonicDBConfig::getSeparator(const DBConnector* db)
+{
+    if (!db)
+    {
+        throw std::invalid_argument("db cannot be null");
+    }
+
+    string dbName = db->getDbName();
+    if (dbName.empty())
+    {
+        return getSeparator(db->getDbId());
+    }
+    else
+    {
+        return getSeparator(dbName);
+    }
+}
+
 string SonicDBConfig::getDbSock(const string &dbName)
 {
     if (!m_init)
@@ -116,6 +143,7 @@ int SonicDBConfig::getDbPort(const string &dbName)
 constexpr const char *SonicDBConfig::DEFAULT_SONIC_DB_CONFIG_FILE;
 unordered_map<string, pair<string, pair<string, int>>> SonicDBConfig::m_inst_info;
 unordered_map<string, SonicDBInfo> SonicDBConfig::m_db_info;
+unordered_map<int, string> SonicDBConfig::m_db_separator;
 bool SonicDBConfig::m_init = false;
 
 constexpr const char *DBConnector::DEFAULT_UNIXSOCKET;

--- a/common/dbconnector.h
+++ b/common/dbconnector.h
@@ -10,6 +10,8 @@
 
 namespace swss {
 
+class DBConnector;
+
 class SonicDBInfo
 {
 public:
@@ -25,6 +27,8 @@ public:
     static std::string getDbInst(const std::string &dbName);
     static int getDbId(const std::string &dbName);
     static std::string getSeparator(const std::string &dbName);
+    static std::string getSeparator(int dbId);
+    static std::string getSeparator(const DBConnector* db);
     static std::string getDbSock(const std::string &dbName);
     static std::string getDbHostname(const std::string &dbName);
     static int getDbPort(const std::string &dbName);
@@ -36,6 +40,8 @@ private:
     static std::unordered_map<std::string, std::pair<std::string, std::pair<std::string, int>>> m_inst_info;
     // { dbName, {instName, dbId} }
     static std::unordered_map<std::string, SonicDBInfo> m_db_info;
+    // { dbIp, separator }
+    static std::unordered_map<int, std::string> m_db_separator;
     static bool m_init;
 };
 

--- a/common/producerstatetable.cpp
+++ b/common/producerstatetable.cpp
@@ -20,7 +20,7 @@ ProducerStateTable::ProducerStateTable(DBConnector *db, const string &tableName)
 }
 
 ProducerStateTable::ProducerStateTable(RedisPipeline *pipeline, const string &tableName, bool buffered)
-    : TableBase(tableName, SonicDBConfig::getSeparator(pipeline->getDbName()))
+    : TableBase(tableName, SonicDBConfig::getSeparator(pipeline->getDBConnector()))
     , TableName_KeySet(tableName)
     , m_buffered(buffered)
     , m_pipeowned(false)

--- a/common/redispipeline.h
+++ b/common/redispipeline.h
@@ -109,6 +109,11 @@ public:
         return m_db->getDbName();
     }
 
+    DBConnector *getDBConnector()
+    {
+        return m_db;
+    }
+
 private:
     DBConnector *m_db;
     std::queue<int> m_expectedTypes;

--- a/common/table.cpp
+++ b/common/table.cpp
@@ -36,7 +36,7 @@ Table::Table(const DBConnector *db, const string &tableName)
 }
 
 Table::Table(RedisPipeline *pipeline, const string &tableName, bool buffered)
-    : TableBase(tableName, SonicDBConfig::getSeparator(pipeline->getDbName()))
+    : TableBase(tableName, SonicDBConfig::getSeparator(pipeline->getDBConnector()))
     , m_buffered(buffered)
     , m_pipeowned(false)
     , m_pipe(pipeline)

--- a/tests/redis_ut.cpp
+++ b/tests/redis_ut.cpp
@@ -144,7 +144,13 @@ void clearDB()
 
 void TableBasicTest(string tableName)
 {
+
     DBConnector db("TEST_DB", 0, true);
+    int dbId = db.getDbId();
+
+    // Test we can still use dbId to construct a DBConnector
+    DBConnector db_dup(dbId, "localhost", 6379, 0);
+    cout << "db_dup separator: " << SonicDBConfig::getSeparator(&db_dup) << endl;
 
     Table t(&db, tableName);
 


### PR DESCRIPTION
If DBConnector is constructed by a dbId, there is no dbName at all. We need to get a separator from the dbId. And the mapping is get from database_config.json.

The bug was introduced by https://github.com/Azure/sonic-swss-common/pull/336