### PR TITLE
The pclose() function returns -1 if error is detected for executing s…

### DIFF
--- a/common/exec.cpp
+++ b/common/exec.cpp
@@ -34,7 +34,7 @@ int exec(const string &cmd, string &stdout)
     }
 
     int ret = pclose(pipe);
-    if (ret != 0)
+    if (ret == -1)
     {
         SWSS_LOG_ERROR("%s: %s", cmd.c_str(), strerror(errno));
     }


### PR DESCRIPTION
The pclose () function will return the termination state of the shell, which is the end state of the subroutine.
If an error occurs, pclose() function returns -1, and the cause of the error is stored in errno.

  Signed-off-by: Irene Pan <irene_pan@edge-core.com>