### PR TITLE
Throw proper exceptions when talking with Redis

### DIFF
--- a/common/redispipeline.h
+++ b/common/redispipeline.h
@@ -77,7 +77,11 @@ public:
         if (m_remaining == 0) return NULL;
 
         redisReply *reply;
-        redisGetReply(m_db->getContext(), (void**)&reply);
+        int rc = redisGetReply(m_db->getContext(), (void**)&reply);
+        if (rc != REDIS_OK)
+        {
+            throw RedisError("Failed to redisGetReply in RedisPipeline::pop", m_db->getContext());
+        }
         RedisReply r(reply);
         m_remaining--;
 

--- a/common/redispipeline.h
+++ b/common/redispipeline.h
@@ -33,7 +33,13 @@ public:
             case REDIS_REPLY_STATUS:
             case REDIS_REPLY_INTEGER:
             {
-                redisAppendFormattedCommand(m_db->getContext(), command.c_str(), command.length());
+                int rc = redisAppendFormattedCommand(m_db->getContext(), command.c_str(), command.length());
+                if (rc != REDIS_OK)
+                {
+                    // The only reason of error is REDIS_ERR_OOM (Out of memory)
+                    // ref: https://github.com/redis/hiredis/blob/master/hiredis.c
+                    throw std::bad_alloc();
+                }
                 m_expectedTypes.push(expectedType);
                 m_remaining++;
                 mayflush();

--- a/common/redisreply.cpp
+++ b/common/redisreply.cpp
@@ -30,15 +30,33 @@ inline void guard(FUNC func, const char* command)
 
 RedisReply::RedisReply(DBConnector *db, const RedisCommand& command)
 {
-    redisAppendFormattedCommand(db->getContext(), command.c_str(), command.length());
-    redisGetReply(db->getContext(), (void**)&m_reply);
+    int rc = redisAppendFormattedCommand(db->getContext(), command.c_str(), command.length());
+    if (rc != REDIS_OK)
+    {
+        throw RedisResponseError("Failed to redisAppendFormattedCommand with " + string(command.c_str()), db->getContext());
+    }
+
+    rc = redisGetReply(db->getContext(), (void**)&m_reply);
+    if (rc != REDIS_OK)
+    {
+        throw RedisResponseError("Failed to redisGetReply with " + string(command.c_str()), db->getContext());
+    }
     guard([&]{checkReply();}, command.c_str());
 }
 
 RedisReply::RedisReply(DBConnector *db, const string &command)
 {
-    redisAppendCommand(db->getContext(), command.c_str());
-    redisGetReply(db->getContext(), (void**)&m_reply);
+    int rc = redisAppendCommand(db->getContext(), command.c_str());
+    if (rc != REDIS_OK)
+    {
+        throw RedisResponseError("Failed to redisAppendFormattedCommand with " + command, db->getContext());
+    }
+
+    rc = redisGetReply(db->getContext(), (void**)&m_reply);
+    if (rc != REDIS_OK)
+    {
+        throw RedisResponseError("Failed to redisGetReply with " + command, db->getContext());
+    }
     guard([&]{checkReply();}, command.c_str());
 }
 

--- a/common/redisreply.cpp
+++ b/common/redisreply.cpp
@@ -33,7 +33,9 @@ RedisReply::RedisReply(DBConnector *db, const RedisCommand& command)
     int rc = redisAppendFormattedCommand(db->getContext(), command.c_str(), command.length());
     if (rc != REDIS_OK)
     {
-        throw RedisError("Failed to redisAppendFormattedCommand with " + string(command.c_str()), db->getContext());
+        // The only reason of error is REDIS_ERR_OOM (Out of memory)
+        // ref: https://github.com/redis/hiredis/blob/master/hiredis.c
+        throw bad_alloc();
     }
 
     rc = redisGetReply(db->getContext(), (void**)&m_reply);
@@ -49,7 +51,9 @@ RedisReply::RedisReply(DBConnector *db, const string &command)
     int rc = redisAppendCommand(db->getContext(), command.c_str());
     if (rc != REDIS_OK)
     {
-        throw RedisError("Failed to redisAppendFormattedCommand with " + command, db->getContext());
+        // The only reason of error is REDIS_ERR_OOM (Out of memory)
+        // ref: https://github.com/redis/hiredis/blob/master/hiredis.c
+        throw bad_alloc();
     }
 
     rc = redisGetReply(db->getContext(), (void**)&m_reply);

--- a/common/redisreply.cpp
+++ b/common/redisreply.cpp
@@ -33,13 +33,13 @@ RedisReply::RedisReply(DBConnector *db, const RedisCommand& command)
     int rc = redisAppendFormattedCommand(db->getContext(), command.c_str(), command.length());
     if (rc != REDIS_OK)
     {
-        throw RedisResponseError("Failed to redisAppendFormattedCommand with " + string(command.c_str()), db->getContext());
+        throw RedisError("Failed to redisAppendFormattedCommand with " + string(command.c_str()), db->getContext());
     }
 
     rc = redisGetReply(db->getContext(), (void**)&m_reply);
     if (rc != REDIS_OK)
     {
-        throw RedisResponseError("Failed to redisGetReply with " + string(command.c_str()), db->getContext());
+        throw RedisError("Failed to redisGetReply with " + string(command.c_str()), db->getContext());
     }
     guard([&]{checkReply();}, command.c_str());
 }
@@ -49,13 +49,13 @@ RedisReply::RedisReply(DBConnector *db, const string &command)
     int rc = redisAppendCommand(db->getContext(), command.c_str());
     if (rc != REDIS_OK)
     {
-        throw RedisResponseError("Failed to redisAppendFormattedCommand with " + command, db->getContext());
+        throw RedisError("Failed to redisAppendFormattedCommand with " + command, db->getContext());
     }
 
     rc = redisGetReply(db->getContext(), (void**)&m_reply);
     if (rc != REDIS_OK)
     {
-        throw RedisResponseError("Failed to redisGetReply with " + command, db->getContext());
+        throw RedisError("Failed to redisGetReply with " + command, db->getContext());
     }
     guard([&]{checkReply();}, command.c_str());
 }

--- a/common/redisreply.h
+++ b/common/redisreply.h
@@ -2,12 +2,36 @@
 #define __REDISREPLY__
 
 #include <hiredis/hiredis.h>
+#include <string>
 #include <stdexcept>
 #include "rediscommand.h"
 
 namespace swss {
 
 class DBConnector;
+
+class RedisResponseError : public std::runtime_error
+{
+    int m_err;
+    std::string m_errstr;
+    mutable std::string m_message;
+public:
+    RedisResponseError(const std::string& arg, redisContext *ctx)
+        : std::runtime_error(arg)
+        , m_err(ctx->err)
+        , m_errstr(ctx->errstr)
+    {
+    }
+
+    const char *what() const noexcept override
+    {
+        if (m_message.empty())
+        {
+            m_message = std::string("RedisResponseError: ") + std::runtime_error::what() + ": err=" + std::to_string(m_err) + ": errstr=" + m_errstr;
+        }
+        return m_message.c_str();
+    }
+};
 
 class RedisReply
 {

--- a/common/redisreply.h
+++ b/common/redisreply.h
@@ -10,13 +10,13 @@ namespace swss {
 
 class DBConnector;
 
-class RedisResponseError : public std::runtime_error
+class RedisError : public std::runtime_error
 {
     int m_err;
     std::string m_errstr;
     mutable std::string m_message;
 public:
-    RedisResponseError(const std::string& arg, redisContext *ctx)
+    RedisError(const std::string& arg, redisContext *ctx)
         : std::runtime_error(arg)
         , m_err(ctx->err)
         , m_errstr(ctx->errstr)

--- a/common/redisreply.h
+++ b/common/redisreply.h
@@ -27,7 +27,7 @@ public:
     {
         if (m_message.empty())
         {
-            m_message = std::string("RedisResponseError: ") + std::runtime_error::what() + ": err=" + std::to_string(m_err) + ": errstr=" + m_errstr;
+            m_message = std::string("RedisResponseError: ") + std::runtime_error::what() + ", err=" + std::to_string(m_err) + ": errstr=" + m_errstr;
         }
         return m_message.c_str();
     }


### PR DESCRIPTION
Original we don't handle error code when talking with Redis by hiredis APIs. So we will realize it happening far away from the first place and get confusing error message.

Old
```
C++ exception with description "Memory exception, reply is null: Cannot allocate memory" thrown in the test body.
```

New
```
C++ exception with description "RedisResponseError: Failed to redisGetReply with CLIENT GETNAME: err=3: errstr=Server closed the connection" thrown in the test body.
```