### PR TITLE
DBConnector classes to understand the namespace.

### DIFF
--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -140,6 +140,8 @@ void SonicDBConfig::initializeGlobalConfig(const string &file)
 
     // Set it as the global config file is already parsed and init done.
     m_global_init = true;
+    // Make regular init also done
+    m_init = true;
 }
 
 void SonicDBConfig::initialize(const string &file, const string &nameSpace)
@@ -175,28 +177,28 @@ void SonicDBConfig::initialize(const string &file, const string &nameSpace)
 string SonicDBConfig::getDbInst(const string &dbName, const string &nameSpace)
 {
     if (!m_init)
-        initialize(nameSpace);
+        initialize(DEFAULT_SONIC_DB_CONFIG_FILE, nameSpace);
     return m_db_info[nameSpace].at(dbName).instName;
 }
 
 int SonicDBConfig::getDbId(const string &dbName, const string &nameSpace)
 {
     if (!m_init)
-        initialize(nameSpace);
+        initialize(DEFAULT_SONIC_DB_CONFIG_FILE, nameSpace);
     return m_db_info[nameSpace].at(dbName).dbId;
 }
 
 string SonicDBConfig::getSeparator(const string &dbName, const string &nameSpace)
 {
     if (!m_init)
-        initialize(nameSpace);
+        initialize(DEFAULT_SONIC_DB_CONFIG_FILE, nameSpace);
     return m_db_info[nameSpace].at(dbName).separator;
 }
 
 string SonicDBConfig::getSeparator(int dbId, const string &nameSpace)
 {
     if (!m_init)
-        initialize(nameSpace);
+        initialize(DEFAULT_SONIC_DB_CONFIG_FILE, nameSpace);
     return m_db_separator[nameSpace].at(dbId);
 }
 
@@ -222,21 +224,21 @@ string SonicDBConfig::getSeparator(const DBConnector* db)
 string SonicDBConfig::getDbSock(const string &dbName, const string &nameSpace)
 {
     if (!m_init)
-        initialize(nameSpace);
+        initialize(DEFAULT_SONIC_DB_CONFIG_FILE, nameSpace);
     return m_inst_info[nameSpace].at(getDbInst(dbName)).unix_socket_path;
 }
 
 string SonicDBConfig::getDbHostname(const string &dbName, const string &nameSpace)
 {
     if (!m_init)
-        initialize(nameSpace);
+        initialize(DEFAULT_SONIC_DB_CONFIG_FILE, nameSpace);
     return m_inst_info[nameSpace].at(getDbInst(dbName)).hostname;
 }
 
 int SonicDBConfig::getDbPort(const string &dbName, const string &nameSpace)
 {
     if (!m_init)
-        initialize(nameSpace);
+        initialize(DEFAULT_SONIC_DB_CONFIG_FILE, nameSpace);
     return m_inst_info[nameSpace].at(getDbInst(dbName)).port;
 }
 
@@ -369,16 +371,7 @@ string DBConnector::getNamespace() const
 DBConnector *DBConnector::newConnector(unsigned int timeout) const
 {
     DBConnector *ret;
-    if (getContext()->connection_type == REDIS_CONN_TCP)
-        ret = new DBConnector(getDbId(),
-                               getContext()->tcp.host,
-                               getContext()->tcp.port,
-                               timeout);
-    else
-        ret = new DBConnector(getDbId(),
-                               getContext()->unix_sock.path,
-                               timeout);
-    ret->m_dbName = m_dbName;
+    ret = new DBConnector(getDbName(), timeout, (getContext()->connection_type == REDIS_CONN_TCP), getNamespace());
     return ret;
 }
 

--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -69,7 +69,7 @@ void SonicDBConfig::parseDatabaseConfig(const string &file,
 
 void SonicDBConfig::initializeGlobalConfig(const string &file)
 {
-    std::string local_file, ns_name;
+    std::string local_file, dir_name, ns_name;
     std::unordered_map<std::string, SonicDBInfo> db_entry;
     std::unordered_map<std::string, RedisInstInfo> inst_entry;
     std::unordered_map<int, std::string> separator_entry;
@@ -82,9 +82,14 @@ void SonicDBConfig::initializeGlobalConfig(const string &file)
         return;
     }
 
+
     ifstream i(file);
     if (i.good())
     {
+        // Get the directory name from the file path given as input.
+        std::string::size_type pos = file.rfind("/");
+        dir_name = file.substr(0,pos+1);
+
         try
         {
             json j;
@@ -92,7 +97,7 @@ void SonicDBConfig::initializeGlobalConfig(const string &file)
 
             for (auto& element : j["INCLUDES"])
             {
-                local_file.append(DEFAULT_SONIC_DB_CONFIG_DIR);
+                local_file.append(dir_name);
                 local_file.append(element["include"]);
 
                 if(element["namespace"].empty())
@@ -253,7 +258,6 @@ vector<string> SonicDBConfig::getNamespaces()
 
 constexpr const char *SonicDBConfig::DEFAULT_SONIC_DB_CONFIG_FILE;
 constexpr const char *SonicDBConfig::DEFAULT_SONIC_DB_GLOBAL_CONFIG_FILE;
-constexpr const char *SonicDBConfig::DEFAULT_SONIC_DB_CONFIG_DIR;
 unordered_map<string, unordered_map<string, RedisInstInfo>> SonicDBConfig::m_inst_info;
 unordered_map<string, unordered_map<string, SonicDBInfo>> SonicDBConfig::m_db_info;
 unordered_map<string, unordered_map<int, string>> SonicDBConfig::m_db_separator;

--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -16,17 +16,11 @@ using namespace std;
 
 namespace swss {
 
-void SonicDBConfig::initialize(const string &file)
+void SonicDBConfig::parse_config(const string &file,
+                    std::unordered_map<std::string, SonicInstInfo> &inst_entry,
+                    std::unordered_map<std::string, SonicDBInfo> &db_entry,
+                    std::unordered_map<int, std::string> &separator_entry)
 {
-
-    SWSS_LOG_ENTER();
-
-    if (m_init)
-    {
-        SWSS_LOG_ERROR("SonicDBConfig already initialized");
-        throw runtime_error("SonicDBConfig already initialized");
-    }
-
     ifstream i(file);
     if (i.good())
     {
@@ -40,7 +34,7 @@ void SonicDBConfig::initialize(const string &file)
                string socket = it.value().at("unix_socket_path");
                string hostname = it.value().at("hostname");
                int port = it.value().at("port");
-               m_inst_info[instName] = {socket, {hostname, port}};
+               inst_entry[instName] = {socket, hostname, port};
             }
 
             for (auto it = j["DATABASES"].begin(); it!= j["DATABASES"].end(); it++)
@@ -49,12 +43,12 @@ void SonicDBConfig::initialize(const string &file)
                string instName = it.value().at("instance");
                int dbId = it.value().at("id");
                string separator = it.value().at("separator");
-               m_db_info[dbName] = {instName, dbId, separator};
+               db_entry[dbName] = {instName, dbId, separator};
 
-               m_db_separator.emplace(dbId, separator);
+               separator_entry.emplace(dbId, separator);
             }
-            m_init = true;
         }
+
         catch (domain_error& e)
         {
             SWSS_LOG_ERROR("key doesn't exist in json object, NULL value has no iterator >> %s\n", e.what());
@@ -73,32 +67,126 @@ void SonicDBConfig::initialize(const string &file)
     }
 }
 
-string SonicDBConfig::getDbInst(const string &dbName)
+void SonicDBConfig::initialize_global_config(const string &file)
 {
-    if (!m_init)
-        initialize();
-    return m_db_info.at(dbName).instName;
+    std::string local_file, ns_name;
+    std::unordered_map<std::string, SonicDBInfo> db_entry;
+    std::unordered_map<std::string, SonicInstInfo> inst_entry;
+    std::unordered_map<int, std::string> separator_entry;
+
+    SWSS_LOG_ENTER();
+
+    if (m_global_init)
+    {
+        SWSS_LOG_ERROR("SonicDBConfig Global config is already initialized");
+        return;
+    }
+
+    ifstream i(file);
+    if (i.good())
+    {
+        try
+        {
+            json j;
+            i >> j;
+
+            for (auto& element : j["INCLUDES"])
+            {
+                local_file.append(DEFAULT_SONIC_DB_CONFIG_DIR);
+                local_file.append(element["include"]);
+
+                if(element["namespace"].empty())
+                {
+                    ns_name = "";
+                }
+                else
+                {
+                    ns_name = element["namespace"];
+                }
+
+                parse_config(local_file, inst_entry, db_entry, separator_entry);
+                m_inst_info[ns_name] = inst_entry;
+                m_db_info[ns_name] = db_entry;
+                m_db_separator[ns_name] = separator_entry;
+
+                inst_entry.clear();
+                db_entry.clear();
+                separator_entry.clear();
+                local_file.clear();
+            }
+        }
+
+        catch (domain_error& e)
+        {
+            SWSS_LOG_ERROR("key doesn't exist in json object, NULL value has no iterator >> %s\n", e.what());
+            throw runtime_error("key doesn't exist in json object, NULL value has no iterator >> " + string(e.what()));
+        }
+        catch (exception &e)
+        {
+            SWSS_LOG_ERROR("Sonic database config file syntax error >> %s\n", e.what());
+            throw runtime_error("Sonic database config file syntax error >> " + string(e.what()));
+        }
+    }
+
+    // Set it as the global config file is already parsed and init done.
+    m_global_init = true;
 }
 
-int SonicDBConfig::getDbId(const string &dbName)
+void SonicDBConfig::initialize(const string &file, const string &nameSpace)
 {
-    if (!m_init)
-        initialize();
-    return m_db_info.at(dbName).dbId;
+    std::unordered_map<std::string, SonicDBInfo> db_entry;
+    std::unordered_map<std::string, SonicInstInfo> inst_entry;
+    std::unordered_map<int, std::string> separator_entry;
+
+    SWSS_LOG_ENTER();
+
+    if (m_init)
+    {
+        SWSS_LOG_ERROR("SonicDBConfig already initialized");
+        throw runtime_error("SonicDBConfig already initialized");
+    }
+
+    if(nameSpace.empty())
+    {
+        parse_config(file, inst_entry, db_entry, separator_entry);
+        m_inst_info[""] = inst_entry;
+        m_db_info[""] = db_entry;
+        m_db_separator[""] = separator_entry;
+    }
+    else
+        initialize_global_config();
+
+
+    // Set it as the config file is already parsed and init done.
+    m_init = true;
 }
 
-string SonicDBConfig::getSeparator(const string &dbName)
+string SonicDBConfig::getDbInst(const string &dbName, const string &nameSpace)
 {
     if (!m_init)
-        initialize();
-    return m_db_info.at(dbName).separator;
+        initialize(nameSpace);
+    return m_db_info[nameSpace].at(dbName).instName;
 }
 
-string SonicDBConfig::getSeparator(int dbId)
+int SonicDBConfig::getDbId(const string &dbName, const string &nameSpace)
 {
     if (!m_init)
-        initialize();
-    return m_db_separator.at(dbId);
+        initialize(nameSpace);
+    return m_db_info[nameSpace].at(dbName).dbId;
+}
+
+string SonicDBConfig::getSeparator(const string &dbName, const string &nameSpace)
+{
+    if (!m_init)
+        initialize(nameSpace);
+    return m_db_info[nameSpace].at(dbName).separator;
+}
+
+string SonicDBConfig::getSeparator(int dbId, const string &nameSpace)
+{
+    if (!m_init)
+        initialize(nameSpace);
+    return m_db_separator[nameSpace].at(dbId);
 }
 
 string SonicDBConfig::getSeparator(const DBConnector* db)
@@ -109,42 +197,61 @@ string SonicDBConfig::getSeparator(const DBConnector* db)
     }
 
     string dbName = db->getDbName();
+    string nameSpace = db->getNamespace();
     if (dbName.empty())
     {
-        return getSeparator(db->getDbId());
+        return getSeparator(db->getDbId(), nameSpace);
     }
     else
     {
-        return getSeparator(dbName);
+        return getSeparator(dbName, nameSpace);
     }
 }
 
-string SonicDBConfig::getDbSock(const string &dbName)
+string SonicDBConfig::getDbSock(const string &dbName, const string &nameSpace)
 {
     if (!m_init)
-        initialize();
-    return m_inst_info.at(getDbInst(dbName)).first;
+        initialize(nameSpace);
+    return m_inst_info[nameSpace].at(getDbInst(dbName)).socket;
 }
 
-string SonicDBConfig::getDbHostname(const string &dbName)
+string SonicDBConfig::getDbHostname(const string &dbName, const string &nameSpace)
 {
     if (!m_init)
-        initialize();
-    return m_inst_info.at(getDbInst(dbName)).second.first;
+        initialize(nameSpace);
+    return m_inst_info[nameSpace].at(getDbInst(dbName)).hostName;
 }
 
-int SonicDBConfig::getDbPort(const string &dbName)
+int SonicDBConfig::getDbPort(const string &dbName, const string &nameSpace)
 {
     if (!m_init)
-        initialize();
-    return m_inst_info.at(getDbInst(dbName)).second.second;
+        initialize(nameSpace);
+    return m_inst_info[nameSpace].at(getDbInst(dbName)).port;
+}
+
+vector<string> SonicDBConfig::getNamespaces()
+{
+    vector<string> list;
+
+    if (!m_global_init)
+        initialize_global_config();
+
+    for (auto it = m_inst_info.cbegin(); it != m_inst_info.cend(); ++it) {
+        if(!((it->first).empty()))
+            list.push_back(it->first);
+    }
+
+    return list;
 }
 
 constexpr const char *SonicDBConfig::DEFAULT_SONIC_DB_CONFIG_FILE;
-unordered_map<string, pair<string, pair<string, int>>> SonicDBConfig::m_inst_info;
-unordered_map<string, SonicDBInfo> SonicDBConfig::m_db_info;
-unordered_map<int, string> SonicDBConfig::m_db_separator;
+constexpr const char *SonicDBConfig::DEFAULT_SONIC_DB_GLOBAL_CONFIG_FILE;
+constexpr const char *SonicDBConfig::DEFAULT_SONIC_DB_CONFIG_DIR;
+unordered_map<string, unordered_map<string, SonicInstInfo>> SonicDBConfig::m_inst_info;
+unordered_map<string, unordered_map<string, SonicDBInfo>> SonicDBConfig::m_db_info;
+unordered_map<string, unordered_map<int, string>> SonicDBConfig::m_db_separator;
 bool SonicDBConfig::m_init = false;
+bool SonicDBConfig::m_global_init = false;
 
 constexpr const char *DBConnector::DEFAULT_UNIXSOCKET;
 
@@ -164,7 +271,8 @@ DBConnector::~DBConnector()
 
 DBConnector::DBConnector(int dbId, const string& hostname, int port,
                          unsigned int timeout) :
-    m_dbId(dbId)
+    m_dbId(dbId),
+    m_nameSpace("")
 {
     struct timeval tv = {0, (suseconds_t)timeout * 1000};
 
@@ -181,7 +289,8 @@ DBConnector::DBConnector(int dbId, const string& hostname, int port,
 }
 
 DBConnector::DBConnector(int dbId, const string& unixPath, unsigned int timeout) :
-    m_dbId(dbId)
+    m_dbId(dbId),
+    m_nameSpace("")
 {
     struct timeval tv = {0, (suseconds_t)timeout * 1000};
 
@@ -197,25 +306,26 @@ DBConnector::DBConnector(int dbId, const string& unixPath, unsigned int timeout)
     select(this);
 }
 
-DBConnector::DBConnector(const string& dbName, unsigned int timeout, bool isTcpConn)
-    : m_dbId(SonicDBConfig::getDbId(dbName))
+DBConnector::DBConnector(const string& dbName, unsigned int timeout, bool isTcpConn, const string& nameSpace)
+    : m_dbId(SonicDBConfig::getDbId(dbName, nameSpace))
     , m_dbName(dbName)
+    , m_nameSpace(nameSpace)
 {
     struct timeval tv = {0, (suseconds_t)timeout * 1000};
 
     if (timeout)
     {
         if (isTcpConn)
-            m_conn = redisConnectWithTimeout(SonicDBConfig::getDbHostname(dbName).c_str(), SonicDBConfig::getDbPort(dbName), tv);
+            m_conn = redisConnectWithTimeout(SonicDBConfig::getDbHostname(dbName, nameSpace).c_str(), SonicDBConfig::getDbPort(dbName, nameSpace), tv);
         else
-            m_conn = redisConnectUnixWithTimeout(SonicDBConfig::getDbSock(dbName).c_str(), tv);
+            m_conn = redisConnectUnixWithTimeout(SonicDBConfig::getDbSock(dbName, nameSpace).c_str(), tv);
     }
     else
     {
         if (isTcpConn)
-            m_conn = redisConnect(SonicDBConfig::getDbHostname(dbName).c_str(), SonicDBConfig::getDbPort(dbName));
+            m_conn = redisConnect(SonicDBConfig::getDbHostname(dbName, nameSpace).c_str(), SonicDBConfig::getDbPort(dbName, nameSpace));
         else
-            m_conn = redisConnectUnix(SonicDBConfig::getDbSock(dbName).c_str());
+            m_conn = redisConnectUnix(SonicDBConfig::getDbSock(dbName, nameSpace).c_str());
     }
 
     if (m_conn->err)
@@ -238,6 +348,11 @@ int DBConnector::getDbId() const
 string DBConnector::getDbName() const
 {
     return m_dbName;
+}
+
+string DBConnector::getNamespace() const
+{
+    return m_nameSpace;
 }
 
 DBConnector *DBConnector::newConnector(unsigned int timeout) const

--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -86,9 +86,14 @@ void SonicDBConfig::initializeGlobalConfig(const string &file)
     ifstream i(file);
     if (i.good())
     {
+        local_file = dir_name = std::string();
+
         // Get the directory name from the file path given as input.
         std::string::size_type pos = file.rfind("/");
-        dir_name = file.substr(0,pos+1);
+        if( pos != std::string::npos)
+        {
+            dir_name = file.substr(0,pos+1);
+        }
 
         try
         {
@@ -102,6 +107,13 @@ void SonicDBConfig::initializeGlobalConfig(const string &file)
 
                 if(element["namespace"].empty())
                 {
+                    // If database_config.json is already initlized via SonicDBConfig::initialize
+                    // skip initializing it here again.
+                    if(m_init)
+                    {
+                        local_file.clear();
+                        continue;
+                    }
                     ns_name = EMPTY_NAMESPACE;
                 }
                 else
@@ -140,6 +152,7 @@ void SonicDBConfig::initializeGlobalConfig(const string &file)
 
     // Set it as the global config file is already parsed and init done.
     m_global_init = true;
+
     // Make regular init also done
     m_init = true;
 }

--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -225,7 +225,7 @@ string SonicDBConfig::getDbSock(const string &dbName, const string &nameSpace)
 {
     if (!m_init)
         initialize(DEFAULT_SONIC_DB_CONFIG_FILE, nameSpace);
-    return m_inst_info[nameSpace].at(getDbInst(dbName)).unix_socket_path;
+    return m_inst_info[nameSpace].at(getDbInst(dbName)).unixSocketPath;
 }
 
 string SonicDBConfig::getDbHostname(const string &dbName, const string &nameSpace)

--- a/common/dbconnector.h
+++ b/common/dbconnector.h
@@ -16,7 +16,7 @@ class DBConnector;
 class RedisInstInfo
 {
 public:
-    std::string unix_socket_path;
+    std::string unixSocketPath;
     std::string hostname;
     int port;
 };

--- a/common/dbconnector.h
+++ b/common/dbconnector.h
@@ -7,17 +7,17 @@
 #include <utility>
 
 #include <hiredis/hiredis.h>
-#define EMPTY_NAMESPACE ""
+#define EMPTY_NAMESPACE std::string()
 
 namespace swss {
 
 class DBConnector;
 
-class SonicInstInfo
+class RedisInstInfo
 {
 public:
-    std::string socket;
-    std::string hostName;
+    std::string unix_socket_path;
+    std::string hostname;
     int port;
 };
 
@@ -32,12 +32,8 @@ public:
 class SonicDBConfig
 {
 public:
-    static void parse_config(const std::string &file, 
-                             std::unordered_map<std::string, SonicInstInfo> &inst_entry,
-                             std::unordered_map<std::string, SonicDBInfo> &db_entry, 
-                             std::unordered_map<int, std::string> &separator_entry);
     static void initialize(const std::string &file = DEFAULT_SONIC_DB_CONFIG_FILE, const std::string &nameSpace = EMPTY_NAMESPACE);
-    static void initialize_global_config(const std::string &file = DEFAULT_SONIC_DB_GLOBAL_CONFIG_FILE);
+    static void initializeGlobalConfig(const std::string &file = DEFAULT_SONIC_DB_GLOBAL_CONFIG_FILE);
     static std::string getDbInst(const std::string &dbName, const std::string &nameSpace = EMPTY_NAMESPACE);
     static int getDbId(const std::string &dbName, const std::string &nameSpace = EMPTY_NAMESPACE);
     static std::string getSeparator(const std::string &dbName, const std::string &nameSpace = EMPTY_NAMESPACE);
@@ -55,13 +51,17 @@ private:
     static constexpr const char *DEFAULT_SONIC_DB_CONFIG_FILE = "/var/run/redis/sonic-db/database_config.json";
     static constexpr const char *DEFAULT_SONIC_DB_GLOBAL_CONFIG_FILE = "/var/run/redis/sonic-db/database_global.json";
     // { namespace { instName, { unix_socket_path, hostname, port } } }
-    static std::unordered_map<std::string, std::unordered_map<std::string, SonicInstInfo>> m_inst_info;
+    static std::unordered_map<std::string, std::unordered_map<std::string, RedisInstInfo>> m_inst_info;
     // { namespace, { dbName, {instName, dbId, separator} } }
     static std::unordered_map<std::string, std::unordered_map<std::string, SonicDBInfo>> m_db_info;
     // { namespace, { dbId, separator } }
     static std::unordered_map<std::string, std::unordered_map<int, std::string>> m_db_separator;
     static bool m_init;
     static bool m_global_init;
+    static void parseDatabaseConfig(const std::string &file,
+                                    std::unordered_map<std::string, RedisInstInfo> &inst_entry,
+                                    std::unordered_map<std::string, SonicDBInfo> &db_entry,
+                                    std::unordered_map<int, std::string> &separator_entry);
 };
 
 class DBConnector
@@ -104,7 +104,7 @@ private:
     redisContext *m_conn;
     int m_dbId;
     std::string m_dbName;
-    std::string m_nameSpace;
+    std::string m_namespace;
 };
 
 }

--- a/common/dbconnector.h
+++ b/common/dbconnector.h
@@ -47,7 +47,6 @@ public:
     static bool isGlobalInit() { return m_global_init; };
 
 private:
-    static constexpr const char *DEFAULT_SONIC_DB_CONFIG_DIR = "/var/run/redis/sonic-db/";
     static constexpr const char *DEFAULT_SONIC_DB_CONFIG_FILE = "/var/run/redis/sonic-db/database_config.json";
     static constexpr const char *DEFAULT_SONIC_DB_GLOBAL_CONFIG_FILE = "/var/run/redis/sonic-db/database_global.json";
     // { namespace { instName, { unix_socket_path, hostname, port } } }

--- a/common/dbconnector.h
+++ b/common/dbconnector.h
@@ -7,6 +7,7 @@
 #include <utility>
 
 #include <hiredis/hiredis.h>
+#define EMPTY_NAMESPACE ""
 
 namespace swss {
 
@@ -35,16 +36,16 @@ public:
                              std::unordered_map<std::string, SonicInstInfo> &inst_entry,
                              std::unordered_map<std::string, SonicDBInfo> &db_entry, 
                              std::unordered_map<int, std::string> &separator_entry);
-    static void initialize(const std::string &file = DEFAULT_SONIC_DB_CONFIG_FILE, const std::string &nameSpace = "");
+    static void initialize(const std::string &file = DEFAULT_SONIC_DB_CONFIG_FILE, const std::string &nameSpace = EMPTY_NAMESPACE);
     static void initialize_global_config(const std::string &file = DEFAULT_SONIC_DB_GLOBAL_CONFIG_FILE);
-    static std::string getDbInst(const std::string &dbName, const std::string &nameSpace = "");
-    static int getDbId(const std::string &dbName, const std::string &nameSpace = "");
-    static std::string getSeparator(const std::string &dbName, const std::string &nameSpace = "");
-    static std::string getSeparator(int dbId, const std::string &nameSpace = "");
+    static std::string getDbInst(const std::string &dbName, const std::string &nameSpace = EMPTY_NAMESPACE);
+    static int getDbId(const std::string &dbName, const std::string &nameSpace = EMPTY_NAMESPACE);
+    static std::string getSeparator(const std::string &dbName, const std::string &nameSpace = EMPTY_NAMESPACE);
+    static std::string getSeparator(int dbId, const std::string &nameSpace = EMPTY_NAMESPACE);
     static std::string getSeparator(const DBConnector* db);
-    static std::string getDbSock(const std::string &dbName, const std::string &nameSpace = "");
-    static std::string getDbHostname(const std::string &dbName, const std::string &nameSpace = "");
-    static int getDbPort(const std::string &dbName, const std::string &nameSpace = "");
+    static std::string getDbSock(const std::string &dbName, const std::string &nameSpace = EMPTY_NAMESPACE);
+    static std::string getDbHostname(const std::string &dbName, const std::string &nameSpace = EMPTY_NAMESPACE);
+    static int getDbPort(const std::string &dbName, const std::string &nameSpace = EMPTY_NAMESPACE);
     static std::vector<std::string> getNamespaces();
     static bool isInit() { return m_init; };
     static bool isGlobalInit() { return m_global_init; };
@@ -55,9 +56,9 @@ private:
     static constexpr const char *DEFAULT_SONIC_DB_GLOBAL_CONFIG_FILE = "/var/run/redis/sonic-db/database_global.json";
     // { namespace { instName, { unix_socket_path, hostname, port } } }
     static std::unordered_map<std::string, std::unordered_map<std::string, SonicInstInfo>> m_inst_info;
-    // { namespace, { dbName, {instName, dbId} } }
+    // { namespace, { dbName, {instName, dbId, separator} } }
     static std::unordered_map<std::string, std::unordered_map<std::string, SonicDBInfo>> m_db_info;
-    // { namespace, { dbIp, separator } }
+    // { namespace, { dbId, separator } }
     static std::unordered_map<std::string, std::unordered_map<int, std::string>> m_db_separator;
     static bool m_init;
     static bool m_global_init;
@@ -77,7 +78,7 @@ public:
      */
     DBConnector(int dbId, const std::string &hostname, int port, unsigned int timeout);
     DBConnector(int dbId, const std::string &unixPath, unsigned int timeout);
-    DBConnector(const std::string &dbName, unsigned int timeout, bool isTcpConn = false, const std::string &nameSpace = "");
+    DBConnector(const std::string &dbName, unsigned int timeout, bool isTcpConn = false, const std::string &nameSpace = EMPTY_NAMESPACE);
 
     ~DBConnector();
 

--- a/common/dbconnector.h
+++ b/common/dbconnector.h
@@ -12,6 +12,14 @@ namespace swss {
 
 class DBConnector;
 
+class SonicInstInfo
+{
+public:
+    std::string socket;
+    std::string hostName;
+    int port;
+};
+
 class SonicDBInfo
 {
 public:
@@ -23,26 +31,36 @@ public:
 class SonicDBConfig
 {
 public:
-    static void initialize(const std::string &file = DEFAULT_SONIC_DB_CONFIG_FILE);
-    static std::string getDbInst(const std::string &dbName);
-    static int getDbId(const std::string &dbName);
-    static std::string getSeparator(const std::string &dbName);
-    static std::string getSeparator(int dbId);
+    static void parse_config(const std::string &file, 
+                             std::unordered_map<std::string, SonicInstInfo> &inst_entry,
+                             std::unordered_map<std::string, SonicDBInfo> &db_entry, 
+                             std::unordered_map<int, std::string> &separator_entry);
+    static void initialize(const std::string &file = DEFAULT_SONIC_DB_CONFIG_FILE, const std::string &nameSpace = "");
+    static void initialize_global_config(const std::string &file = DEFAULT_SONIC_DB_GLOBAL_CONFIG_FILE);
+    static std::string getDbInst(const std::string &dbName, const std::string &nameSpace = "");
+    static int getDbId(const std::string &dbName, const std::string &nameSpace = "");
+    static std::string getSeparator(const std::string &dbName, const std::string &nameSpace = "");
+    static std::string getSeparator(int dbId, const std::string &nameSpace = "");
     static std::string getSeparator(const DBConnector* db);
-    static std::string getDbSock(const std::string &dbName);
-    static std::string getDbHostname(const std::string &dbName);
-    static int getDbPort(const std::string &dbName);
+    static std::string getDbSock(const std::string &dbName, const std::string &nameSpace = "");
+    static std::string getDbHostname(const std::string &dbName, const std::string &nameSpace = "");
+    static int getDbPort(const std::string &dbName, const std::string &nameSpace = "");
+    static std::vector<std::string> getNamespaces();
     static bool isInit() { return m_init; };
+    static bool isGlobalInit() { return m_global_init; };
 
 private:
+    static constexpr const char *DEFAULT_SONIC_DB_CONFIG_DIR = "/var/run/redis/sonic-db/";
     static constexpr const char *DEFAULT_SONIC_DB_CONFIG_FILE = "/var/run/redis/sonic-db/database_config.json";
-    // { instName, { unix_socket_path, {hostname, port} } }
-    static std::unordered_map<std::string, std::pair<std::string, std::pair<std::string, int>>> m_inst_info;
-    // { dbName, {instName, dbId} }
-    static std::unordered_map<std::string, SonicDBInfo> m_db_info;
-    // { dbIp, separator }
-    static std::unordered_map<int, std::string> m_db_separator;
+    static constexpr const char *DEFAULT_SONIC_DB_GLOBAL_CONFIG_FILE = "/var/run/redis/sonic-db/database_global.json";
+    // { namespace { instName, { unix_socket_path, hostname, port } } }
+    static std::unordered_map<std::string, std::unordered_map<std::string, SonicInstInfo>> m_inst_info;
+    // { namespace, { dbName, {instName, dbId} } }
+    static std::unordered_map<std::string, std::unordered_map<std::string, SonicDBInfo>> m_db_info;
+    // { namespace, { dbIp, separator } }
+    static std::unordered_map<std::string, std::unordered_map<int, std::string>> m_db_separator;
     static bool m_init;
+    static bool m_global_init;
 };
 
 class DBConnector
@@ -59,13 +77,14 @@ public:
      */
     DBConnector(int dbId, const std::string &hostname, int port, unsigned int timeout);
     DBConnector(int dbId, const std::string &unixPath, unsigned int timeout);
-    DBConnector(const std::string &dbName, unsigned int timeout, bool isTcpConn = false);
+    DBConnector(const std::string &dbName, unsigned int timeout, bool isTcpConn = false, const std::string &nameSpace = "");
 
     ~DBConnector();
 
     redisContext *getContext() const;
     int getDbId() const;
     std::string getDbName() const;
+    std::string getNamespace() const;
 
     static void select(DBConnector *db);
 
@@ -84,6 +103,7 @@ private:
     redisContext *m_conn;
     int m_dbId;
     std::string m_dbName;
+    std::string m_nameSpace;
 };
 
 }

--- a/common/redisselect.cpp
+++ b/common/redisselect.cpp
@@ -16,7 +16,7 @@ int RedisSelect::getFd()
 {
     return m_subscribe->getContext()->fd;
 }
-int RedisSelect::getDbId()
+int RedisSelect::getDbConnectorId()
 {
     return m_subscribe->getDbId();
 }

--- a/common/redisselect.cpp
+++ b/common/redisselect.cpp
@@ -16,6 +16,15 @@ int RedisSelect::getFd()
 {
     return m_subscribe->getContext()->fd;
 }
+int RedisSelect::getDbId()
+{
+    return m_subscribe->getDbId();
+}
+
+std::string RedisSelect::getDbNamespace()
+{
+    return m_subscribe->getNamespace();
+}
 
 uint64_t RedisSelect::readData()
 {

--- a/common/redisselect.h
+++ b/common/redisselect.h
@@ -20,6 +20,8 @@ public:
     bool hasCachedData() override;
     bool initializedWithData() override;
     void updateAfterRead() override;
+    int getDbId() override;
+    std::string getDbNamespace() override;
 
     /* Create a new redisContext, SELECT DB and SUBSCRIBE */
     void subscribe(DBConnector* db, const std::string &channelName);

--- a/common/redisselect.h
+++ b/common/redisselect.h
@@ -20,7 +20,7 @@ public:
     bool hasCachedData() override;
     bool initializedWithData() override;
     void updateAfterRead() override;
-    int getDbId() override;
+    int getDbConnectorId() override;
     std::string getDbNamespace() override;
 
     /* Create a new redisContext, SELECT DB and SUBSCRIBE */

--- a/common/selectable.h
+++ b/common/selectable.h
@@ -58,6 +58,16 @@ public:
         return m_priority;
     }
 
+    virtual int getDbId()
+    {
+        return 0;
+    }
+
+    virtual std::string getDbNamespace()
+    {
+        return std::string();
+    }
+
 private:
 
     friend class Select;

--- a/common/selectable.h
+++ b/common/selectable.h
@@ -58,7 +58,7 @@ public:
         return m_priority;
     }
 
-    virtual int getDbId()
+    virtual int getDbConnectorId()
     {
         return 0;
     }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -28,6 +28,7 @@ tests_SOURCES = redis_ut.cpp                \
                 warm_restart_ut.cpp         \
                 redis_multi_db_ut.cpp       \
                 logger_ut.cpp               \
+                redis_multi_ns_ut.cpp       \
                 fdb_flush.cpp               \
                 main.cpp
 

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -7,6 +7,8 @@ using namespace swss;
 
 string existing_file = "./tests/redis_multi_db_ut_config/database_config.json";
 string nonexisting_file = "./tests/redis_multi_db_ut_config/database_config_nonexisting.json";
+string global_existing_file = "./tests/redis_multi_db_ut_config/database_global.json";
+string global_nonexisting_file = "./tests/redis_multi_db_ut_config/database_global_nonexisting.json";
 
 class SwsscommonEnvironment : public ::testing::Environment {
 public:
@@ -32,6 +34,28 @@ public:
         SonicDBConfig::initialize(existing_file);
         cout<<"INIT: load local db config file, isInit = "<<SonicDBConfig::isInit()<<endl;
         EXPECT_TRUE(SonicDBConfig::isInit());
+
+        // Test the database_global.json file which is added newly.
+        // by default , global_init should be false
+        cout<<"Default : isGlobalInit = "<<SonicDBConfig::isGlobalInit()<<endl;
+        EXPECT_FALSE(SonicDBConfig::isGlobalInit());
+
+        // load nonexisting file, should throw exception with NO file existing
+        try
+        {
+            cout<<"INIT: loading nonexisting global db config file"<<endl;
+            SonicDBConfig::initialize(global_nonexisting_file);
+        }
+        catch (exception &e)
+        {
+            EXPECT_TRUE(strstr(e.what(), "Sonic database global file doesn't exist"));
+        }
+        EXPECT_FALSE(SonicDBConfig::isGlobalInit());
+
+        // load local global file, init should be true
+        SonicDBConfig::initializeGlobalConfig(global_existing_file);
+        cout<<"INIT: load global db config file, isInit = "<<SonicDBConfig::isGlobalInit()<<endl;
+        EXPECT_TRUE(SonicDBConfig::isGlobalInit());
     }
 };
 

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -35,7 +35,7 @@ public:
         cout<<"INIT: load local db config file, isInit = "<<SonicDBConfig::isInit()<<endl;
         EXPECT_TRUE(SonicDBConfig::isInit());
 
-        // Test the database_global.json file which is added newly.
+        // Test the database_global.json file
         // by default , global_init should be false
         cout<<"Default : isGlobalInit = "<<SonicDBConfig::isGlobalInit()<<endl;
         EXPECT_FALSE(SonicDBConfig::isGlobalInit());
@@ -44,11 +44,11 @@ public:
         try
         {
             cout<<"INIT: loading nonexisting global db config file"<<endl;
-            SonicDBConfig::initialize(global_nonexisting_file);
+            SonicDBConfig::initializeGlobalConfig(global_nonexisting_file);
         }
         catch (exception &e)
         {
-            EXPECT_TRUE(strstr(e.what(), "Sonic database global file doesn't exist"));
+            EXPECT_TRUE(strstr(e.what(), "Sonic database global config file doesn't exist"));
         }
         EXPECT_FALSE(SonicDBConfig::isGlobalInit());
 

--- a/tests/redis_multi_db_ut_config/database_config0.json
+++ b/tests/redis_multi_db_ut_config/database_config0.json
@@ -1,0 +1,82 @@
+{
+    "INSTANCES": {
+        "redis":{
+            "hostname" : "127.0.0.1",
+            "port": 6379,
+            "unix_socket_path": "/var/run/redis0/redis.sock"
+        }
+    },
+    "DATABASES" : {
+        "APPL_DB" : {
+            "id" : 0,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "ASIC_DB" : {
+            "id" : 1,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "COUNTERS_DB" : {
+            "id" : 2,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "LOGLEVEL_DB" : {
+            "id" : 3,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "CONFIG_DB" : {
+            "id" : 4,
+            "separator": "|",
+            "instance" : "redis"
+        },
+        "PFC_WD_DB" : {
+            "id" : 5,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "FLEX_COUNTER_DB" : {
+            "id" : 5,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "STATE_DB" : {
+            "id" : 6,
+            "separator": "|",
+            "instance" : "redis"
+        },
+        "SNMP_OVERLAY_DB" : {
+            "id" : 7,
+            "separator": "|",
+            "instance" : "redis"
+        },
+        "ASIC_DB2" : {
+            "id" : 10,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "COUNTERS_DB2" : {
+            "id" : 11,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "FLEX_COUNTER_DB2" : {
+            "id" : 12,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "STATE_DB2" : {
+            "id" : 13,
+            "separator": "|",
+            "instance" : "redis"
+        },
+        "TEST_DB" : {
+            "id" : 15,
+            "separator": ":",
+            "instance" : "redis"
+        }
+    },
+    "VERSION" : "1.0"
+}

--- a/tests/redis_multi_db_ut_config/database_config1.json
+++ b/tests/redis_multi_db_ut_config/database_config1.json
@@ -1,0 +1,82 @@
+{
+    "INSTANCES": {
+        "redis":{
+            "hostname" : "127.0.0.1",
+            "port": 6379,
+            "unix_socket_path": "/var/run/redis1/redis.sock"
+        }
+    },
+    "DATABASES" : {
+        "APPL_DB" : {
+            "id" : 0,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "ASIC_DB" : {
+            "id" : 1,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "COUNTERS_DB" : {
+            "id" : 2,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "LOGLEVEL_DB" : {
+            "id" : 3,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "CONFIG_DB" : {
+            "id" : 4,
+            "separator": "|",
+            "instance" : "redis"
+        },
+        "PFC_WD_DB" : {
+            "id" : 5,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "FLEX_COUNTER_DB" : {
+            "id" : 5,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "STATE_DB" : {
+            "id" : 6,
+            "separator": "|",
+            "instance" : "redis"
+        },
+        "SNMP_OVERLAY_DB" : {
+            "id" : 7,
+            "separator": "|",
+            "instance" : "redis"
+        },
+        "ASIC_DB2" : {
+            "id" : 10,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "COUNTERS_DB2" : {
+            "id" : 11,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "FLEX_COUNTER_DB2" : {
+            "id" : 12,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "STATE_DB2" : {
+            "id" : 13,
+            "separator": "|",
+            "instance" : "redis"
+        },
+        "TEST_DB" : {
+            "id" : 15,
+            "separator": ":",
+            "instance" : "redis"
+        }
+    },
+    "VERSION" : "1.0"
+}

--- a/tests/redis_multi_db_ut_config/database_global.json
+++ b/tests/redis_multi_db_ut_config/database_global.json
@@ -1,0 +1,16 @@
+{
+    "INCLUDES" : [
+        {
+            "include" : "database_config.json"
+        },
+        {
+            "namespace" : "asic0",
+            "include" : "../redis_multi_db_ut_config/database_config0.json"
+        },
+        {
+            "namespace" : "asic1",
+            "include" : "../redis_multi_db_ut_config/database_config1.json"
+        }
+    ],
+    "VERSION" : "1.0"
+}

--- a/tests/redis_multi_ns_ut.cpp
+++ b/tests/redis_multi_ns_ut.cpp
@@ -13,9 +13,9 @@ extern string global_existing_file;
 
 TEST(DBConnector, multi_ns_test)
 {
-    std::string local_file, ns_name;
-    vector<string> list;
-    vector<string> ns_list;
+    std::string local_file, dir_name, ns_name;
+    vector<string> namespaces;
+    vector<string> ns_names;
 
     // load global config file again, should throw exception with init already done
     try
@@ -34,9 +34,14 @@ TEST(DBConnector, multi_ns_test)
         json g;
         f >> g;
 
+        // Get the directory name from the file path given as input.
+        std::string::size_type pos = global_existing_file.rfind("/");
+        dir_name = global_existing_file.substr(0,pos+1);
+
         for (auto& element : g["INCLUDES"])
         {
-            local_file = element["include"];
+            local_file.append(dir_name);
+            local_file.append(element["include"]);
 
             if(element["namespace"].empty())
             {
@@ -45,11 +50,12 @@ TEST(DBConnector, multi_ns_test)
             else
             {
                 ns_name = element["namespace"];
-                list.push_back(ns_name);
+                namespaces.push_back(ns_name);
             }
 
             // parse config file
             ifstream i(local_file);
+
             if (i.good())
             {
                 json j;
@@ -83,11 +89,14 @@ TEST(DBConnector, multi_ns_test)
                    EXPECT_EQ(m_inst_info[instName].port, SonicDBConfig::getDbPort(dbName, ns_name));
                 }
             }
+             local_file.clear();
         }
     }
 
     // Get the namespaces from the database_global.json file and compare with the list we created here.
-    ns_list = SonicDBConfig::getNamespaces();
-    EXPECT_EQ(ns_list.size(), list.size());
-    EXPECT_TRUE(list == ns_list);
+    ns_names = SonicDBConfig::getNamespaces();
+    sort (namespaces.begin(), namespaces.end());
+    sort (ns_names.begin(), ns_names.end());
+    EXPECT_EQ(ns_names.size(), namespaces.size());
+    EXPECT_TRUE(namespaces == ns_names);
 }

--- a/tests/redis_multi_ns_ut.cpp
+++ b/tests/redis_multi_ns_ut.cpp
@@ -76,13 +76,13 @@ TEST(DBConnector, multi_ns_test)
                    string instName = it.value().at("instance");
                    int dbId = it.value().at("id");
                    cout<<"testing "<<dbName<<endl;
-                   cout<<instName<<"#"<<dbId<<"#"<<m_inst_info[instName].unix_socket_path<<"#"<<m_inst_info[instName].hostname<<"#"<<m_inst_info[instName].port<<endl;
+                   cout<<instName<<"#"<<dbId<<"#"<<m_inst_info[instName].unixSocketPath<<"#"<<m_inst_info[instName].hostname<<"#"<<m_inst_info[instName].port<<endl;
                    // dbInst info matches between get api and context in json file
                    EXPECT_EQ(instName, SonicDBConfig::getDbInst(dbName, ns_name));
                    // dbId info matches between get api and context in json file
                    EXPECT_EQ(dbId, SonicDBConfig::getDbId(dbName, ns_name));
                    // socket info matches between get api and context in json file
-                   EXPECT_EQ(m_inst_info[instName].unix_socket_path, SonicDBConfig::getDbSock(dbName, ns_name));
+                   EXPECT_EQ(m_inst_info[instName].unixSocketPath, SonicDBConfig::getDbSock(dbName, ns_name));
                    // hostname info matches between get api and context in json file
                    EXPECT_EQ(m_inst_info[instName].hostname, SonicDBConfig::getDbHostname(dbName, ns_name));
                    // port info matches between get api and context in json file

--- a/tests/redis_multi_ns_ut.cpp
+++ b/tests/redis_multi_ns_ut.cpp
@@ -1,0 +1,93 @@
+#include <iostream>
+#include <fstream>
+#include "gtest/gtest.h"
+#include "common/dbconnector.h"
+#include "common/json.hpp"
+#include <unordered_map>
+
+using namespace std;
+using namespace swss;
+using json = nlohmann::json;
+
+extern string global_existing_file;
+
+TEST(DBConnector, multi_ns_test)
+{
+    std::string local_file, ns_name;
+    vector<string> list;
+    vector<string> ns_list;
+
+    // load global config file again, should throw exception with init already done
+    try
+    {
+        cout<<"INIT: loading local config file again"<<endl;
+        SonicDBConfig::initializeGlobalConfig(global_existing_file);
+    }
+    catch (exception &e)
+    {
+        EXPECT_TRUE(strstr(e.what(), "SonicDBConfig already initialized"));
+    }
+
+    ifstream f(global_existing_file);
+    if (f.good())
+    {
+        json g;
+        f >> g;
+
+        for (auto& element : g["INCLUDES"])
+        {
+            local_file = element["include"];
+
+            if(element["namespace"].empty())
+            {
+                ns_name = EMPTY_NAMESPACE;
+            }
+            else
+            {
+                ns_name = element["namespace"];
+                list.push_back(ns_name);
+            }
+
+            // parse config file
+            ifstream i(local_file);
+            if (i.good())
+            {
+                json j;
+                i >> j;
+                unordered_map<string, RedisInstInfo> m_inst_info;
+                for (auto it = j["INSTANCES"].begin(); it!= j["INSTANCES"].end(); it++)
+                {
+                   string instName = it.key();
+                   string socket = it.value().at("unix_socket_path");
+                   string hostname = it.value().at("hostname");
+                   int port = it.value().at("port");
+                   m_inst_info[instName] = {socket, hostname, port};
+                }
+
+                for (auto it = j["DATABASES"].begin(); it!= j["DATABASES"].end(); it++)
+                {
+                   string dbName = it.key();
+                   string instName = it.value().at("instance");
+                   int dbId = it.value().at("id");
+                   cout<<"testing "<<dbName<<endl;
+                   cout<<instName<<"#"<<dbId<<"#"<<m_inst_info[instName].unix_socket_path<<"#"<<m_inst_info[instName].hostname<<"#"<<m_inst_info[instName].port<<endl;
+                   // dbInst info matches between get api and context in json file
+                   EXPECT_EQ(instName, SonicDBConfig::getDbInst(dbName, ns_name));
+                   // dbId info matches between get api and context in json file
+                   EXPECT_EQ(dbId, SonicDBConfig::getDbId(dbName, ns_name));
+                   // socket info matches between get api and context in json file
+                   EXPECT_EQ(m_inst_info[instName].unix_socket_path, SonicDBConfig::getDbSock(dbName, ns_name));
+                   // hostname info matches between get api and context in json file
+                   EXPECT_EQ(m_inst_info[instName].hostname, SonicDBConfig::getDbHostname(dbName, ns_name));
+                   // port info matches between get api and context in json file
+                   EXPECT_EQ(m_inst_info[instName].port, SonicDBConfig::getDbPort(dbName, ns_name));
+                }
+            }
+        }
+    }
+
+    // Get the namespaces from the database_global.json file and compare with the list we created here.
+    ns_list = SonicDBConfig::getNamespaces();
+    EXPECT_EQ(ns_list.size(), list.size());
+    EXPECT_TRUE(list == ns_list);
+}


### PR DESCRIPTION
Why:
The dbconnector classes here need to understand the namespace, to connect to redis databases running in database containers in different linux network namespaces in case of multi-asic platforms.

What:
The class data structures are modified to handle the new dimension of namespace. New api's are added to parse the database_global.json file and to retrieve the list of namespaces + parse the respective database_config.json file. The namespaces will be ""(default namespace for the linux host) and "asic0", "aisic1" .... as present in the /var/run/redis/sonic-db/database_global.json file.

How verified:
Verification was done on a multi-asic platform with pmon scripts which uses swsscommon dbconnector classes.
**Note** : testcases to be updated, in this or in a follow up PR.