### PR TITLE
Added support in Swig file to cast Selectable object to Subscriber Table object

### DIFF
--- a/pyext/swsscommon.i
+++ b/pyext/swsscommon.i
@@ -52,17 +52,15 @@
 }
 
 %inline %{
-swss::RedisSelect *CastSelectableToRedisSelectObj(swss::Selectable *temp) {
-  return dynamic_cast<swss::RedisSelect *>(temp);
+template <typename T>
+T castSelectableObj(swss::Selectable *temp)
+{
+    return dynamic_cast<T>(temp);
 }
 %}
 
-%inline %{
-swss::SubscriberStateTable *CastSelectableToSubscriberTableObj(swss::Selectable *temp) {
-  return dynamic_cast<swss::SubscriberStateTable *>(temp);
-}
-%}
-
+%template(CastSelectableToRedisSelectObj) castSelectableObj<swss::RedisSelect *>;
+%template(CastSelectableToSubscriberTableObj) castSelectableObj<swss::SubscriberStateTable *>;
 
 %include "schema.h"
 %include "dbconnector.h"

--- a/pyext/swsscommon.i
+++ b/pyext/swsscommon.i
@@ -57,6 +57,13 @@ swss::RedisSelect *CastSelectableToRedisSelectObj(swss::Selectable *temp) {
 }
 %}
 
+%inline %{
+swss::SubscriberStateTable *CastSelectableToSubscriberTableObj(swss::Selectable *temp) {
+  return dynamic_cast<swss::SubscriberStateTable *>(temp);
+}
+%}
+
+
 %include "schema.h"
 %include "dbconnector.h"
 %include "sonicv2connector.h"


### PR DESCRIPTION
What I did:
Added support in Swig file to cast Selectable object to SubscriberTable Object. 
Updated to use template function.

Why I did:
This way in application code we can  find out which subscribe
table select has return.

How I verify:
Verify after cast able to call getTableName() API and it return correct value.