### PR TITLE
Reintroducing PR #364 - DBconnector to support namespaces.

### DIFF
--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -82,7 +82,6 @@ void SonicDBConfig::initializeGlobalConfig(const string &file)
         return;
     }
 
-
     ifstream i(file);
     if (i.good())
     {
@@ -126,6 +125,12 @@ void SonicDBConfig::initializeGlobalConfig(const string &file)
                 m_db_info[ns_name] = db_entry;
                 m_db_separator[ns_name] = separator_entry;
 
+                if(element["namespace"].empty())
+                {
+                    // Make regular init also done
+                    m_init = true;
+                }
+
                 inst_entry.clear();
                 db_entry.clear();
                 separator_entry.clear();
@@ -143,20 +148,17 @@ void SonicDBConfig::initializeGlobalConfig(const string &file)
             SWSS_LOG_ERROR("Sonic database config file syntax error >> %s\n", e.what());
             throw runtime_error("Sonic database config file syntax error >> " + string(e.what()));
         }
-
-        // Set it as the global config file is already parsed and init done.
-        m_global_init = true;
-
-        // Make regular init also done
-        m_init = true;
     }
     else
     {
         SWSS_LOG_ERROR("Sonic database config global file doesn't exist at %s\n", file.c_str());
     }
+
+    // Set it as the global config file is already parsed and init done.
+    m_global_init = true;
 }
 
-void SonicDBConfig::initialize(const string &file, const string &nameSpace)
+void SonicDBConfig::initialize(const string &file)
 {
     std::unordered_map<std::string, SonicDBInfo> db_entry;
     std::unordered_map<std::string, RedisInstInfo> inst_entry;
@@ -164,32 +166,19 @@ void SonicDBConfig::initialize(const string &file, const string &nameSpace)
 
     SWSS_LOG_ENTER();
 
-    // namespace string is empty, use the file given as input to parse.
-    if(nameSpace.empty())
+    if (m_init)
     {
-        if (m_init)
-        {
-            SWSS_LOG_ERROR("SonicDBConfig already initialized");
-            throw runtime_error("SonicDBConfig already initialized");
-        }
-
-        parseDatabaseConfig(file, inst_entry, db_entry, separator_entry);
-        m_inst_info[EMPTY_NAMESPACE] = inst_entry;
-        m_db_info[EMPTY_NAMESPACE] = db_entry;
-        m_db_separator[EMPTY_NAMESPACE] = separator_entry;
-
-        // Set it as the config file is already parsed and init done.
-        m_init = true;
+        SWSS_LOG_ERROR("SonicDBConfig already initialized");
+        throw runtime_error("SonicDBConfig already initialized");
     }
-    else
-    {
-        // If global initialization is not done, ask user to initialize global DB Config first.
-        if (!m_global_init)
-        {
-            SWSS_LOG_ERROR("Initialize global DB config first using API SonicDBConfig::initializeGlobalConfig \n");
-            throw runtime_error("Initialize global DB config using API SonicDBConfig::initializeGlobalConfig");
-        }
-    }
+
+    parseDatabaseConfig(file, inst_entry, db_entry, separator_entry);
+    m_inst_info[EMPTY_NAMESPACE] = inst_entry;
+    m_db_info[EMPTY_NAMESPACE] = db_entry;
+    m_db_separator[EMPTY_NAMESPACE] = separator_entry;
+
+    // Set it as the config file is already parsed and init done.
+    m_init = true;
 }
 
 void SonicDBConfig::validateNamespace(const string &nameSpace)
@@ -219,7 +208,7 @@ void SonicDBConfig::validateNamespace(const string &nameSpace)
 string SonicDBConfig::getDbInst(const string &dbName, const string &nameSpace)
 {
     if (!m_init)
-        initialize(DEFAULT_SONIC_DB_CONFIG_FILE, nameSpace);
+        initialize(DEFAULT_SONIC_DB_CONFIG_FILE);
     validateNamespace(nameSpace);
     return m_db_info[nameSpace].at(dbName).instName;
 }
@@ -227,7 +216,7 @@ string SonicDBConfig::getDbInst(const string &dbName, const string &nameSpace)
 int SonicDBConfig::getDbId(const string &dbName, const string &nameSpace)
 {
     if (!m_init)
-        initialize(DEFAULT_SONIC_DB_CONFIG_FILE, nameSpace);
+        initialize(DEFAULT_SONIC_DB_CONFIG_FILE);
     validateNamespace(nameSpace);
     return m_db_info[nameSpace].at(dbName).dbId;
 }
@@ -235,7 +224,7 @@ int SonicDBConfig::getDbId(const string &dbName, const string &nameSpace)
 string SonicDBConfig::getSeparator(const string &dbName, const string &nameSpace)
 {
     if (!m_init)
-        initialize(DEFAULT_SONIC_DB_CONFIG_FILE, nameSpace);
+        initialize(DEFAULT_SONIC_DB_CONFIG_FILE);
     validateNamespace(nameSpace);
     return m_db_info[nameSpace].at(dbName).separator;
 }
@@ -243,7 +232,7 @@ string SonicDBConfig::getSeparator(const string &dbName, const string &nameSpace
 string SonicDBConfig::getSeparator(int dbId, const string &nameSpace)
 {
     if (!m_init)
-        initialize(DEFAULT_SONIC_DB_CONFIG_FILE, nameSpace);
+        initialize(DEFAULT_SONIC_DB_CONFIG_FILE);
     validateNamespace(nameSpace);
     return m_db_separator[nameSpace].at(dbId);
 }
@@ -270,7 +259,7 @@ string SonicDBConfig::getSeparator(const DBConnector* db)
 string SonicDBConfig::getDbSock(const string &dbName, const string &nameSpace)
 {
     if (!m_init)
-        initialize(DEFAULT_SONIC_DB_CONFIG_FILE, nameSpace);
+        initialize(DEFAULT_SONIC_DB_CONFIG_FILE);
     validateNamespace(nameSpace);
     return m_inst_info[nameSpace].at(getDbInst(dbName)).unixSocketPath;
 }
@@ -278,7 +267,7 @@ string SonicDBConfig::getDbSock(const string &dbName, const string &nameSpace)
 string SonicDBConfig::getDbHostname(const string &dbName, const string &nameSpace)
 {
     if (!m_init)
-        initialize(DEFAULT_SONIC_DB_CONFIG_FILE, nameSpace);
+        initialize(DEFAULT_SONIC_DB_CONFIG_FILE);
     validateNamespace(nameSpace);
     return m_inst_info[nameSpace].at(getDbInst(dbName)).hostname;
 }
@@ -286,7 +275,7 @@ string SonicDBConfig::getDbHostname(const string &dbName, const string &nameSpac
 int SonicDBConfig::getDbPort(const string &dbName, const string &nameSpace)
 {
     if (!m_init)
-        initialize(DEFAULT_SONIC_DB_CONFIG_FILE, nameSpace);
+        initialize(DEFAULT_SONIC_DB_CONFIG_FILE);
     validateNamespace(nameSpace);
     return m_inst_info[nameSpace].at(getDbInst(dbName)).port;
 }

--- a/common/dbconnector.h
+++ b/common/dbconnector.h
@@ -7,10 +7,19 @@
 #include <utility>
 
 #include <hiredis/hiredis.h>
+#define EMPTY_NAMESPACE std::string()
 
 namespace swss {
 
 class DBConnector;
+
+class RedisInstInfo
+{
+public:
+    std::string unixSocketPath;
+    std::string hostname;
+    int port;
+};
 
 class SonicDBInfo
 {
@@ -23,26 +32,35 @@ public:
 class SonicDBConfig
 {
 public:
-    static void initialize(const std::string &file = DEFAULT_SONIC_DB_CONFIG_FILE);
-    static std::string getDbInst(const std::string &dbName);
-    static int getDbId(const std::string &dbName);
-    static std::string getSeparator(const std::string &dbName);
-    static std::string getSeparator(int dbId);
+    static void initialize(const std::string &file = DEFAULT_SONIC_DB_CONFIG_FILE, const std::string &nameSpace = EMPTY_NAMESPACE);
+    static void initializeGlobalConfig(const std::string &file = DEFAULT_SONIC_DB_GLOBAL_CONFIG_FILE);
+    static std::string getDbInst(const std::string &dbName, const std::string &nameSpace = EMPTY_NAMESPACE);
+    static int getDbId(const std::string &dbName, const std::string &nameSpace = EMPTY_NAMESPACE);
+    static std::string getSeparator(const std::string &dbName, const std::string &nameSpace = EMPTY_NAMESPACE);
+    static std::string getSeparator(int dbId, const std::string &nameSpace = EMPTY_NAMESPACE);
     static std::string getSeparator(const DBConnector* db);
-    static std::string getDbSock(const std::string &dbName);
-    static std::string getDbHostname(const std::string &dbName);
-    static int getDbPort(const std::string &dbName);
+    static std::string getDbSock(const std::string &dbName, const std::string &nameSpace = EMPTY_NAMESPACE);
+    static std::string getDbHostname(const std::string &dbName, const std::string &nameSpace = EMPTY_NAMESPACE);
+    static int getDbPort(const std::string &dbName, const std::string &nameSpace = EMPTY_NAMESPACE);
+    static std::vector<std::string> getNamespaces();
     static bool isInit() { return m_init; };
+    static bool isGlobalInit() { return m_global_init; };
 
 private:
     static constexpr const char *DEFAULT_SONIC_DB_CONFIG_FILE = "/var/run/redis/sonic-db/database_config.json";
-    // { instName, { unix_socket_path, {hostname, port} } }
-    static std::unordered_map<std::string, std::pair<std::string, std::pair<std::string, int>>> m_inst_info;
-    // { dbName, {instName, dbId} }
-    static std::unordered_map<std::string, SonicDBInfo> m_db_info;
-    // { dbIp, separator }
-    static std::unordered_map<int, std::string> m_db_separator;
+    static constexpr const char *DEFAULT_SONIC_DB_GLOBAL_CONFIG_FILE = "/var/run/redis/sonic-db/database_global.json";
+    // { namespace { instName, { unix_socket_path, hostname, port } } }
+    static std::unordered_map<std::string, std::unordered_map<std::string, RedisInstInfo>> m_inst_info;
+    // { namespace, { dbName, {instName, dbId, separator} } }
+    static std::unordered_map<std::string, std::unordered_map<std::string, SonicDBInfo>> m_db_info;
+    // { namespace, { dbId, separator } }
+    static std::unordered_map<std::string, std::unordered_map<int, std::string>> m_db_separator;
     static bool m_init;
+    static bool m_global_init;
+    static void parseDatabaseConfig(const std::string &file,
+                                    std::unordered_map<std::string, RedisInstInfo> &inst_entry,
+                                    std::unordered_map<std::string, SonicDBInfo> &db_entry,
+                                    std::unordered_map<int, std::string> &separator_entry);
 };
 
 class DBConnector
@@ -59,13 +77,14 @@ public:
      */
     DBConnector(int dbId, const std::string &hostname, int port, unsigned int timeout);
     DBConnector(int dbId, const std::string &unixPath, unsigned int timeout);
-    DBConnector(const std::string &dbName, unsigned int timeout, bool isTcpConn = false);
+    DBConnector(const std::string &dbName, unsigned int timeout, bool isTcpConn = false, const std::string &nameSpace = EMPTY_NAMESPACE);
 
     ~DBConnector();
 
     redisContext *getContext() const;
     int getDbId() const;
     std::string getDbName() const;
+    std::string getNamespace() const;
 
     static void select(DBConnector *db);
 
@@ -84,6 +103,7 @@ private:
     redisContext *m_conn;
     int m_dbId;
     std::string m_dbName;
+    std::string m_namespace;
 };
 
 }

--- a/common/dbconnector.h
+++ b/common/dbconnector.h
@@ -34,6 +34,7 @@ class SonicDBConfig
 public:
     static void initialize(const std::string &file = DEFAULT_SONIC_DB_CONFIG_FILE, const std::string &nameSpace = EMPTY_NAMESPACE);
     static void initializeGlobalConfig(const std::string &file = DEFAULT_SONIC_DB_GLOBAL_CONFIG_FILE);
+    static void validateNamespace(const std::string &nameSpace);
     static std::string getDbInst(const std::string &dbName, const std::string &nameSpace = EMPTY_NAMESPACE);
     static int getDbId(const std::string &dbName, const std::string &nameSpace = EMPTY_NAMESPACE);
     static std::string getSeparator(const std::string &dbName, const std::string &nameSpace = EMPTY_NAMESPACE);
@@ -77,7 +78,8 @@ public:
      */
     DBConnector(int dbId, const std::string &hostname, int port, unsigned int timeout);
     DBConnector(int dbId, const std::string &unixPath, unsigned int timeout);
-    DBConnector(const std::string &dbName, unsigned int timeout, bool isTcpConn = false, const std::string &nameSpace = EMPTY_NAMESPACE);
+    DBConnector(const std::string &dbName, unsigned int timeout, bool isTcpConn = false);
+    DBConnector(const std::string &dbName, unsigned int timeout, bool isTcpConn, const std::string &nameSpace);
 
     ~DBConnector();
 

--- a/common/dbconnector.h
+++ b/common/dbconnector.h
@@ -32,7 +32,7 @@ public:
 class SonicDBConfig
 {
 public:
-    static void initialize(const std::string &file = DEFAULT_SONIC_DB_CONFIG_FILE, const std::string &nameSpace = EMPTY_NAMESPACE);
+    static void initialize(const std::string &file = DEFAULT_SONIC_DB_CONFIG_FILE);
     static void initializeGlobalConfig(const std::string &file = DEFAULT_SONIC_DB_GLOBAL_CONFIG_FILE);
     static void validateNamespace(const std::string &nameSpace);
     static std::string getDbInst(const std::string &dbName, const std::string &nameSpace = EMPTY_NAMESPACE);

--- a/common/redisselect.cpp
+++ b/common/redisselect.cpp
@@ -16,6 +16,15 @@ int RedisSelect::getFd()
 {
     return m_subscribe->getContext()->fd;
 }
+int RedisSelect::getDbConnectorId()
+{
+    return m_subscribe->getDbId();
+}
+
+std::string RedisSelect::getDbNamespace()
+{
+    return m_subscribe->getNamespace();
+}
 
 uint64_t RedisSelect::readData()
 {

--- a/common/redisselect.h
+++ b/common/redisselect.h
@@ -20,6 +20,8 @@ public:
     bool hasCachedData() override;
     bool initializedWithData() override;
     void updateAfterRead() override;
+    int getDbConnectorId() override;
+    std::string getDbNamespace() override;
 
     /* Create a new redisContext, SELECT DB and SUBSCRIBE */
     void subscribe(DBConnector* db, const std::string &channelName);

--- a/common/selectable.h
+++ b/common/selectable.h
@@ -58,6 +58,16 @@ public:
         return m_priority;
     }
 
+    virtual int getDbConnectorId()
+    {
+        return 0;
+    }
+
+    virtual std::string getDbNamespace()
+    {
+        return std::string();
+    }
+
 private:
 
     friend class Select;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -28,6 +28,7 @@ tests_SOURCES = redis_ut.cpp                \
                 warm_restart_ut.cpp         \
                 redis_multi_db_ut.cpp       \
                 logger_ut.cpp               \
+                redis_multi_ns_ut.cpp       \
                 fdb_flush.cpp               \
                 main.cpp
 

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -7,6 +7,8 @@ using namespace swss;
 
 string existing_file = "./tests/redis_multi_db_ut_config/database_config.json";
 string nonexisting_file = "./tests/redis_multi_db_ut_config/database_config_nonexisting.json";
+string global_existing_file = "./tests/redis_multi_db_ut_config/database_global.json";
+string global_nonexisting_file = "./tests/redis_multi_db_ut_config/database_global_nonexisting.json";
 
 class SwsscommonEnvironment : public ::testing::Environment {
 public:
@@ -32,6 +34,28 @@ public:
         SonicDBConfig::initialize(existing_file);
         cout<<"INIT: load local db config file, isInit = "<<SonicDBConfig::isInit()<<endl;
         EXPECT_TRUE(SonicDBConfig::isInit());
+
+        // Test the database_global.json file
+        // by default , global_init should be false
+        cout<<"Default : isGlobalInit = "<<SonicDBConfig::isGlobalInit()<<endl;
+        EXPECT_FALSE(SonicDBConfig::isGlobalInit());
+
+        // load nonexisting file, should throw exception with NO file existing
+        try
+        {
+            cout<<"INIT: loading nonexisting global db config file"<<endl;
+            SonicDBConfig::initializeGlobalConfig(global_nonexisting_file);
+        }
+        catch (exception &e)
+        {
+            EXPECT_TRUE(strstr(e.what(), "Sonic database global config file doesn't exist"));
+        }
+        EXPECT_FALSE(SonicDBConfig::isGlobalInit());
+
+        // load local global file, init should be true
+        SonicDBConfig::initializeGlobalConfig(global_existing_file);
+        cout<<"INIT: load global db config file, isInit = "<<SonicDBConfig::isGlobalInit()<<endl;
+        EXPECT_TRUE(SonicDBConfig::isGlobalInit());
     }
 };
 

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -8,7 +8,6 @@ using namespace swss;
 string existing_file = "./tests/redis_multi_db_ut_config/database_config.json";
 string nonexisting_file = "./tests/redis_multi_db_ut_config/database_config_nonexisting.json";
 string global_existing_file = "./tests/redis_multi_db_ut_config/database_global.json";
-string global_nonexisting_file = "./tests/redis_multi_db_ut_config/database_global_nonexisting.json";
 
 #define TEST_DB  "APPL_DB"
 #define TEST_NAMESPACE  "asic0"
@@ -55,11 +54,6 @@ public:
             EXPECT_TRUE(strstr(e.what(), "Initialize global DB config using API SonicDBConfig::initializeGlobalConfig"));
         }
 
-        // load nonexisting database_global.json file, no exception thrown, and global_init flag is still False.
-        cout<<"INIT: loading nonexisting global db config file"<<endl;
-        SonicDBConfig::initializeGlobalConfig(global_nonexisting_file);
-        EXPECT_FALSE(SonicDBConfig::isGlobalInit());
-
         // load local global file, init should be true
         SonicDBConfig::initializeGlobalConfig(global_existing_file);
         cout<<"INIT: load global db config file, isInit = "<<SonicDBConfig::isGlobalInit()<<endl;
@@ -75,6 +69,7 @@ public:
         {
             EXPECT_TRUE(strstr(e.what(), "Namespace invalid is not a valid namespace name in config file"));
         }
+
     }
 };
 

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -10,6 +10,10 @@ string nonexisting_file = "./tests/redis_multi_db_ut_config/database_config_none
 string global_existing_file = "./tests/redis_multi_db_ut_config/database_global.json";
 string global_nonexisting_file = "./tests/redis_multi_db_ut_config/database_global_nonexisting.json";
 
+#define TEST_DB  "APPL_DB"
+#define TEST_NAMESPACE  "asic0"
+#define INVALID_NAMESPACE  "invalid"
+
 class SwsscommonEnvironment : public ::testing::Environment {
 public:
     // Override this to define how to set up the environment.
@@ -40,22 +44,37 @@ public:
         cout<<"Default : isGlobalInit = "<<SonicDBConfig::isGlobalInit()<<endl;
         EXPECT_FALSE(SonicDBConfig::isGlobalInit());
 
-        // load nonexisting file, should throw exception with NO file existing
+        // Call an API which actually needs the data populated by SonicDBConfig::initializeGlobalConfig
         try
         {
-            cout<<"INIT: loading nonexisting global db config file"<<endl;
-            SonicDBConfig::initializeGlobalConfig(global_nonexisting_file);
+            cout<<"INIT: Invoking SonicDBConfig::getDbId(APPL_DB, asic0)"<<endl;
+            SonicDBConfig::getDbId(TEST_DB, TEST_NAMESPACE);
         }
         catch (exception &e)
         {
-            EXPECT_TRUE(strstr(e.what(), "Sonic database global config file doesn't exist"));
+            EXPECT_TRUE(strstr(e.what(), "Initialize global DB config using API SonicDBConfig::initializeGlobalConfig"));
         }
+
+        // load nonexisting database_global.json file, no exception thrown, and global_init flag is still False.
+        cout<<"INIT: loading nonexisting global db config file"<<endl;
+        SonicDBConfig::initializeGlobalConfig(global_nonexisting_file);
         EXPECT_FALSE(SonicDBConfig::isGlobalInit());
 
         // load local global file, init should be true
         SonicDBConfig::initializeGlobalConfig(global_existing_file);
         cout<<"INIT: load global db config file, isInit = "<<SonicDBConfig::isGlobalInit()<<endl;
         EXPECT_TRUE(SonicDBConfig::isGlobalInit());
+
+        // Call an API with wrong namespace passed
+        try
+        {
+            cout<<"INIT: Invoking SonicDBConfig::getDbId(APPL_DB, invalid)"<<endl;
+            SonicDBConfig::getDbId(TEST_DB, INVALID_NAMESPACE);
+        }
+        catch (exception &e)
+        {
+            EXPECT_TRUE(strstr(e.what(), "Namespace invalid is not a valid namespace name in config file"));
+        }
     }
 };
 

--- a/tests/redis_multi_db_ut_config/database_config0.json
+++ b/tests/redis_multi_db_ut_config/database_config0.json
@@ -1,0 +1,82 @@
+{
+    "INSTANCES": {
+        "redis":{
+            "hostname" : "127.0.0.1",
+            "port": 6379,
+            "unix_socket_path": "/var/run/redis0/redis.sock"
+        }
+    },
+    "DATABASES" : {
+        "APPL_DB" : {
+            "id" : 0,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "ASIC_DB" : {
+            "id" : 1,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "COUNTERS_DB" : {
+            "id" : 2,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "LOGLEVEL_DB" : {
+            "id" : 3,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "CONFIG_DB" : {
+            "id" : 4,
+            "separator": "|",
+            "instance" : "redis"
+        },
+        "PFC_WD_DB" : {
+            "id" : 5,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "FLEX_COUNTER_DB" : {
+            "id" : 5,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "STATE_DB" : {
+            "id" : 6,
+            "separator": "|",
+            "instance" : "redis"
+        },
+        "SNMP_OVERLAY_DB" : {
+            "id" : 7,
+            "separator": "|",
+            "instance" : "redis"
+        },
+        "ASIC_DB2" : {
+            "id" : 10,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "COUNTERS_DB2" : {
+            "id" : 11,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "FLEX_COUNTER_DB2" : {
+            "id" : 12,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "STATE_DB2" : {
+            "id" : 13,
+            "separator": "|",
+            "instance" : "redis"
+        },
+        "TEST_DB" : {
+            "id" : 15,
+            "separator": ":",
+            "instance" : "redis"
+        }
+    },
+    "VERSION" : "1.0"
+}

--- a/tests/redis_multi_db_ut_config/database_config1.json
+++ b/tests/redis_multi_db_ut_config/database_config1.json
@@ -1,0 +1,82 @@
+{
+    "INSTANCES": {
+        "redis":{
+            "hostname" : "127.0.0.1",
+            "port": 6379,
+            "unix_socket_path": "/var/run/redis1/redis.sock"
+        }
+    },
+    "DATABASES" : {
+        "APPL_DB" : {
+            "id" : 0,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "ASIC_DB" : {
+            "id" : 1,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "COUNTERS_DB" : {
+            "id" : 2,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "LOGLEVEL_DB" : {
+            "id" : 3,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "CONFIG_DB" : {
+            "id" : 4,
+            "separator": "|",
+            "instance" : "redis"
+        },
+        "PFC_WD_DB" : {
+            "id" : 5,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "FLEX_COUNTER_DB" : {
+            "id" : 5,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "STATE_DB" : {
+            "id" : 6,
+            "separator": "|",
+            "instance" : "redis"
+        },
+        "SNMP_OVERLAY_DB" : {
+            "id" : 7,
+            "separator": "|",
+            "instance" : "redis"
+        },
+        "ASIC_DB2" : {
+            "id" : 10,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "COUNTERS_DB2" : {
+            "id" : 11,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "FLEX_COUNTER_DB2" : {
+            "id" : 12,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "STATE_DB2" : {
+            "id" : 13,
+            "separator": "|",
+            "instance" : "redis"
+        },
+        "TEST_DB" : {
+            "id" : 15,
+            "separator": ":",
+            "instance" : "redis"
+        }
+    },
+    "VERSION" : "1.0"
+}

--- a/tests/redis_multi_db_ut_config/database_global.json
+++ b/tests/redis_multi_db_ut_config/database_global.json
@@ -1,0 +1,16 @@
+{
+    "INCLUDES" : [
+        {
+            "include" : "database_config.json"
+        },
+        {
+            "namespace" : "asic0",
+            "include" : "../redis_multi_db_ut_config/database_config0.json"
+        },
+        {
+            "namespace" : "asic1",
+            "include" : "../redis_multi_db_ut_config/database_config1.json"
+        }
+    ],
+    "VERSION" : "1.0"
+}

--- a/tests/redis_multi_ns_ut.cpp
+++ b/tests/redis_multi_ns_ut.cpp
@@ -1,0 +1,102 @@
+#include <iostream>
+#include <fstream>
+#include "gtest/gtest.h"
+#include "common/dbconnector.h"
+#include "common/json.hpp"
+#include <unordered_map>
+
+using namespace std;
+using namespace swss;
+using json = nlohmann::json;
+
+extern string global_existing_file;
+
+TEST(DBConnector, multi_ns_test)
+{
+    std::string local_file, dir_name, ns_name;
+    vector<string> namespaces;
+    vector<string> ns_names;
+
+    // load global config file again, should throw exception with init already done
+    try
+    {
+        cout<<"INIT: loading local config file again"<<endl;
+        SonicDBConfig::initializeGlobalConfig(global_existing_file);
+    }
+    catch (exception &e)
+    {
+        EXPECT_TRUE(strstr(e.what(), "SonicDBConfig already initialized"));
+    }
+
+    ifstream f(global_existing_file);
+    if (f.good())
+    {
+        json g;
+        f >> g;
+
+        // Get the directory name from the file path given as input.
+        std::string::size_type pos = global_existing_file.rfind("/");
+        dir_name = global_existing_file.substr(0,pos+1);
+
+        for (auto& element : g["INCLUDES"])
+        {
+            local_file.append(dir_name);
+            local_file.append(element["include"]);
+
+            if(element["namespace"].empty())
+            {
+                ns_name = EMPTY_NAMESPACE;
+            }
+            else
+            {
+                ns_name = element["namespace"];
+                namespaces.push_back(ns_name);
+            }
+
+            // parse config file
+            ifstream i(local_file);
+
+            if (i.good())
+            {
+                json j;
+                i >> j;
+                unordered_map<string, RedisInstInfo> m_inst_info;
+                for (auto it = j["INSTANCES"].begin(); it!= j["INSTANCES"].end(); it++)
+                {
+                   string instName = it.key();
+                   string socket = it.value().at("unix_socket_path");
+                   string hostname = it.value().at("hostname");
+                   int port = it.value().at("port");
+                   m_inst_info[instName] = {socket, hostname, port};
+                }
+
+                for (auto it = j["DATABASES"].begin(); it!= j["DATABASES"].end(); it++)
+                {
+                   string dbName = it.key();
+                   string instName = it.value().at("instance");
+                   int dbId = it.value().at("id");
+                   cout<<"testing "<<dbName<<endl;
+                   cout<<instName<<"#"<<dbId<<"#"<<m_inst_info[instName].unixSocketPath<<"#"<<m_inst_info[instName].hostname<<"#"<<m_inst_info[instName].port<<endl;
+                   // dbInst info matches between get api and context in json file
+                   EXPECT_EQ(instName, SonicDBConfig::getDbInst(dbName, ns_name));
+                   // dbId info matches between get api and context in json file
+                   EXPECT_EQ(dbId, SonicDBConfig::getDbId(dbName, ns_name));
+                   // socket info matches between get api and context in json file
+                   EXPECT_EQ(m_inst_info[instName].unixSocketPath, SonicDBConfig::getDbSock(dbName, ns_name));
+                   // hostname info matches between get api and context in json file
+                   EXPECT_EQ(m_inst_info[instName].hostname, SonicDBConfig::getDbHostname(dbName, ns_name));
+                   // port info matches between get api and context in json file
+                   EXPECT_EQ(m_inst_info[instName].port, SonicDBConfig::getDbPort(dbName, ns_name));
+                }
+            }
+             local_file.clear();
+        }
+    }
+
+    // Get the namespaces from the database_global.json file and compare with the list we created here.
+    ns_names = SonicDBConfig::getNamespaces();
+    sort (namespaces.begin(), namespaces.end());
+    sort (ns_names.begin(), ns_names.end());
+    EXPECT_EQ(ns_names.size(), namespaces.size());
+    EXPECT_TRUE(namespaces == ns_names);
+}

--- a/tests/redis_multi_ns_ut.cpp
+++ b/tests/redis_multi_ns_ut.cpp
@@ -76,7 +76,7 @@ TEST(DBConnector, multi_ns_test)
                    string instName = it.value().at("instance");
                    int dbId = it.value().at("id");
                    cout<<"testing "<<dbName<<endl;
-                   cout<<instName<<"#"<<dbId<<"#"<<m_inst_info[instName].unixSocketPath<<"#"<<m_inst_info[instName].hostname<<"#"<<m_inst_info[instName].port<<endl;
+                   cout<<ns_name<<"#"<<dbId<<dbName<<"#"<<m_inst_info[instName].unixSocketPath<<"#"<<m_inst_info[instName].hostname<<"#"<<m_inst_info[instName].port<<endl;
                    // dbInst info matches between get api and context in json file
                    EXPECT_EQ(instName, SonicDBConfig::getDbInst(dbName, ns_name));
                    // dbId info matches between get api and context in json file


### PR DESCRIPTION
Adding PR #364 back. 

It was reverted earlier as there was a build failure with **sonic-swss/tests/mock_tests/mock_dbconnector.cpp** failing to build due to DBConnnector constructor being redefined there (Issue mentioned in https://github.com/Azure/sonic-swss/issues/1363). 
I have addressed it now by keeping the old constructor and delegating that to the new constructor which has "namespace" as additional argument.

This PR, I have included the changes to further align the dbConnector class here in sonic-swss-common with one present in sonic-py-swssdk
       1. Ignore ( don't throw exception ) if the database_global.json file is not present.
       2. validate the namespace before using it.