### PR TITLE
use sysconfig instead of distutils.sysconfig

### DIFF
--- a/m4/python3.m4
+++ b/m4/python3.m4
@@ -103,7 +103,7 @@ AC_DEFUN([AM_PATH_PYTHON3],
   AC_SUBST([PYTHON3_PLATFORM], [$am_cv_python3_platform])
 
   AC_CACHE_CHECK([for $am_display_PYTHON3 bldlibrary], [am_cv_python3_bldlibrary],
-    [am_cv_python3_bldlibrary=`$PYTHON3 -c "import sys; from distutils import sysconfig; sys.stdout.write(sysconfig.get_config_var('BLDLIBRARY'))"`])
+    [am_cv_python3_bldlibrary=`$PYTHON3 -c "import sys; import sysconfig; sys.stdout.write(sysconfig.get_config_var('BLDLIBRARY'))"`])
   AC_SUBST([PYTHON3_BLDLIBRARY], [$am_cv_python3_bldlibrary])
 
   dnl Set up 4 directories:


### PR DESCRIPTION
sysconfig is added in Python3.2

distutils.sysconfig is from Python2

Python3.6 does not support distutils.sysconfig

Signed-off-by: Guohan Lu <lguohan@gmail.com>