### PR TITLE
SWIG functions accept Unicode input

### DIFF
--- a/pyext/swsscommon.i
+++ b/pyext/swsscommon.i
@@ -3,6 +3,15 @@
 %rename(delete) del;
 
 %{
+// ref: http://www.swig.org/Doc3.0/Python.html
+// A Python 2 string is not a unicode string by default and should a Unicode
+// string be passed to C/C++ it will fail to convert to a C/C++ string (char *
+// or std::string types). The Python 2 behavior can be made more like Python 3
+// by defining SWIG_PYTHON_2_UNICODE when compiling the generated C/C++ code.
+// Unicode strings will be successfully accepted and converted from UTF-8, but
+// note that they are returned as a normal Python 2 string
+#define SWIG_PYTHON_2_UNICODE
+
 #include "schema.h"
 #include "dbconnector.h"
 #include "dbinterface.h"

--- a/tests/test_redis_ut.py
+++ b/tests/test_redis_ut.py
@@ -146,6 +146,12 @@ def test_DBInterface():
     assert "field1" in fvs
     assert fvs["field1"] == "value2"
 
+    # Test keys
+    ks = db.keys("TEST_DB", "key*");
+    assert len(ks) == 1
+    ks = db.keys("TEST_DB", u"key*");
+    assert len(ks) == 1
+
     # Test del
     db.set("TEST_DB", "key3", "field4", "value5")
     deleted = db.delete("TEST_DB", "key3")


### PR DESCRIPTION
Fixed https://github.com/Azure/sonic-buildimage/issues/5927 in common library.

Try to align to the behavior of redis-py python library in Python 2 environment. The parameter could be either a byte str or Unicode str.
```
>>> import redis
>>> r = redis.Redis(db=1)
>>> r.hgetall('ASIC_STATE:SAI_OBJECT_TYPE_FDB_ENTRY:{"bvid":"oid:0x260000000005be","mac":"FE:54:00:24:E6:9F","switch_id":"oid:0x21000000000000"}')
{'SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID': 'oid:0x3a0000000005bf', 'SAI_FDB_ENTRY_ATTR_TYPE': 'SAI_FDB_ENTRY_TYPE_DYNAMIC'}
>>> r.hgetall(u'ASIC_STATE:SAI_OBJECT_TYPE_FDB_ENTRY:{"bvid":"oid:0x260000000005be","mac":"FE:54:00:24:E6:9F","switch_id":"oid:0x21000000000000"}')
{'SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID': 'oid:0x3a0000000005bf', 'SAI_FDB_ENTRY_ATTR_TYPE': 'SAI_FDB_ENTRY_TYPE_DYNAMIC'}
```


The old behavior of swss-common SWIG wrapped functions in Python 2 only accept byte str. Fix it by a global macro in `.i` file.