### PR TITLE
Handle exception in Select

### DIFF
--- a/common/redisselect.cpp
+++ b/common/redisselect.cpp
@@ -27,7 +27,7 @@ uint64_t RedisSelect::readData()
     redisReply *reply = nullptr;
 
     if (redisGetReply(m_subscribe->getContext(), reinterpret_cast<void**>(&reply)) != REDIS_OK)
-        throw std::runtime_error("Unable to read redis reply");
+        throw std::runtime_error("Unable to read redis reply from RedisSelect::readData() redisGetReply()");
 
     freeReplyObject(reply);
     m_queueLength++;
@@ -47,7 +47,7 @@ uint64_t RedisSelect::readData()
 
     if (status != REDIS_OK)
     {
-        throw std::runtime_error("Unable to read redis reply");
+        throw std::runtime_error("Unable to read redis reply from RedisSelect::readData() redisGetReplyFromReader()");
     }
     return 0;
 }

--- a/common/select.cpp
+++ b/common/select.cpp
@@ -106,7 +106,15 @@ int Select::poll_descriptors(Selectable **c, unsigned int timeout)
     {
         int fd = events[i].data.fd;
         Selectable* sel = m_objects[fd];
-        sel->readData();
+        try
+        {
+            sel->readData();
+        }
+        catch (const std::runtime_error& ex)
+        {
+            SWSS_LOG_ERROR("readData error: %s", ex.what());
+            return Select::ERROR;
+        }
         m_ready.insert(sel);
     }
 


### PR DESCRIPTION
Fixed https://github.com/Azure/sonic-buildimage/issues/5893

Original, `caclmgrd` crashed during ```fast-reboot``` with following log. Note that the exception handling already improves, so different from the log in the above issue
```
Dec  4 18:10:06.964034 sonic INFO caclmgrd[2660]: Traceback (most recent call last):
Dec  4 18:10:06.964250 sonic INFO caclmgrd[2660]:   File "/usr/local/bin/caclmgrd", line 670, in <module>
Dec  4 18:10:06.964377 sonic INFO caclmgrd[2660]:     main()
Dec  4 18:10:06.964509 sonic INFO caclmgrd[2660]:   File "/usr/local/bin/caclmgrd", line 666, in main
Dec  4 18:10:06.964631 sonic INFO caclmgrd[2660]:     caclmgr.run()
Dec  4 18:10:06.964751 sonic INFO caclmgrd[2660]:   File "/usr/local/bin/caclmgrd", line 610, in run
Dec  4 18:10:06.964891 sonic INFO caclmgrd[2660]:     (state, selectableObj) = sel.select(SELECT_TIMEOUT_MS)
Dec  4 18:10:06.965014 sonic INFO caclmgrd[2660]:   File "/usr/lib/python3/dist-packages/swsscommon/swsscommon.py", line 1322, in select
Dec  4 18:10:06.965135 sonic INFO caclmgrd[2660]:     return _swsscommon.Select_select(self, timeout)
Dec  4 18:10:06.965262 sonic INFO caclmgrd[2660]: RuntimeError: Unable to read redis reply
Dec  4 18:10:07.013540 sonic NOTICE systemd[1]: caclmgrd.service: Main process exited, code=exited, status=1/FAILURE
Dec  4 18:10:07.013784 sonic WARNING systemd[1]: caclmgrd.service: Failed with result 'exit-code'.
```

After this PR, `caclmgrd` will report errors during ```fast-reboot```
```
Dec  4 19:07:27.682565 sonic ERR caclmgrd[2165]: :- poll_descriptors: readData error: Unable to read redis reply
Dec  4 19:07:27.781333 sonic ERR caclmgrd[2165]: :- poll_descriptors: readData error: Unable to read redis reply
Dec  4 19:07:27.870789 sonic INFO caclmgrd[2165]: DaemonBase: Caught SIGTERM - exiting...
Dec  4 19:07:27.911119 sonic NOTICE systemd[1]: caclmgrd.service: Main process exited, code=exited, status=143/n/a
Dec  4 19:07:27.911374 sonic WARNING systemd[1]: caclmgrd.service: Failed with result 'exit-code'.
```