### PR TITLE
Change logging from ERROR to INFO for debugs related to database_global

### DIFF
--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -77,7 +77,7 @@ void SonicDBConfig::initializeGlobalConfig(const string &file)
 
     if (m_global_init)
     {
-        SWSS_LOG_ERROR("SonicDBConfig Global config is already initialized");
+        SWSS_LOG_INFO("SonicDBConfig Global config is already initialized");
         return;
     }
 
@@ -150,7 +150,7 @@ void SonicDBConfig::initializeGlobalConfig(const string &file)
     }
     else
     {
-        SWSS_LOG_ERROR("Sonic database config global file doesn't exist at %s\n", file.c_str());
+        SWSS_LOG_INFO("Sonic database config global file doesn't exist at %s\n", file.c_str());
     }
 
     // Set it as the global config file is already parsed and init done.


### PR DESCRIPTION
Fix for the issue : https://github.com/Azure/sonic-buildimage/issues/5680

There are platforms which don't have the database_global.json file and hence, change the error level from ERROR to INFO here. This is in sync with sonic-swsssdk-py/dbconnector implementation as well.