### PR TITLE
[packaging]: Add Support For Libboost v1.71.0

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: sonic
 Maintainer: Shuotian Cheng <shuche@microsoft.com>
 Section: net
 Priority: optional
-Build-Depends: dh-exec (>=0.3), debhelper (>= 9), autotools-dev, libboost-dev
+Build-Depends: dh-exec (>=0.3), debhelper (>= 9), autotools-dev, libboost-dev | libboost1.71-dev
 Standards-Version: 1.0.0
 
 Package: libswsscommon


### PR DESCRIPTION
This PR defines libboost v1.71.0 as an alternative package
for libswsscommon.

singed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>