### PR TITLE
Add support for hexists call

### DIFF
--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -619,7 +619,7 @@ bool DBConnector::exists(const string &key)
     }
     rexists.format("EXISTS %s", key.c_str());
     RedisReply r(this, rexists, REDIS_REPLY_INTEGER);
-    return (r.getContext()->integer > 0);
+    return r.getContext()->integer > 0;
 }
 
 int64_t DBConnector::hdel(const string &key, const string &field)
@@ -652,6 +652,7 @@ void DBConnector::set(const string &key, const string &value)
     RedisReply r(this, sset, REDIS_REPLY_STATUS);
 }
 
+2020-05-29 23:41:31.177615 IFCS_LOG_INFO [NODE] [ifcs_init] Initializing IFCS, boot type = 0
 void DBConnector::config_set(const std::string &key, const std::string &value)
 {
     RedisCommand sset;
@@ -738,6 +739,14 @@ shared_ptr<string> DBConnector::hget(const string &key, const string &field)
 
     SWSS_LOG_ERROR("HGET failed, reply-type: %d, %s: %s", reply->type, key.c_str(), field.c_str());
     throw runtime_error("HGET failed, unexpected reply type, memory exception");
+}
+
+bool DBConnector::hexists(const string &key, const string &field)
+{
+    RedisCommand rexists;
+    rexists.format("HEXISTS %s %s", key.c_str(), field.c_str());
+    RedisReply r(this, rexists, REDIS_REPLY_INTEGER);
+    return r.getContext()->integer > 0;
 }
 
 int64_t DBConnector::rpush(const string &list, const string &item)

--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -652,7 +652,6 @@ void DBConnector::set(const string &key, const string &value)
     RedisReply r(this, sset, REDIS_REPLY_STATUS);
 }
 
-2020-05-29 23:41:31.177615 IFCS_LOG_INFO [NODE] [ifcs_init] Initializing IFCS, boot type = 0
 void DBConnector::config_set(const std::string &key, const std::string &value)
 {
     RedisCommand sset;

--- a/common/dbconnector.h
+++ b/common/dbconnector.h
@@ -188,6 +188,8 @@ public:
 
     std::shared_ptr<std::string> hget(const std::string &key, const std::string &field);
 
+    bool hexists(const std::string &key, const std::string &field);
+
     int64_t incr(const std::string &key);
 
     int64_t decr(const std::string &key);

--- a/common/dbinterface.cpp
+++ b/common/dbinterface.cpp
@@ -72,6 +72,11 @@ std::string DBInterface::get(const std::string& dbName, const std::string& hash,
     return blockable<std::string>(innerfunc, dbName, blocking);
 }
 
+bool DBInterface::hexists(const std::string& dbName, const std::string& hash, const std::string& key)
+{
+    return m_redisClient.at(dbName).hexists(hash, key);
+}
+
 std::map<std::string, std::string> DBInterface::get_all(const std::string& dbName, const std::string& hash, bool blocking)
 {
     auto innerfunc = [&]

--- a/common/dbinterface.h
+++ b/common/dbinterface.h
@@ -38,6 +38,7 @@ public:
     void delete_all_by_pattern(const std::string& dbName, const std::string& pattern);
     bool exists(const std::string& dbName, const std::string& key);
     std::string get(const std::string& dbName, const std::string& hash, const std::string& key, bool blocking = false);
+    bool hexists(const std::string& dbName, const std::string& hash, const std::string& key);
     std::map<std::string, std::string> get_all(const std::string& dbName, const std::string& hash, bool blocking = false);
     std::vector<std::string> keys(const std::string& dbName, const char *pattern = "*", bool blocking = false);
     int64_t publish(const std::string& dbName, const std::string& channel, const std::string& message);

--- a/common/sonicv2connector.cpp
+++ b/common/sonicv2connector.cpp
@@ -74,6 +74,11 @@ std::string SonicV2Connector::get(const std::string& db_name, const std::string&
     return m_dbintf.get(db_name, _hash, key, blocking);
 }
 
+bool SonicV2Connector::hexists(const std::string& db_name, const std::string& _hash, const std::string& key)
+{
+    return m_dbintf.hexists(db_name, _hash, key);
+}
+
 std::map<std::string, std::string> SonicV2Connector::get_all(const std::string& db_name, const std::string& _hash, bool blocking)
 {
     return m_dbintf.get_all(db_name, _hash, blocking);

--- a/common/sonicv2connector.h
+++ b/common/sonicv2connector.h
@@ -43,6 +43,8 @@ public:
 
     std::string get(const std::string& db_name, const std::string& _hash, const std::string& key, bool blocking=false);
 
+    bool hexists(const std::string& db_name, const std::string& _hash, const std::string& key);
+
     std::map<std::string, std::string> get_all(const std::string& db_name, const std::string& _hash, bool blocking=false);
 
     int64_t set(const std::string& db_name, const std::string& _hash, const std::string& key, const std::string& val, bool blocking=false);


### PR DESCRIPTION
Add support for hexists call.

Tested using below code snippet:

```
from swsscommon.swsscommon import SonicV2Connector

db = SonicV2Connector(host='127.0.0.1')
db.connect(db.COUNTERS_DB)
db.connect(db.ASIC_DB)

ex = int(db.hexists(db.COUNTERS_DB, "COUNTERS_PORT_NAME_MAP", "Ethernet0"))
if ex == 1:
    print "Exists"
else:
    print "Do not exists"
```