### PR TITLE
Fix bug: RedisTransactioner pops empty container, mistaken copy constructor usage

### DIFF
--- a/common/dbconnector.h
+++ b/common/dbconnector.h
@@ -120,7 +120,7 @@ public:
      * Timeout - The time in milisecond until exception is been thrown. For
      *           infinite wait, set this value to 0
      */
-    DBConnector(const DBConnector &other);
+    explicit DBConnector(const DBConnector &other);
     DBConnector(int dbId, const RedisContext &ctx);
     DBConnector(int dbId, const std::string &hostname, int port, unsigned int timeout);
     DBConnector(int dbId, const std::string &unixPath, unsigned int timeout);

--- a/common/dbconnector.h
+++ b/common/dbconnector.h
@@ -219,9 +219,9 @@ private:
 template<typename OutputIterator>
 void DBConnector::hgetall(const std::string &key, OutputIterator result)
 {
-    RedisCommand sincr;
-    sincr.format("HGETALL %s", key.c_str());
-    RedisReply r(this, sincr, REDIS_REPLY_ARRAY);
+    RedisCommand shgetall;
+    shgetall.format("HGETALL %s", key.c_str());
+    RedisReply r(this, shgetall, REDIS_REPLY_ARRAY);
 
     auto ctx = r.getContext();
 

--- a/common/dbinterface.cpp
+++ b/common/dbinterface.cpp
@@ -326,7 +326,7 @@ void DBInterface::_onetime_connect(int dbId, const string& dbName)
     bool inserted = rc.second;
     if (inserted)
     {
-        auto redisClient = rc.first->second;
+        auto& redisClient = rc.first->second;
         redisClient.config_set("notify-keyspace-events", KEYSPACE_EVENTS);
     }
 }

--- a/common/pubsub.h
+++ b/common/pubsub.h
@@ -13,7 +13,7 @@ namespace swss {
 class PubSub : protected RedisSelect
 {
 public:
-    PubSub(DBConnector *other);
+    explicit PubSub(DBConnector *other);
 
     std::map<std::string, std::string> get_message();
 

--- a/common/redistran.cpp
+++ b/common/redistran.cpp
@@ -73,6 +73,10 @@ void RedisTransactioner::enqueue(const std::string &command, int expectedType)
 
 redisReply *RedisTransactioner::dequeueReply()
 {
+    if (m_results.empty())
+    {
+        return NULL;
+    }
     redisReply *ret = m_results.front();
     m_results.pop_front();
     return ret;
@@ -80,7 +84,10 @@ redisReply *RedisTransactioner::dequeueReply()
 
 void RedisTransactioner::clearResults()
 {
-    if (m_results.empty()) return;
+    if (m_results.empty())
+    {
+        return;
+    }
     for (const auto& r: m_results)
     {
         freeReplyObject(r);


### PR DESCRIPTION
Include several fixes and refactors:
- Simply refactor DBConnector hgetall()
- Fix RedisTransactioner: handle empty deque
- Move complex class constructor as explicit, and fix several mistaken copy constructor usage
