### PR TITLE
[pyext] allow to catch exceptions raised in python

### DIFF
--- a/pyext/swsscommon.i
+++ b/pyext/swsscommon.i
@@ -32,10 +32,14 @@
 %include <exception.i>
 
 %exception {
-    try {
+    try
+    {
         $action
-    } catch (const std::exception& e) {
-        SWIG_exception(SWIG_RuntimeError, e.what());
+    }
+    SWIG_CATCH_STDEXCEPT // catch std::exception derivatives
+    catch (...)
+    {
+        SWIG_exception(SWIG_UnknownError, "unknown exception");
     }
 }
 

--- a/pyext/swsscommon.i
+++ b/pyext/swsscommon.i
@@ -29,6 +29,15 @@
 %include <std_map.i>
 %include <typemaps.i>
 %include <stdint.i>
+%include <exception.i>
+
+%exception {
+    try {
+        $action
+    } catch (const std::exception& e) {
+        SWIG_exception(SWIG_RuntimeError, e.what());
+    }
+}
 
 %template(FieldValuePair) std::pair<std::string, std::string>;
 %template(FieldValuePairs) std::vector<std::pair<std::string, std::string>>;


### PR DESCRIPTION
Without this change:
```
>>> from swsscommon import swsscommon
>>> swsscommon.DBConnector('CONFIG_DB', 0)
terminate called after throwing an instance of 'std::system_error'
  what():  Unable to connect to redis (unix-socket): Cannot assign requested address
Aborted
```

With this change:
```
>>> from swsscommon import swsscommon
>>> swsscommon.DBConnector('CONFIG_DB', 0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python2.7/dist-packages/swsscommon/swsscommon.py", line 1067, in __init__
    this = _swsscommon.new_DBConnector(*args)
RuntimeError: Unable to connect to redis (unix-socket): Cannot assign requested address
>>>
```

Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>