### PR TITLE
Fix SubscriberStateTable::hasCachedData formula for a timing risk

### DIFF
--- a/common/subscriberstatetable.cpp
+++ b/common/subscriberstatetable.cpp
@@ -89,7 +89,7 @@ bool SubscriberStateTable::hasData()
 
 bool SubscriberStateTable::hasCachedData()
 {
-    return m_buffer.size() > 1 || m_keyspace_event_buffer.size() > 1;
+    return m_buffer.size() + m_keyspace_event_buffer.size() > 1;
 }
 
 void SubscriberStateTable::pops(deque<KeyOpFieldsValuesTuple> &vkco, const string& /*prefix*/)

--- a/tests/redis_subscriber_state_ut.cpp
+++ b/tests/redis_subscriber_state_ut.cpp
@@ -222,6 +222,129 @@ TEST(SubscriberStateTable, set)
     }
 }
 
+TEST(SubscriberStateTable, set2_pop1_set1_pop1)
+{
+    clearDB();
+
+    /* Prepare producer */
+    DBConnector db("TEST_DB", 0, true);
+    Table p(&db, testTableName);
+    //string key = "TheKey";
+    int maxNumOfFields = 2;
+
+    /* Prepare subscriber */
+    SubscriberStateTable c(&db, testTableName);
+    Select cs;
+    Selectable *selectcs;
+    cs.addSelectable(&c);
+
+    /* Set 1st, 2nd */
+    int index;
+    for (index = 0; index < 2; index++)
+    {
+        vector<FieldValueTuple> fields;
+        for (int j = 0; j < maxNumOfFields; j++)
+        {
+            FieldValueTuple t(field(index, j), value(index, j));
+            fields.push_back(t);
+        }
+        p.set(key(index, 0), fields);
+    }
+
+    /* Pop 1st */
+    index = 0;
+    {
+        int ret = cs.select(&selectcs);
+        EXPECT_EQ(ret, Select::OBJECT);
+        KeyOpFieldsValuesTuple kco;
+        c.pop(kco);
+
+        // std::deque<KeyOpFieldsValuesTuple> vkco;
+        // c.pops(vkco);
+        // printf("vkco.size(): %zu\n", vkco.size());
+        // EXPECT_EQ(vkco.size(), 3);
+        // kco = vkco[0];
+        EXPECT_EQ(kfvKey(kco), key(index, 0));
+        EXPECT_EQ(kfvOp(kco), "SET");
+
+        auto fvs = kfvFieldsValues(kco);
+        EXPECT_EQ(fvs.size(), (unsigned int)(maxNumOfFields));
+
+        map<string, string> mm;
+        for (auto fv: fvs)
+        {
+            mm[fvField(fv)] = fvValue(fv);
+        }
+
+        for (int j = 0; j < maxNumOfFields; j++)
+        {
+            EXPECT_EQ(mm[field(index, j)], value(index, j));
+        }
+    }
+
+    /* Set 3rd */
+    for (index = 2; index < 3; index++)
+    {
+        vector<FieldValueTuple> fields;
+        for (int j = 0; j < maxNumOfFields; j++)
+        {
+            FieldValueTuple t(field(index, j), value(index, j));
+            fields.push_back(t);
+        }
+        p.set(key(index, 0), fields);
+    }
+
+    /* Pop 2nd */
+    index = 1;
+    {
+        int ret = cs.select(&selectcs);
+        EXPECT_EQ(ret, Select::OBJECT);
+        KeyOpFieldsValuesTuple kco;
+        c.pop(kco);
+        EXPECT_EQ(kfvKey(kco), key(index, 0));
+        EXPECT_EQ(kfvOp(kco), "SET");
+
+        auto fvs = kfvFieldsValues(kco);
+        EXPECT_EQ(fvs.size(), (unsigned int)(maxNumOfFields));
+
+        map<string, string> mm;
+        for (auto fv: fvs)
+        {
+            mm[fvField(fv)] = fvValue(fv);
+        }
+
+        for (int j = 0; j < maxNumOfFields; j++)
+        {
+            EXPECT_EQ(mm[field(index, j)], value(index, j));
+        }
+    }
+
+    /* Pop 3rd */
+    index = 2;
+    {
+        int ret = cs.select(&selectcs);
+        EXPECT_EQ(ret, Select::OBJECT);
+        KeyOpFieldsValuesTuple kco;
+        c.pop(kco);
+        EXPECT_EQ(kfvKey(kco), key(index, 0));
+        EXPECT_EQ(kfvOp(kco), "SET");
+
+        auto fvs = kfvFieldsValues(kco);
+        EXPECT_EQ(fvs.size(), (unsigned int)(maxNumOfFields));
+
+        map<string, string> mm;
+        for (auto fv: fvs)
+        {
+            mm[fvField(fv)] = fvValue(fv);
+        }
+
+        for (int j = 0; j < maxNumOfFields; j++)
+        {
+            EXPECT_EQ(mm[field(index, j)], value(index, j));
+        }
+    }
+}
+
 TEST(SubscriberStateTable, pops_intial)
 {
     clearDB();

--- a/tests/redis_subscriber_state_ut.cpp
+++ b/tests/redis_subscriber_state_ut.cpp
@@ -229,7 +229,6 @@ TEST(SubscriberStateTable, set2_pop1_set1_pop1)
     /* Prepare producer */
     DBConnector db("TEST_DB", 0, true);
     Table p(&db, testTableName);
-    //string key = "TheKey";
     int maxNumOfFields = 2;
 
     /* Prepare subscriber */
@@ -259,11 +258,6 @@ TEST(SubscriberStateTable, set2_pop1_set1_pop1)
         KeyOpFieldsValuesTuple kco;
         c.pop(kco);
 
-        // std::deque<KeyOpFieldsValuesTuple> vkco;
-        // c.pops(vkco);
-        // printf("vkco.size(): %zu\n", vkco.size());
-        // EXPECT_EQ(vkco.size(), 3);
-        // kco = vkco[0];
         EXPECT_EQ(kfvKey(kco), key(index, 0));
         EXPECT_EQ(kfvOp(kco), "SET");
 
@@ -322,6 +316,7 @@ TEST(SubscriberStateTable, set2_pop1_set1_pop1)
     /* Pop 3rd */
     index = 2;
     {
+        // Note: the code before this commit will hang at below select()
         int ret = cs.select(&selectcs);
         EXPECT_EQ(ret, Select::OBJECT);
         KeyOpFieldsValuesTuple kco;


### PR DESCRIPTION
The issue statement:
If the use case of SubscriberStateTable meets below conditions:
1. First `Select::select()`, then `SubscriberStateTable::pop()` instead of `SubscriberStateTable::pops()`
2. The table under SubscriberStateTable is changing extreme high frequently

There is a rare timing risk inside the implementation of SubscriberStateTable, leading to a state that SubscriberStateTable holds two entries but `Select::select()` is stuck. If the table has new change (operation), SubscriberStateTable may recover.

The fix:
`SubscriberStateTable::hasCachedData` should return true if there are 2 or more entries internally, including entries in `m_buffer` which were read by previous `pops()`, or entries in `m_keyspace_event_buffer` which will be read by next `pops()`.

Ideally, we need to cherry-pick to all the release branches since 201803.

Search the code, I found similar use cases, so the same issue is possible to happen at one of the places.
```
src/sonic-platform-daemons/sonic-xcvrd/scripts/xcvrd:943:        sst = swsscommon.SubscriberStateTable(appl_db, swsscommon.APP_PORT_TABLE_NAME)
src/sonic-platform-daemons/sonic-ledd/scripts/ledd:83:        sst = swsscommon.SubscriberStateTable(appl_db, swsscommon.APP_PORT_TABLE_NAME)
dockers/docker-lldp/lldpmgrd:207:        sst_confdb = swsscommon.SubscriberStateTable(self.config_db, swsscommon.CFG_PORT_TABLE_NAME)
dockers/docker-lldp/lldpmgrd:211:        sst_appdb = swsscommon.SubscriberStateTable(self.appl_db, swsscommon.APP_PORT_TABLE_NAME)
files/image_config/caclmgrd/caclmgrd:466:            subscribe_acl_table = swsscommon.SubscriberStateTable(acl_db_connector, swsscommon.CFG_ACL_TABLE_TABLE_NAME)
files/image_config/caclmgrd/caclmgrd:468:            subscribe_acl_rule_table = swsscommon.SubscriberStateTable(acl_db_connector, swsscommon.CFG_ACL_RULE_TABLE_NAME)
```