### PR TITLE
[rediscommand] Add missed vector header to rediscommand.h

### DIFF
--- a/common/rediscommand.h
+++ b/common/rediscommand.h
@@ -2,6 +2,7 @@
 #include <string.h>
 #include <utility>
 #include <tuple>
+#include <vector>
 
 namespace swss {
 


### PR DESCRIPTION
Signed-off-by: Ze Gan <ganze718@gmail.com>