### PR TITLE
[swig] translate C++ `del` to python `delete`

### DIFF
--- a/common/dbconnector.h
+++ b/common/dbconnector.h
@@ -146,6 +146,17 @@ public:
 
     int64_t del(const std::string &key);
 
+#ifdef SWIG
+    // SWIG interface file (.i) globally rename map C++ `del` to python `delete`,
+    // but applications already followed the old behavior of auto renamed `_del`.
+    // So we implemented old behavior for backward compatiblity
+    // TODO: remove this function after applications use the function name `delete`
+    %pythoncode %{
+        def _del(self, *args, **kwargs):
+            return self.delete(*args, **kwargs)
+    %}
+#endif
+
     bool exists(const std::string &key);
 
     int64_t hdel(const std::string &key, const std::string &field);

--- a/common/producerstatetable.h
+++ b/common/producerstatetable.h
@@ -24,6 +24,17 @@ public:
                      const std::string &op = DEL_COMMAND,
                      const std::string &prefix = EMPTY_PREFIX);
 
+#ifdef SWIG
+    // SWIG interface file (.i) globally rename map C++ `del` to python `delete`,
+    // but applications already followed the old behavior of auto renamed `_del`.
+    // So we implemented old behavior for backward compatiblity
+    // TODO: remove this function after applications use the function name `delete`
+    %pythoncode %{
+        def _del(self, *args, **kwargs):
+            return self.delete(*args, **kwargs)
+    %}
+#endif
+
     void flush();
 
     int64_t count();

--- a/common/producertable.h
+++ b/common/producertable.h
@@ -35,6 +35,17 @@ public:
                      const std::string &op = DEL_COMMAND,
                      const std::string &prefix = EMPTY_PREFIX);
 
+#ifdef SWIG
+    // SWIG interface file (.i) globally rename map C++ `del` to python `delete`,
+    // but applications already followed the old behavior of auto renamed `_del`.
+    // So we implemented old behavior for backward compatiblity
+    // TODO: remove this function after applications use the function name `delete`
+    %pythoncode %{
+        def _del(self, *args, **kwargs):
+            return self.delete(*args, **kwargs)
+    %}
+#endif
+
     void flush();
 
 private:

--- a/common/table.h
+++ b/common/table.h
@@ -152,6 +152,18 @@ public:
     virtual void del(const std::string &key,
                      const std::string &op = "",
                      const std::string &prefix = EMPTY_PREFIX);
+
+#ifdef SWIG
+    // SWIG interface file (.i) globally rename map C++ `del` to python `delete`,
+    // but applications already followed the old behavior of auto renamed `_del`.
+    // So we implemented old behavior for backward compatiblity
+    // TODO: remove this function after applications use the function name `delete`
+    %pythoncode %{
+        def _del(self, *args, **kwargs):
+            return self.delete(*args, **kwargs)
+    %}
+#endif
+
     virtual void hdel(const std::string &key,
                       const std::string &field,
                       const std::string &op = "",

--- a/pyext/swsscommon.i
+++ b/pyext/swsscommon.i
@@ -1,5 +1,7 @@
 %module swsscommon
 
+%rename(delete) del;
+
 %{
 #include "schema.h"
 #include "dbconnector.h"

--- a/tests/test_redis_ut.py
+++ b/tests/test_redis_ut.py
@@ -146,6 +146,17 @@ def test_DBInterface():
     assert "field1" in fvs
     assert fvs["field1"] == "value2"
 
+    # Test del
+    db.set("TEST_DB", "key3", "field4", "value5")
+    deleted = db.delete("TEST_DB", "key3")
+    assert deleted == 1
+    deleted = db.delete("TEST_DB", "key3")
+    assert deleted == 0
+
+    # Test pubsub
+    redisclient = db.get_redis_client("TEST_DB")
+    ps = redisclient.pubsub()
+
     # Test dict.get()
     assert fvs.get("field1") == "value2"
     assert fvs.get("field1_noexisting") == None

--- a/tests/test_redis_ut.py
+++ b/tests/test_redis_ut.py
@@ -153,10 +153,6 @@ def test_DBInterface():
     deleted = db.delete("TEST_DB", "key3")
     assert deleted == 0
 
-    # Test pubsub
-    redisclient = db.get_redis_client("TEST_DB")
-    ps = redisclient.pubsub()
-
     # Test dict.get()
     assert fvs.get("field1") == "value2"
     assert fvs.get("field1_noexisting") == None


### PR DESCRIPTION
Otherwise SWIG will "smartly" translate it to `_del`
```
Warning 314: 'del' is a python keyword, renaming to '_del'
```

Since some application is using old function name, I keep some functions backward compatible.