### PR TITLE
Fix memory leak in pyext when Selectable is returned to Python

### DIFF
--- a/pyext/Makefile.am
+++ b/pyext/Makefile.am
@@ -9,6 +9,6 @@ _swsscommon_la_LDFLAGS = -module
 _swsscommon_la_LIBADD = ../common/libswsscommon.la -lpython$(PYTHON_VERSION)
 
 swsscommon_wrap.cpp: $(SWIG_SOURCES)
-	$(SWIG) -c++ -python -I../common -o $@ $<
+	$(SWIG) -Wall -c++ -python -I../common -o $@ $<
 
 CLEANFILES = swsscommon_wrap.cpp

--- a/pyext/swsscommon.i
+++ b/pyext/swsscommon.i
@@ -42,8 +42,8 @@
         $result = PyList_New(1);
         PyList_SetItem($result, 0, temp);
     }
-    temp = SWIG_NewPointerObj(*$1, SWIGTYPE_p_swss__Selectable, SWIG_POINTER_OWN);
-    PyList_Append($result, temp);
+    temp = SWIG_NewPointerObj(*$1, SWIGTYPE_p_swss__Selectable, 0);
+    SWIG_Python_AppendOutput($result, temp);
 }
 %include "schema.h"
 %include "dbconnector.h"

--- a/tests/test_redis_ut.py
+++ b/tests/test_redis_ut.py
@@ -1,4 +1,6 @@
 import time
+from threading import Thread
+from pympler.tracker import SummaryTracker
 from swsscommon import swsscommon
 
 def test_ProducerTable():
@@ -87,3 +89,36 @@ def test_DBConnectorRedisClientName():
     db.setClientName(client_name)
     time.sleep(1)
     assert db.getClientName() == client_name
+
+
+def test_SelectMemoryLeak():
+    N = 50000
+    def table_set(t, state):
+        fvs = swsscommon.FieldValuePairs([("status", state)])
+        t.set("123", fvs)
+
+    def generator_SelectMemoryLeak():
+        app_db = swsscommon.DBConnector("APPL_DB", 0, True)
+        t = swsscommon.Table(app_db, "TABLE")
+        for i in xrange(N/2):
+            table_set(t, "up")
+            table_set(t, "down")
+
+    tracker = SummaryTracker()
+    appl_db = swsscommon.DBConnector("APPL_DB", 0, True)
+    sel = swsscommon.Select()
+    sst = swsscommon.SubscriberStateTable(appl_db, "TABLE")
+    sel.addSelectable(sst)
+    thr = Thread(target=generator_SelectMemoryLeak)
+    thr.daemon = True
+    thr.start()
+    time.sleep(5)
+    for _ in xrange(N):
+        state, c = sel.select(1000)
+    diff = tracker.diff()
+    cases = []
+    for name, count, _ in diff:
+        if count >= N:
+            cases.append("%s - %d objects for %d repeats" % (name, count, N))
+    thr.join()
+    assert not cases


### PR DESCRIPTION
We have a memory leak in pyext. As result ledd, lddpd, and pmon could use a lot of memory.
I was able to extract the memory leak patter in the following testcase:
You need to have pympler package installed.
```
# server.py
from swsscommon import swsscommon
from pympler.tracker import SummaryTracker

def main():
  tracker = SummaryTracker()
  appl_db = swsscommon.DBConnector(0, "localhost", 6379, 0)
  sel = swsscommon.Select()
  sst = swsscommon.SubscriberStateTable(appl_db, "TABLE")
  sel.addSelectable(sst)
  for _ in xrange(10000):
    state, c = sel.select(1000)
  tracker.print_diff()

main()
```

With the following client code
client.py
```
from swsscommon import swsscommon


app_db = swsscommon.DBConnector(swsscommon.APPL_DB, "localhost", 6379, 0)
t = swsscommon.Table(app_db, "TABLE")
def z(t, st):
  fvs = swsscommon.FieldValuePairs([("status", st)])
  t.set("123", fvs)

for i in xrange(10000000000000):
  z(t, "up")
  z(t, "down")
```

You can see the following output from the server.py:
```
                                       types |   # objects |   total size
============================================ | =========== | ============
                                        dict |       10006 |      2.67 MB
            swsscommon.swsscommon.Selectable |       10000 |    625.00 KB
                                        list |        1270 |    128.94 KB
                                         str |        1270 |     71.11 KB
                                         int |         147 |      3.45 KB
                                        type |           1 |    872     B
                                       tuple |           5 |    360     B
                          wrapper_descriptor |           4 |    320     B
                           member_descriptor |           2 |    144     B
                                        code |           1 |    128     B
                       function (store_info) |           1 |    120     B
                                        cell |           2 |    112     B
                                     weakref |           1 |     88     B
                           getset_descriptor |           1 |     72     B
  swsscommon.swsscommon.SubscriberStateTable |           1 |     64     B
```

You can see from the output that 10000 dicts and swsscommon.swsscommon.Selectable were leaked. It is the same as number of iterations in the select loop.

With the fix the output is the following:
```
                                       types |   # objects |   total size
============================================ | =========== | ============
                                        list |        1270 |    128.94 KB
                                         str |        1270 |     71.11 KB
                                         int |         147 |      3.45 KB
                                        dict |           7 |      2.66 KB
                                        type |           1 |    872     B
                                       tuple |           5 |    360     B
                          wrapper_descriptor |           4 |    320     B
                           member_descriptor |           2 |    144     B
                                        code |           1 |    128     B
                       function (store_info) |           1 |    120     B
                                        cell |           2 |    112     B
                                     weakref |           1 |     88     B
                           getset_descriptor |           1 |     72     B
  swsscommon.swsscommon.SubscriberStateTable |           1 |     64     B
            swsscommon.swsscommon.Selectable |           1 |     64     B

```
The test is added. It requires https://github.com/Azure/sonic-buildimage/pull/4652
The test result if we have memory leak
```
root@05ad98abefdd:/src/sonic-swss-common# cat check.txt
============================= test session starts ==============================
platform linux2 -- Python 2.7.13, pytest-3.0.6, py-1.4.32, pluggy-0.4.0 -- /usr/bin/python
cachedir: .cache
rootdir: /src/sonic-swss-common, inifile:
collecting ... collected 7 items

tests/test_redis_ut.py::test_ProducerTable PASSED
tests/test_redis_ut.py::test_ProducerStateTable PASSED
tests/test_redis_ut.py::test_Table PASSED
tests/test_redis_ut.py::test_SubscriberStateTable PASSED
tests/test_redis_ut.py::test_Notification PASSED
tests/test_redis_ut.py::test_DBConnectorRedisClientName PASSED
tests/test_redis_ut.py::test_SelectMemoryLeak FAILED

=================================== FAILURES ===================================
____________________________ test_SelectMemoryLeak _____________________________

    def test_SelectMemoryLeak():
        N = 50000
        def table_set(t, state):
            fvs = swsscommon.FieldValuePairs([("status", state)])
            t.set("123", fvs)

        def generator_SelectMemoryLeak():
            app_db = swsscommon.DBConnector("APPL_DB", 0, True)
            t = swsscommon.Table(app_db, "TABLE")
            for i in xrange(N/2):
                table_set(t, "up")
                table_set(t, "down")

        tracker = SummaryTracker()
        appl_db = swsscommon.DBConnector("APPL_DB", 0, True)
        sel = swsscommon.Select()
        sst = swsscommon.SubscriberStateTable(appl_db, "TABLE")
        sel.addSelectable(sst)
        thr = Thread(target=generator_SelectMemoryLeak)
        thr.daemon = True
        thr.start()
        time.sleep(5)
        for _ in xrange(N):
            state, c = sel.select(1000)
        diff = tracker.diff()
        cases = []
        for name, count, _ in diff:
            if count >= N:
                cases.append("%s - %d objects for %d repeats" % (name, count, N))
        thr.join()
>       assert not cases
E       assert not ['swsscommon.swsscommon.Selectable - 50000 objects for 50000 repeats', 'dict - 50009 objects for 50000 repeats']

tests/test_redis_ut.py:124: AssertionError
===================== 1 failed, 6 passed in 13.43 seconds ======================

```