### PR TITLE
SonicV2Connector supports host and decode_responses in constructor parameters

### DIFF
--- a/common/sonicv2connector.h
+++ b/common/sonicv2connector.h
@@ -70,7 +70,12 @@ private:
 // TODO: implement it with formal SWIG syntax, which will be target language independent
 %pythoncode %{
     _old_SonicV2Connector__init__ = SonicV2Connector.__init__
-    def _new_SonicV2Connector__init__(self, use_unix_socket_path = False, namespace = ''):
+    def _new_SonicV2Connector__init__(self, use_unix_socket_path = False, namespace = '', **kwargs):
+        if 'host' in kwargs:
+            # Note: host argument will be ignored, same as in sonic-py-swsssdk
+            kwargs.pop('host')
+        if 'decode_responses' in kwargs and kwargs.pop('decode_responses') != True:
+            raise ValueError('decode_responses must be True if specified, False is not supported')
         if namespace is None:
             namespace = ''
         _old_SonicV2Connector__init__(self, use_unix_socket_path = use_unix_socket_path, netns = namespace)

--- a/tests/test_redis_ut.py
+++ b/tests/test_redis_ut.py
@@ -180,3 +180,16 @@ def test_DBInterface():
     # Test default namespace parameter
     db = SonicV2Connector(use_unix_socket_path=True)
     assert db.namespace == ''
+
+    # Test no exception
+    try:
+        db = SonicV2Connector(host='127.0.0.1')
+        db = SonicV2Connector(use_unix_socket_path=True, namespace='', decode_responses=True)
+        db = SonicV2Connector(use_unix_socket_path=False, decode_responses=True)
+        db = SonicV2Connector(host="127.0.0.1", decode_responses=True)
+    except:
+        assert False, 'Unexpected exception raised'
+
+    # Test exception
+    with pytest.raises(ValueError):
+        db = SonicV2Connector(decode_responses=False)


### PR DESCRIPTION
To emulate the constructor of python version https://github.com/Azure/sonic-py-swsssdk/blob/master/src/swsssdk/dbconnector.py