### PR TITLE
Chassisd config table to store admin state

### DIFF
--- a/common/schema.h
+++ b/common/schema.h
@@ -268,6 +268,8 @@ namespace swss {
 #define CFG_FG_NHG_PREFIX                           "FG_NHG_PREFIX"
 #define CFG_FG_NHG_MEMBER                           "FG_NHG_MEMBER"
 
+#define CFG_CHASSIS_MODULE_TABLE                    "CHASSIS_MODULE"
+
 /***** STATE DATABASE *****/
 
 #define STATE_SWITCH_CAPABILITY_TABLE_NAME          "SWITCH_CAPABILITY_TABLE"


### PR DESCRIPTION
sonic-swss-common: Changes to introduce a config table name to store card admin state

HLD: https://github.com/Azure/SONiC/pull/646

**- What I did**
Introduced a config table to store the card admin state in a modular chassis

