### PR TITLE
Fix memory leak in RedisCommand

### DIFF
--- a/common/rediscommand.cpp
+++ b/common/rediscommand.cpp
@@ -18,6 +18,12 @@ RedisCommand::~RedisCommand()
 
 void RedisCommand::format(const char *fmt, ...)
 {
+    if (temp != nullptr)
+    {
+        redisFreeCommand(temp);
+        temp = nullptr;
+    }
+
     va_list ap;
     va_start(ap, fmt);
     int len = redisvFormatCommand(&temp, fmt, ap);
@@ -31,6 +37,12 @@ void RedisCommand::format(const char *fmt, ...)
 
 void RedisCommand::formatArgv(int argc, const char **argv, const size_t *argvlen)
 {
+    if (temp != nullptr)
+    {
+        redisFreeCommand(temp);
+        temp = nullptr;
+    }
+
     int len = redisFormatCommandArgv(&temp, argc, argv, argvlen);
     if (len == -1) {
         throw std::bad_alloc();


### PR DESCRIPTION
Fix memory leak if a `RedisCommand` object were to be reused. That is, a memory leak would have occurred if the methods `format()` or `formatArgv()` were to be used more than once on the same object. This change simply ensures that currently allocated memory gets freed before new memory gets allocated.