### PR TITLE
Change log level for logger thread

### DIFF
--- a/common/logger.cpp
+++ b/common/logger.cpp
@@ -200,7 +200,7 @@ Logger::Priority Logger::getMinPrio()
 
         if (ret == Select::TIMEOUT)
         {
-            SWSS_LOG_INFO("%s select timeout", __PRETTY_FUNCTION__);
+            SWSS_LOG_DEBUG("%s select timeout", __PRETTY_FUNCTION__);
             continue;
         }
 


### PR DESCRIPTION
Logs keeps coming every 1 second without any useful info, making it hard to use INFO level. Reducing to debug level

```
Oct 26 22:05:24.775111 str2-acs-02 INFO swss#orchagent: :- settingThread: void swss::Logger::settingThread() select timeout
Oct 26 22:05:25.776202 str2-acs-02 INFO swss#orchagent: :- settingThread: void swss::Logger::settingThread() select timeout
Oct 26 22:05:26.777356 str2-acs-02 INFO swss#orchagent: :- settingThread: void swss::Logger::settingThread() select timeout
```