### PR TITLE
Fix SonicV2Connector interfaces

### DIFF
--- a/common/sonicv2connector.cpp
+++ b/common/sonicv2connector.cpp
@@ -64,29 +64,29 @@ bool SonicV2Connector::exists(const std::string& db_name, const std::string& key
     return m_dbintf.exists(db_name, key);
 }
 
-std::vector<std::string> SonicV2Connector::keys(const std::string& db_name, const char *pattern)
+std::vector<std::string> SonicV2Connector::keys(const std::string& db_name, const char *pattern, bool blocking)
 {
-    return m_dbintf.keys(db_name, pattern);
+    return m_dbintf.keys(db_name, pattern, blocking);
 }
 
-std::string SonicV2Connector::get(const std::string& db_name, const std::string& _hash, const std::string& key)
+std::string SonicV2Connector::get(const std::string& db_name, const std::string& _hash, const std::string& key, bool blocking)
 {
-    return m_dbintf.get(db_name, _hash, key);
+    return m_dbintf.get(db_name, _hash, key, blocking);
 }
 
-std::map<std::string, std::string> SonicV2Connector::get_all(const std::string& db_name, const std::string& _hash)
+std::map<std::string, std::string> SonicV2Connector::get_all(const std::string& db_name, const std::string& _hash, bool blocking)
 {
-    return m_dbintf.get_all(db_name, _hash);
+    return m_dbintf.get_all(db_name, _hash, blocking);
 }
 
-int64_t SonicV2Connector::set(const std::string& db_name, const std::string& _hash, const std::string& key, const std::string& val)
+int64_t SonicV2Connector::set(const std::string& db_name, const std::string& _hash, const std::string& key, const std::string& val, bool blocking)
 {
-    return m_dbintf.set(db_name, _hash, key, val);
+    return m_dbintf.set(db_name, _hash, key, val, blocking);
 }
 
-int64_t SonicV2Connector::del(const std::string& db_name, const std::string& key)
+int64_t SonicV2Connector::del(const std::string& db_name, const std::string& key, bool blocking)
 {
-    return m_dbintf.del(db_name, key);
+    return m_dbintf.del(db_name, key, blocking);
 }
 
 void SonicV2Connector::delete_all_by_pattern(const std::string& db_name, const std::string& pattern)

--- a/common/sonicv2connector.h
+++ b/common/sonicv2connector.h
@@ -39,15 +39,15 @@ public:
 
     bool exists(const std::string& db_name, const std::string& key);
 
-    std::vector<std::string> keys(const std::string& db_name, const char *pattern="*");
+    std::vector<std::string> keys(const std::string& db_name, const char *pattern="*", bool blocking=false);
 
-    std::string get(const std::string& db_name, const std::string& _hash, const std::string& key);
+    std::string get(const std::string& db_name, const std::string& _hash, const std::string& key, bool blocking=false);
 
-    std::map<std::string, std::string> get_all(const std::string& db_name, const std::string& _hash);
+    std::map<std::string, std::string> get_all(const std::string& db_name, const std::string& _hash, bool blocking=false);
 
-    int64_t set(const std::string& db_name, const std::string& _hash, const std::string& key, const std::string& val);
+    int64_t set(const std::string& db_name, const std::string& _hash, const std::string& key, const std::string& val, bool blocking=false);
 
-    int64_t del(const std::string& db_name, const std::string& key);
+    int64_t del(const std::string& db_name, const std::string& key, bool blocking=false);
 
     void delete_all_by_pattern(const std::string& db_name, const std::string& pattern);
 

--- a/common/sonicv2connector.h
+++ b/common/sonicv2connector.h
@@ -70,8 +70,17 @@ private:
 // TODO: implement it with formal SWIG syntax, which will be target language independent
 %pythoncode %{
     _old_SonicV2Connector__init__ = SonicV2Connector.__init__
-    def _new_SonicV2Connector__init__(self, use_unix_socket_path = False, namespace = None):
+    def _new_SonicV2Connector__init__(self, use_unix_socket_path = False, namespace = ''):
+        if namespace is None:
+            namespace = ''
         _old_SonicV2Connector__init__(self, use_unix_socket_path = use_unix_socket_path, netns = namespace)
+        for db_name in self.get_db_list():
+            # set a database name as a constant value attribute.
+            setattr(self, db_name, db_name)
+            getmethod = lambda self: db_name
+            SonicV2Connector.__swig_getmethods__[db_name] = getmethod
+            SonicV2Connector.__swig_setmethods__[db_name] = None
+
     SonicV2Connector.__init__ = _new_SonicV2Connector__init__
 %}
 #endif

--- a/common/sonicv2connector.h
+++ b/common/sonicv2connector.h
@@ -74,6 +74,9 @@ private:
         if namespace is None:
             namespace = ''
         _old_SonicV2Connector__init__(self, use_unix_socket_path = use_unix_socket_path, netns = namespace)
+
+        # Add database name attributes into SonicV2Connector instance
+        # Note: this is difficult to implement in C++
         for db_name in self.get_db_list():
             # set a database name as a constant value attribute.
             setattr(self, db_name, db_name)

--- a/pyext/swsscommon.i
+++ b/pyext/swsscommon.i
@@ -35,6 +35,16 @@
 %template(FieldValueMap) std::map<std::string, std::string>;
 %template(VectorString) std::vector<std::string>;
 
+%pythoncode %{
+    def _FieldValueMap__get(self, key, defval):
+        if key in self:
+            return self[key]
+        else:
+            return defval
+
+    FieldValueMap.get = _FieldValueMap__get
+%}
+
 %apply int *OUTPUT {int *fd};
 %typemap(in, numinputs=0) swss::Selectable ** (swss::Selectable *temp) {
     $1 = &temp;

--- a/tests/test_redis_ut.py
+++ b/tests/test_redis_ut.py
@@ -138,6 +138,7 @@ def test_DBInterface():
     dbintf.connect(15, "TEST_DB")
 
     db = SonicV2Connector(use_unix_socket_path=True, namespace='')
+    assert db.TEST_DB == 'TEST_DB'
     assert db.namespace == ''
     db.connect("TEST_DB")
     db.set("TEST_DB", "key0", "field1", "value2")
@@ -146,10 +147,18 @@ def test_DBInterface():
     assert fvs["field1"] == "value2"
     assert fvs.get("field1", "default") == "value2"
     assert fvs.get("nonfield", "default") == "default"
-    assert db.TEST_DB == 'TEST_DB'
 
+    # Test blocking
+    fvs = db.get_all("TEST_DB", "key0", blocking=True)
+    assert "field1" in fvs
+    assert fvs["field1"] == "value2"
+    assert fvs.get("field1", "default") == "value2"
+    assert fvs.get("nonfield", "default") == "default"
+
+    # Test empty/none namespace
     db = SonicV2Connector(use_unix_socket_path=True, namespace=None)
     assert db.namespace == ''
 
+    # Test default namespace parameter
     db = SonicV2Connector(use_unix_socket_path=True)
     assert db.namespace == ''

--- a/tests/test_redis_ut.py
+++ b/tests/test_redis_ut.py
@@ -144,6 +144,8 @@ def test_DBInterface():
     fvs = db.get_all("TEST_DB", "key0")
     assert "field1" in fvs
     assert fvs["field1"] == "value2"
+    assert fvs.get("field1", "default") == "value2"
+    assert fvs.get("nonfield", "default") == "default"
     assert db.TEST_DB == 'TEST_DB'
 
     db = SonicV2Connector(use_unix_socket_path=True, namespace=None)

--- a/tests/test_redis_ut.py
+++ b/tests/test_redis_ut.py
@@ -144,3 +144,10 @@ def test_DBInterface():
     fvs = db.get_all("TEST_DB", "key0")
     assert "field1" in fvs
     assert fvs["field1"] == "value2"
+    assert db.TEST_DB == 'TEST_DB'
+
+    db = SonicV2Connector(use_unix_socket_path=True, namespace=None)
+    assert db.namespace == ''
+
+    db = SonicV2Connector(use_unix_socket_path=True)
+    assert db.namespace == ''


### PR DESCRIPTION
1. pyext will pass empty string instead of None to SonicV2Connector ctor
2. add database name attributes
3. FieldValueMap class emulate the python dict interface