### PR TITLE
add RESTAPI_DB and renumber the GB_*_DB ids to match what is in sonic…

### DIFF
--- a/common/database_config.json
+++ b/common/database_config.json
@@ -52,18 +52,23 @@
             "separator": "|",
             "instance" : "redis"
         },
-        "GB_ASIC_DB" : {
+        "RESTAPI_DB" : {
             "id" : 8,
             "separator": "|",
             "instance" : "redis"
         },
-        "GB_COUNTERS_DB" : {
+        "GB_ASIC_DB" : {
             "id" : 9,
             "separator": "|",
             "instance" : "redis"
         },
-        "GB_FLEX_COUNTER_DB" : {
+        "GB_COUNTERS_DB" : {
             "id" : 10,
+            "separator": "|",
+            "instance" : "redis"
+        },
+        "GB_FLEX_COUNTER_DB" : {
+            "id" : 11,
             "separator": "|",
             "instance" : "redis"
         }

--- a/common/schema.h
+++ b/common/schema.h
@@ -16,9 +16,10 @@ namespace swss {
 #define FLEX_COUNTER_DB 5
 #define STATE_DB        6
 #define SNMP_OVERLAY_DB 7
-#define GB_ASIC_DB      8
-#define GB_COUNTERS_DB  9
-#define GB_FLEX_COUNTER_DB  10
+#define RESTAPI_DB      8
+#define GB_ASIC_DB      9
+#define GB_COUNTERS_DB  10
+#define GB_FLEX_COUNTER_DB  11
 
 /***** APPLICATION DATABASE *****/
 


### PR DESCRIPTION
swss-common: sync db id numbers with changes in sonic-buildimage

* add in restapi_db constant that was missing
* renumber gearbox tables accordingly.

  Signed-off-by: syd.logan@broadcom.com
