### PR TITLE
Add lua script for redis multi keys api hmset and del

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -7,6 +7,7 @@ EXTRA_DIST = \
     consumer_table_pops.lua \
     producer_state_table_apply_view.lua \
     table_dump.lua \
+    redis_multi.lua \
     fdb_flush.lua
 
 EXTRA_CONF_DIST = database_config.json

--- a/common/dbconnector.h
+++ b/common/dbconnector.h
@@ -154,6 +154,8 @@ public:
 
     int64_t hdel(const std::string &key, const std::vector<std::string> &fields);
 
+    void hdel(const std::vector<std::string>& keys);
+
     std::unordered_map<std::string, std::string> hgetall(const std::string &key);
 
     template <typename OutputIterator>
@@ -167,6 +169,8 @@ public:
 
     template<typename InputIterator>
     void hmset(const std::string &key, InputIterator start, InputIterator stop);
+
+    void hmset(const std::unordered_map<std::string, std::vector<std::pair<std::string, std::string>>>& multiHash);
 
     std::shared_ptr<std::string> get(const std::string &key);
 
@@ -194,6 +198,8 @@ private:
     int m_dbId;
     std::string m_dbName;
     std::string m_namespace;
+
+    std::string m_shaRedisMulti;
 };
 
 template<typename OutputIterator>

--- a/common/redis_multi.lua
+++ b/common/redis_multi.lua
@@ -1,0 +1,20 @@
+local op = ARGV[1]
+local jj = cjson.decode(KEYS[1])
+
+if op == "mhset" then
+
+    for keyname,o in pairs(jj) do
+        for k,v in pairs(o) do
+            redis.call('HSET', keyname, k, v)
+        end
+    end
+
+elseif op == "mdel" then
+
+    for idx,keyname in ipairs(jj) do
+        redis.call('DEL', keyname)
+    end
+
+else
+    error("unsupported operation command: " .. op .. ", FIXME")
+end


### PR DESCRIPTION
When using SAI bulk in syncd, like create/remove route_entry, we want to have ability to update database as fast as possible, so best way would be to execute every mutable db command inside lua script to make things faster, rather than execute 1 by 1 operation which is done currently inside syncd