### PR TITLE
netlink: Setting nl_socket buffer size to 3M from 2M

### DIFF
--- a/common/netlink.cpp
+++ b/common/netlink.cpp
@@ -35,8 +35,8 @@ NetLink::NetLink(int pri) :
     }
 
     nl_socket_set_nonblocking(m_socket);
-    /* Set socket buffer size to 256KB */
-    nl_socket_set_buffer_size(m_socket, 2097152, 0);
+    /* Set socket buffer size to 3MB */
+    nl_socket_set_buffer_size(m_socket, (3*1024*1024), 0);
 }
 
 NetLink::~NetLink()

--- a/common/netlink.cpp
+++ b/common/netlink.cpp
@@ -36,7 +36,7 @@ NetLink::NetLink(int pri) :
 
     nl_socket_set_nonblocking(m_socket);
     /* Set socket buffer size to 3MB */
-    nl_socket_set_buffer_size(m_socket, (3*1024*1024), 0);
+    nl_socket_set_buffer_size(m_socket, 3145728, 0);
 }
 
 NetLink::~NetLink()


### PR DESCRIPTION
Issue:
netlink out of memory seen for 8K neighbor updates.

Steps:
1. Config IP to 2 interfaces connected to ixia. Ethernet1 (21.0.0.1/16) and Ethernet4 (24.1.1.1/24)

2. DUT copp rules are as ARP CIR=2000 and IP2ME CIR=6000

3. Start Continuos Traffic (5G) is started from ixia connected to Ethernet4 with the DIP matching with the 8K ARP Host Range before learning ARP entries. These traffic will be software forwarded from linux kernel.

4. DUT is configured to learn ARP through ARP Reply packets
echo 1 > /proc/sys/net/ipv4/conf/Ethernet1/arp_accept

5. Start continuos ARP Reply Packet is sent from IXIA connected to Ethernet1 Port at 2K Packet/Secs with Host IP starting from 20.20.0.2 and Incrementing for 8K. 

After step (5), expectation is all 5G traffic must be forwarded from ASIC but not all NEIGH entries are updated to APP_DB and ASIC_DB because of out of memory error.

Increasing the rx buffer limit to 3M fixes the issue.