### PR TITLE
Removed DB specific get api's from Selectable class

### DIFF
--- a/common/redisselect.cpp
+++ b/common/redisselect.cpp
@@ -16,14 +16,10 @@ int RedisSelect::getFd()
 {
     return m_subscribe->getContext()->fd;
 }
-int RedisSelect::getDbConnectorId()
-{
-    return m_subscribe->getDbId();
-}
 
-std::string RedisSelect::getDbNamespace()
+const DBConnector* RedisSelect::getDbConnector() const
 {
-    return m_subscribe->getNamespace();
+    return m_subscribe.get();
 }
 
 uint64_t RedisSelect::readData()

--- a/common/redisselect.h
+++ b/common/redisselect.h
@@ -20,8 +20,7 @@ public:
     bool hasCachedData() override;
     bool initializedWithData() override;
     void updateAfterRead() override;
-    int getDbConnectorId();
-    std::string getDbNamespace();
+    const DBConnector* getDbConnector() const;
 
     /* Create a new redisContext, SELECT DB and SUBSCRIBE */
     void subscribe(DBConnector* db, const std::string &channelName);

--- a/common/redisselect.h
+++ b/common/redisselect.h
@@ -20,8 +20,8 @@ public:
     bool hasCachedData() override;
     bool initializedWithData() override;
     void updateAfterRead() override;
-    int getDbConnectorId() override;
-    std::string getDbNamespace() override;
+    int getDbConnectorId();
+    std::string getDbNamespace();
 
     /* Create a new redisContext, SELECT DB and SUBSCRIBE */
     void subscribe(DBConnector* db, const std::string &channelName);

--- a/common/selectable.h
+++ b/common/selectable.h
@@ -58,16 +58,6 @@ public:
         return m_priority;
     }
 
-    virtual int getDbConnectorId()
-    {
-        return 0;
-    }
-
-    virtual std::string getDbNamespace()
-    {
-        return std::string();
-    }
-
 private:
 
     friend class Select;

--- a/pyext/swsscommon.i
+++ b/pyext/swsscommon.i
@@ -35,6 +35,12 @@
 %typemap(in, numinputs=0) swss::Selectable ** (swss::Selectable *temp) {
     $1 = &temp;
 }
+
+%inline %{
+swss::RedisSelect *CastSelectableToRedisSelectObj(swss::Selectable *temp) {
+  return dynamic_cast<swss::RedisSelect *>(temp);
+}
+%}
 %typemap(argout) swss::Selectable ** {
     PyObject* temp = NULL;
     if (!PyList_Check($result)) {

--- a/pyext/swsscommon.i
+++ b/pyext/swsscommon.i
@@ -36,11 +36,6 @@
     $1 = &temp;
 }
 
-%inline %{
-swss::RedisSelect *CastSelectableToRedisSelectObj(swss::Selectable *temp) {
-  return dynamic_cast<swss::RedisSelect *>(temp);
-}
-%}
 %typemap(argout) swss::Selectable ** {
     PyObject* temp = NULL;
     if (!PyList_Check($result)) {
@@ -51,6 +46,13 @@ swss::RedisSelect *CastSelectableToRedisSelectObj(swss::Selectable *temp) {
     temp = SWIG_NewPointerObj(*$1, SWIGTYPE_p_swss__Selectable, 0);
     SWIG_Python_AppendOutput($result, temp);
 }
+
+%inline %{
+swss::RedisSelect *CastSelectableToRedisSelectObj(swss::Selectable *temp) {
+  return dynamic_cast<swss::RedisSelect *>(temp);
+}
+%}
+
 %include "schema.h"
 %include "dbconnector.h"
 %include "selectable.h"


### PR DESCRIPTION
Why/What I did:-

Change 1:
As per review comments on https://github.com/Azure/sonic-swss-common/pull/376
removed DB specific API from selectable class
to keep it generic.

Change 2: 
However to access to the Dervied Class Redis Select
DB API's via python we need to downcast the the Selectable Object
to RedisSelect object. 
To do this added Helper function  in swig .i file Ref: http://www.swig.org/Doc3.0/Python.html

How I verify:
After this change updated client caclmgrd to call new downcast API and verified we are getting correct information.
Sample Client Side code after this change -

        (state, selectableObj) = sel.select(SELECT_TIMEOUT_MS)
            # Continue if select is timeout or selectable object is not return
            if state != swsscommon.Select.OBJECT:
                continue
            # Get the corresponding namespace from selectable object

            redisSelectObj = swsscommon.CastSelectableToRedisSelectObj(selectableObj)

            namespace = redisSelectObj.getDbConnector().getNamespace()

