### PR TITLE
[loglevel] Avoid accessing null ptr in swssloglevel

### DIFF
--- a/common/loglevel.cpp
+++ b/common/loglevel.cpp
@@ -135,7 +135,10 @@ int main(int argc, char **argv)
         {
             const auto redis_key = std::string(key).append(":").append(key);
             auto level = redisClient.hget(redis_key, DAEMON_LOGLEVEL);
-            std::cout << std::left << std::setw(30) << key << *level << std::endl;
+            if (nullptr == level)
+                std::cerr << std::left << std::setw(30) << key << "Unknown log level" << std::endl;
+            else
+                std::cout << std::left << std::setw(30) << key << *level << std::endl;
         }
         return (EXIT_SUCCESS);
     }

--- a/common/loglevel.cpp
+++ b/common/loglevel.cpp
@@ -125,6 +125,8 @@ int main(int argc, char **argv)
 
     if (print)
     {
+        int errorCount = 0;
+
         if (argc != 2)
         {
             exitWithUsage(EXIT_FAILURE, "-p option does not accept other options");
@@ -136,10 +138,19 @@ int main(int argc, char **argv)
             const auto redis_key = std::string(key).append(":").append(key);
             auto level = redisClient.hget(redis_key, DAEMON_LOGLEVEL);
             if (nullptr == level)
+            {
                 std::cerr << std::left << std::setw(30) << key << "Unknown log level" << std::endl;
+                errorCount ++;
+            }
             else
+            {
                 std::cout << std::left << std::setw(30) << key << *level << std::endl;
+            }
         }
+
+        if (errorCount > 0)
+            return (EXIT_FAILURE);
+
         return (EXIT_SUCCESS);
     }
 


### PR DESCRIPTION
We have an issue [4338 swssloglevel -p crashes](https://github.com/Azure/sonic-buildimage/issues/4338). Looks like the story is like this: someone inserts the log level entries through `ProductionStateTable` but nobody tries consuming those entries, leaving the keys of most of the entries prefixed with an underscore and failing the `swssloglevel` who doesn't try to handle this case.
This PR put a check in the `swssloglevel` as a WA.
On top of that, it's still necessary to find out who is responsible to consume the entries in the database and why it doesn't do that.