### PR TITLE
fix pytest for python3

### DIFF
--- a/tests/test_redis_ut.py
+++ b/tests/test_redis_ut.py
@@ -100,7 +100,7 @@ def test_SelectMemoryLeak():
     def generator_SelectMemoryLeak():
         app_db = swsscommon.DBConnector("APPL_DB", 0, True)
         t = swsscommon.Table(app_db, "TABLE")
-        for i in xrange(N/2):
+        for i in range(int(N/2)):
             table_set(t, "up")
             table_set(t, "down")
 
@@ -113,7 +113,7 @@ def test_SelectMemoryLeak():
     thr.daemon = True
     thr.start()
     time.sleep(5)
-    for _ in xrange(N):
+    for _ in range(N):
         state, c = sel.select(1000)
     diff = tracker.diff()
     cases = []


### PR DESCRIPTION
```
lgh@jenkins-worker-17:~/sonic-swss-common/tests$ py.test -v  
======================================== test session starts ========================================
platform linux -- Python 3.8.2, pytest-4.6.2, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/lgh/sonic-swss-common/tests
plugins: flaky-3.6.1
collected 7 items                                                                                   

test_redis_ut.py::test_ProducerTable PASSED                                                   [ 14%]
test_redis_ut.py::test_ProducerStateTable PASSED                                              [ 28%]
test_redis_ut.py::test_Table PASSED                                                           [ 42%]
test_redis_ut.py::test_SubscriberStateTable PASSED                                            [ 57%]
test_redis_ut.py::test_Notification PASSED                                                    [ 71%]
test_redis_ut.py::test_DBConnectorRedisClientName PASSED                                      [ 85%]
test_redis_ut.py::test_SelectMemoryLeak PASSED                                                [100%]

===================================== 7 passed in 9.90 seconds ======================================
```