### PR TITLE
[dbconnector] Make sure json is declared as non null object

### DIFF
--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -846,7 +846,8 @@ void DBConnector::hmset(const std::unordered_map<std::string, std::vector<std::p
 {
     SWSS_LOG_ENTER();
 
-    json j;
+    // make sure this will be object (not null) when multi hash is empty
+    json j = json::object();
 
     // pack multi hash to json (takes bout 70 ms for 10k to construct)
     for (const auto& kvp: multiHash)

--- a/tests/redis_ut.cpp
+++ b/tests/redis_ut.cpp
@@ -956,3 +956,11 @@ TEST(Select, resultToString)
 
     ASSERT_EQ(u, "UNKNOWN");
 }
+
+TEST(Connector, hmset)
+{
+    DBConnector db("TEST_DB", 0, true);
+
+    // test empty multi hash
+    db.hmset({});
+}


### PR DESCRIPTION
When calling dump() it will generate {} instead null

Signed-off-by: kcudnik <kcudnik@gmail.com>