### PR TITLE
Fix sai api loglevel

### DIFF
--- a/common/logger.cpp
+++ b/common/logger.cpp
@@ -174,12 +174,12 @@ Logger::Priority Logger::getMinPrio()
 
     while (true)
     {
-        if(selectables.size() < m_settingChangeObservers.size())
+        if (selectables.size() < m_settingChangeObservers.size())
         {
             for (const auto& i : m_settingChangeObservers)
             {
                 std::string dbName = i.first;
-                if(selectables.find(dbName) == selectables.end())
+                if (selectables.find(dbName) == selectables.end())
                 {
                     auto table = std::make_shared<ConsumerStateTable>(&db, dbName);
                     selectables.insert(std::make_pair(dbName, table));

--- a/common/logger.cpp
+++ b/common/logger.cpp
@@ -178,11 +178,11 @@ Logger::Priority Logger::getMinPrio()
         {
             for (const auto& i : m_settingChangeObservers)
             {
-                std::string dbName = i.first;
+                const std::string &dbName = i.first;
                 if (selectables.find(dbName) == selectables.end())
                 {
                     auto table = std::make_shared<ConsumerStateTable>(&db, dbName);
-                    selectables.insert(std::make_pair(dbName, table));
+                    selectables.emplace(dbName, table);
                     select.addSelectable(table.get());
                 }
             }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -27,6 +27,7 @@ tests_SOURCES = redis_ut.cpp                \
                 selectable_priority.cpp       \
                 warm_restart_ut.cpp         \
                 redis_multi_db_ut.cpp       \
+                logger_ut.cpp               \
                 fdb_flush.cpp               \
                 main.cpp
 

--- a/tests/logger_ut.cpp
+++ b/tests/logger_ut.cpp
@@ -1,0 +1,70 @@
+#include "common/dbconnector.h"
+#include "common/redisclient.h"
+#include "common/producerstatetable.h"
+#include "common/consumerstatetable.h"
+#include "common/select.h"
+#include "common/schema.h"
+#include "gtest/gtest.h"
+#include <unistd.h>
+
+using namespace std;
+using namespace swss;
+
+void setLoglevel(DBConnector& db, const string& component, const string& loglevel)
+{
+    ProducerStateTable table(&db, component);
+    FieldValueTuple fv(DAEMON_LOGLEVEL, loglevel);
+    std::vector<FieldValueTuple>fieldValues = { fv };
+    table.set(component, fieldValues);
+}
+
+void clearDB()
+{
+    DBConnector db("LOGLEVEL_DB", 0);
+    RedisReply r(&db, "FLUSHALL", REDIS_REPLY_STATUS);
+    r.checkStatusOK();
+}
+
+void prioNotify(const string &component, const string &prioStr)
+{
+    Logger::priorityStringMap.at(prioStr);
+}
+
+TEST(LOGGER, loglevel)
+{
+    DBConnector db("LOGLEVEL_DB", 0);
+    RedisClient redisClient(&db);
+    clearDB();
+
+    string key1 = "table1", key2 = "table2", key3 = "table3";
+    string redis_key1 = key1 + ":" + key1;
+    string redis_key2 = key2 + ":" + key2;
+    string redis_key3 = key3 + ":" + key3;
+
+    cout << "Setting log level for table1." << endl;
+    Logger::linkToDbNative(key1);
+
+    sleep(1);
+
+    cout << "Getting log level for table1." << endl;
+    string level = *redisClient.hget(redis_key1, DAEMON_LOGLEVEL);
+    EXPECT_EQ(level, "NOTICE");
+
+    cout << "Setting log level for other tables." << endl;
+    Logger::linkToDb(key2, prioNotify, "NOTICE");
+    Logger::linkToDb(key3, prioNotify, "INFO");
+    setLoglevel(db, key1, "DEBUG");
+
+    sleep(1);
+
+    cout << "Getting log levels." << endl;
+    string level1 = *redisClient.hget(redis_key1, DAEMON_LOGLEVEL);
+    string level2 = *redisClient.hget(redis_key2, DAEMON_LOGLEVEL);
+    string level3 = *redisClient.hget(redis_key3, DAEMON_LOGLEVEL);
+
+    EXPECT_EQ(level1, "DEBUG");
+    EXPECT_EQ(level2, "NOTICE");
+    EXPECT_EQ(level3, "INFO");
+
+    cout << "Done." << endl;
+}


### PR DESCRIPTION
- Why I did it
This PR contains the code changes to fix the SAI API log level issue Azure/sonic-swss-common#366

- Why this issue happens
In the initialization of syncd, the main function first calls linkToDbNative function to initialize the log level for syncd. Then the log levels for SAI APIs are initialized using linkToDb. Since the settingThread of logger is set up by linkToDbNative function and the ConsumerStateTables are set up only in the initialization of the thread, the SAI API log levels in only added to m_settingChangeObservers, whereas the corresponding ConsumerStateTables are not created. Therefore, the SAI API log levels are not successfully initialized.

- How I did it
Instead of creating ConsumerStateTables at the initialization of settingThread, I create ConsumerStateTables in the execution loop of the thread. Such a change fixes the issue by allowing to create the corresponding ConsumerStateTables when there are new items added to m_settingChangeObservers.

- How to verify it
Verify all SAI API log levels are correctly initialized and can be modified in vs tests. A unit test is also added to simulate the scenario and verify the log levels can be properly handled.
