### PR TITLE
[swig] Add missing functions for ConfigDBConnector

### DIFF
--- a/common/configdb.cpp
+++ b/common/configdb.cpp
@@ -9,7 +9,7 @@ using namespace std;
 using namespace swss;
 
 ConfigDBConnector_Native::ConfigDBConnector_Native(bool use_unix_socket_path, const char *netns)
-    : SonicV2Connector(use_unix_socket_path, netns)
+    : SonicV2Connector_Native(use_unix_socket_path, netns)
     , TABLE_NAME_SEPARATOR("|")
     , KEY_SEPARATOR("|")
 {
@@ -19,7 +19,7 @@ void ConfigDBConnector_Native::db_connect(string db_name, bool wait_for_init, bo
 {
     m_db_name = db_name;
     KEY_SEPARATOR = TABLE_NAME_SEPARATOR = get_db_separator(db_name);
-    SonicV2Connector::connect(m_db_name, retry_on);
+    SonicV2Connector_Native::connect(m_db_name, retry_on);
 
     if (wait_for_init)
     {

--- a/common/configdb.h
+++ b/common/configdb.h
@@ -7,7 +7,7 @@
 
 namespace swss {
 
-class ConfigDBConnector_Native : public SonicV2Connector
+class ConfigDBConnector_Native : public SonicV2Connector_Native
 {
 public:
     ConfigDBConnector_Native(bool use_unix_socket_path = false, const char *netns = "");
@@ -131,7 +131,8 @@ protected:
 
 #ifdef SWIG
 %pythoncode %{
-    class ConfigDBConnector(ConfigDBConnector_Native):
+    ## Note: diamond inheritance, reusing functions in both classes
+    class ConfigDBConnector(SonicV2Connector, ConfigDBConnector_Native):
 
         ## Note: there is no easy way for SWIG to map ctor parameter netns(C++) to namespace(python),
         def __init__(self, use_unix_socket_path = False, namespace = '', **kwargs):

--- a/common/configdb.h
+++ b/common/configdb.h
@@ -10,6 +10,8 @@ namespace swss {
 class ConfigDBConnector_Native : public SonicV2Connector_Native
 {
 public:
+    static constexpr const char *INIT_INDICATOR = "CONFIG_DB_INITIALIZED";
+
     ConfigDBConnector_Native(bool use_unix_socket_path = false, const char *netns = "");
 
     void db_connect(std::string db_name, bool wait_for_init, bool retry_on);
@@ -113,7 +115,6 @@ public:
 #endif
 
 protected:
-    static constexpr const char *INIT_INDICATOR = "CONFIG_DB_INITIALIZED";
     std::string TABLE_NAME_SEPARATOR = "|";
     std::string KEY_SEPARATOR = "|";
 

--- a/common/configdb.h
+++ b/common/configdb.h
@@ -135,7 +135,7 @@ protected:
     ## Note: diamond inheritance, reusing functions in both classes
     class ConfigDBConnector(SonicV2Connector, ConfigDBConnector_Native):
 
-        ## Note: there is no easy way for SWIG to map ctor parameter netns(C++) to namespace(python),
+        ## Note: there is no easy way for SWIG to map ctor parameter netns(C++) to namespace(python)
         def __init__(self, use_unix_socket_path = False, namespace = '', **kwargs):
             if 'decode_responses' in kwargs and kwargs.pop('decode_responses') != True:
                 raise ValueError('decode_responses must be True if specified, False is not supported')

--- a/common/configdb.h
+++ b/common/configdb.h
@@ -14,7 +14,7 @@ public:
 
     ConfigDBConnector_Native(bool use_unix_socket_path = false, const char *netns = "");
 
-    void db_connect(std::string db_name, bool wait_for_init, bool retry_on);
+    void db_connect(std::string db_name, bool wait_for_init = false, bool retry_on = false);
     void connect(bool wait_for_init = true, bool retry_on = false);
 
     void set_entry(std::string table, std::string key, const std::map<std::string, std::string>& data);

--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -659,11 +659,18 @@ void DBConnector::hset(const string &key, const string &field, const string &val
     RedisReply r(this, shset, REDIS_REPLY_INTEGER);
 }
 
-void DBConnector::set(const string &key, const string &value)
+bool DBConnector::set(const string &key, const string &value)
 {
     RedisCommand sset;
     sset.format("SET %s %s", key.c_str(), value.c_str());
     RedisReply r(this, sset, REDIS_REPLY_STATUS);
+    string s = r.getReply<string>();
+    return s == "OK";
+}
+
+bool DBConnector::set(const string &key, int value)
+{
+    return set(key, to_string(value));
 }
 
 void DBConnector::config_set(const std::string &key, const std::string &value)

--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -673,6 +673,15 @@ void DBConnector::config_set(const std::string &key, const std::string &value)
     RedisReply r(this, sset, REDIS_REPLY_STATUS);
 }
 
+bool DBConnector::flushdb()
+{
+    RedisCommand sflushdb;
+    sflushdb.format("FLUSHDB");
+    RedisReply r(this, sflushdb, REDIS_REPLY_STATUS);
+    string s = r.getReply<string>();
+    return s == "OK";
+}
+
 vector<string> DBConnector::keys(const string &key)
 {
     RedisCommand skeys;

--- a/common/dbconnector.h
+++ b/common/dbconnector.h
@@ -242,6 +242,8 @@ public:
 
     void config_set(const std::string &key, const std::string &value);
 
+    bool flushdb();
+
 private:
     void setNamespace(const std::string &netns);
 

--- a/common/dbconnector.h
+++ b/common/dbconnector.h
@@ -209,7 +209,8 @@ public:
 
     std::pair<int, std::vector<std::string>> scan(int cursor = 0, const char *match = "", uint32_t count = 10);
 
-    void set(const std::string &key, const std::string &value);
+    bool set(const std::string &key, const std::string &value);
+    bool set(const std::string &key, int value);
 
     void hset(const std::string &key, const std::string &field, const std::string &value);
 

--- a/common/sonicv2connector.cpp
+++ b/common/sonicv2connector.cpp
@@ -4,18 +4,18 @@
 
 using namespace swss;
 
-SonicV2Connector::SonicV2Connector(bool use_unix_socket_path, const char *netns)
+SonicV2Connector_Native::SonicV2Connector_Native(bool use_unix_socket_path, const char *netns)
     : m_use_unix_socket_path(use_unix_socket_path)
     , m_netns(netns)
 {
 }
 
-std::string SonicV2Connector::getNamespace() const
+std::string SonicV2Connector_Native::getNamespace() const
 {
     return m_netns;
 }
 
-void SonicV2Connector::connect(const std::string& db_name, bool retry_on)
+void SonicV2Connector_Native::connect(const std::string& db_name, bool retry_on)
 {
     if (m_use_unix_socket_path)
     {
@@ -29,92 +29,92 @@ void SonicV2Connector::connect(const std::string& db_name, bool retry_on)
     m_dbintf.connect(db_id, db_name, retry_on);
 }
 
-void SonicV2Connector::close(const std::string& db_name)
+void SonicV2Connector_Native::close(const std::string& db_name)
 {
     m_dbintf.close(db_name);
 }
 
-std::vector<std::string> SonicV2Connector::get_db_list()
+std::vector<std::string> SonicV2Connector_Native::get_db_list()
 {
     return SonicDBConfig::getDbList(m_netns);
 }
 
-int SonicV2Connector::get_dbid(const std::string& db_name)
+int SonicV2Connector_Native::get_dbid(const std::string& db_name)
 {
     return SonicDBConfig::getDbId(db_name, m_netns);
 }
 
-std::string SonicV2Connector::get_db_separator(const std::string& db_name)
+std::string SonicV2Connector_Native::get_db_separator(const std::string& db_name)
 {
     return SonicDBConfig::getSeparator(db_name, m_netns);
 }
 
-DBConnector& SonicV2Connector::get_redis_client(const std::string& db_name)
+DBConnector& SonicV2Connector_Native::get_redis_client(const std::string& db_name)
 {
     return m_dbintf.get_redis_client(db_name);
 }
 
-int64_t SonicV2Connector::publish(const std::string& db_name, const std::string& channel, const std::string& message)
+int64_t SonicV2Connector_Native::publish(const std::string& db_name, const std::string& channel, const std::string& message)
 {
     return m_dbintf.publish(db_name, channel, message);
 }
 
-bool SonicV2Connector::exists(const std::string& db_name, const std::string& key)
+bool SonicV2Connector_Native::exists(const std::string& db_name, const std::string& key)
 {
     return m_dbintf.exists(db_name, key);
 }
 
-std::vector<std::string> SonicV2Connector::keys(const std::string& db_name, const char *pattern, bool blocking)
+std::vector<std::string> SonicV2Connector_Native::keys(const std::string& db_name, const char *pattern, bool blocking)
 {
     return m_dbintf.keys(db_name, pattern, blocking);
 }
 
-std::pair<int, std::vector<std::string>> SonicV2Connector::scan(const std::string& db_name, int cursor, const char *match, uint32_t count)
+std::pair<int, std::vector<std::string>> SonicV2Connector_Native::scan(const std::string& db_name, int cursor, const char *match, uint32_t count)
 {
     return m_dbintf.scan(db_name, cursor, match, count);
 }
 
-std::string SonicV2Connector::get(const std::string& db_name, const std::string& _hash, const std::string& key, bool blocking)
+std::string SonicV2Connector_Native::get(const std::string& db_name, const std::string& _hash, const std::string& key, bool blocking)
 {
     return m_dbintf.get(db_name, _hash, key, blocking);
 }
 
-bool SonicV2Connector::hexists(const std::string& db_name, const std::string& _hash, const std::string& key)
+bool SonicV2Connector_Native::hexists(const std::string& db_name, const std::string& _hash, const std::string& key)
 {
     return m_dbintf.hexists(db_name, _hash, key);
 }
 
-std::map<std::string, std::string> SonicV2Connector::get_all(const std::string& db_name, const std::string& _hash, bool blocking)
+std::map<std::string, std::string> SonicV2Connector_Native::get_all(const std::string& db_name, const std::string& _hash, bool blocking)
 {
     return m_dbintf.get_all(db_name, _hash, blocking);
 }
 
-int64_t SonicV2Connector::set(const std::string& db_name, const std::string& _hash, const std::string& key, const std::string& val, bool blocking)
+int64_t SonicV2Connector_Native::set(const std::string& db_name, const std::string& _hash, const std::string& key, const std::string& val, bool blocking)
 {
     return m_dbintf.set(db_name, _hash, key, val, blocking);
 }
 
-int64_t SonicV2Connector::del(const std::string& db_name, const std::string& key, bool blocking)
+int64_t SonicV2Connector_Native::del(const std::string& db_name, const std::string& key, bool blocking)
 {
     return m_dbintf.del(db_name, key, blocking);
 }
 
-void SonicV2Connector::delete_all_by_pattern(const std::string& db_name, const std::string& pattern)
+void SonicV2Connector_Native::delete_all_by_pattern(const std::string& db_name, const std::string& pattern)
 {
     m_dbintf.delete_all_by_pattern(db_name, pattern);
 }
 
-std::string SonicV2Connector::get_db_socket(const std::string& db_name)
+std::string SonicV2Connector_Native::get_db_socket(const std::string& db_name)
 {
     return SonicDBConfig::getDbSock(db_name, m_netns);
 }
 
-std::string SonicV2Connector::get_db_hostname(const std::string& db_name)
+std::string SonicV2Connector_Native::get_db_hostname(const std::string& db_name)
 {
     return SonicDBConfig::getDbHostname(db_name, m_netns);
 }
 
-int SonicV2Connector::get_db_port(const std::string& db_name)
+int SonicV2Connector_Native::get_db_port(const std::string& db_name)
 {
     return SonicDBConfig::getDbPort(db_name, m_netns);
 }

--- a/common/sonicv2connector.h
+++ b/common/sonicv2connector.h
@@ -63,7 +63,7 @@ private:
 %pythoncode %{
     class SonicV2Connector(SonicV2Connector_Native):
 
-        ## Note: there is no easy way for SWIG to map ctor parameter netns(C++) to namespace(python),
+        ## Note: there is no easy way for SWIG to map ctor parameter netns(C++) to namespace(python)
         def __init__(self, use_unix_socket_path = False, namespace = '', **kwargs):
             if 'host' in kwargs:
                 # Note: host argument will be ignored, same as in sonic-py-swsssdk

--- a/common/sonicv2connector.h
+++ b/common/sonicv2connector.h
@@ -8,20 +8,12 @@
 namespace swss
 {
 
-class SonicV2Connector
+class SonicV2Connector_Native
 {
 public:
-    SonicV2Connector(bool use_unix_socket_path = false, const char *netns = "");
+    SonicV2Connector_Native(bool use_unix_socket_path = false, const char *netns = "");
 
     std::string getNamespace() const;
-
-#ifdef SWIG
-    %pythoncode %{
-        __swig_getmethods__["namespace"] = getNamespace
-        __swig_setmethods__["namespace"] = None
-        if _newclass: namespace = property(getNamespace, None)
-    %}
-#endif
 
     void connect(const std::string& db_name, bool retry_on = true);
 
@@ -68,32 +60,32 @@ private:
 };
 
 #ifdef SWIG
-// TRICK!
-// Note: there is no easy way for SWIG to map ctor parameter netns(C++) to namespace(python),
-// so we use python patch to achieve this
-// TODO: implement it with formal SWIG syntax, which will be target language independent
 %pythoncode %{
-    _old_SonicV2Connector__init__ = SonicV2Connector.__init__
-    def _new_SonicV2Connector__init__(self, use_unix_socket_path = False, namespace = '', **kwargs):
-        if 'host' in kwargs:
-            # Note: host argument will be ignored, same as in sonic-py-swsssdk
-            kwargs.pop('host')
-        if 'decode_responses' in kwargs and kwargs.pop('decode_responses') != True:
-            raise ValueError('decode_responses must be True if specified, False is not supported')
-        if namespace is None:
-            namespace = ''
-        _old_SonicV2Connector__init__(self, use_unix_socket_path = use_unix_socket_path, netns = namespace)
+    class SonicV2Connector(SonicV2Connector_Native):
 
-        # Add database name attributes into SonicV2Connector instance
-        # Note: this is difficult to implement in C++
-        for db_name in self.get_db_list():
-            # set a database name as a constant value attribute.
-            setattr(self, db_name, db_name)
-            getmethod = lambda self: db_name
-            SonicV2Connector.__swig_getmethods__[db_name] = getmethod
-            SonicV2Connector.__swig_setmethods__[db_name] = None
+        ## Note: there is no easy way for SWIG to map ctor parameter netns(C++) to namespace(python),
+        def __init__(self, use_unix_socket_path = False, namespace = '', **kwargs):
+            if 'host' in kwargs:
+                # Note: host argument will be ignored, same as in sonic-py-swsssdk
+                kwargs.pop('host')
+            if 'decode_responses' in kwargs and kwargs.pop('decode_responses') != True:
+                raise ValueError('decode_responses must be True if specified, False is not supported')
+            if namespace is None:
+                namespace = ''
+            super(SonicV2Connector, self).__init__(use_unix_socket_path = use_unix_socket_path, netns = namespace)
 
-    SonicV2Connector.__init__ = _new_SonicV2Connector__init__
+            # Add database name attributes into SonicV2Connector instance
+            # Note: this is difficult to implement in C++
+            for db_name in self.get_db_list():
+                # set a database name as a constant value attribute.
+                setattr(self, db_name, db_name)
+                getmethod = lambda self: db_name
+                SonicV2Connector.__swig_getmethods__[db_name] = getmethod
+                SonicV2Connector.__swig_setmethods__[db_name] = None
+
+        @property
+        def namespace(self):
+            return self.getNamespace()
 %}
 #endif
 }

--- a/pyext/swsscommon.i
+++ b/pyext/swsscommon.i
@@ -13,7 +13,6 @@
 #define SWIG_PYTHON_2_UNICODE
 
 #include "schema.h"
-#include "configdb.h"
 #include "dbconnector.h"
 #include "dbinterface.h"
 #include "sonicv2connector.h"
@@ -35,6 +34,7 @@
 #include "notificationproducer.h"
 #include "warm_restart.h"
 #include "logger.h"
+#include "configdb.h"
 %}
 
 %include <std_string.i>
@@ -109,7 +109,6 @@ T castSelectableObj(swss::Selectable *temp)
 %template(CastSelectableToSubscriberTableObj) castSelectableObj<swss::SubscriberStateTable *>;
 
 %include "schema.h"
-%include "configdb.h"
 %include "dbconnector.h"
 %include "sonicv2connector.h"
 %include "pubsub.h"
@@ -119,6 +118,7 @@ T castSelectableObj(swss::Selectable *temp)
 %include "redispipeline.h"
 %include "redisselect.h"
 %include "redistran.h"
+%include "configdb.h"
 
 %extend swss::DBConnector {
     %template(hgetall) hgetall<std::map<std::string, std::string>>;

--- a/tests/redis_ut.cpp
+++ b/tests/redis_ut.cpp
@@ -318,7 +318,7 @@ TEST(DBConnector, DBInterface)
     dbintf.set_redis_kwargs("", "127.0.0.1", 6379);
     dbintf.connect(15, "TEST_DB");
 
-    SonicV2Connector db;
+    SonicV2Connector_Native db;
     db.connect("TEST_DB");
     db.set("TEST_DB", "key0", "field1", "value2");
     auto fvs = db.get_all("TEST_DB", "key0");

--- a/tests/test_redis_ut.py
+++ b/tests/test_redis_ut.py
@@ -301,3 +301,6 @@ def test_ConfigDBScan():
     for i in range(0, n):
         s = str(i)
         config_db.delete_table("TEST_TYPE" + s)
+
+    client = config_db.get_redis_client(config_db.CONFIG_DB)
+    client.flushdb()

--- a/tests/test_redis_ut.py
+++ b/tests/test_redis_ut.py
@@ -323,3 +323,11 @@ def test_ConfigDBFlush():
     client.flushdb()
     allconfig = config_db.get_config()
     assert len(allconfig) == 0
+
+def test_ConfigDBConnect():
+    config_db = ConfigDBConnector()
+    config_db.db_connect('CONFIG_DB')
+    client = config_db.get_redis_client(config_db.CONFIG_DB)
+    client.flushdb()
+    allconfig = config_db.get_config()
+    assert len(allconfig) == 0

--- a/tests/test_redis_ut.py
+++ b/tests/test_redis_ut.py
@@ -302,5 +302,11 @@ def test_ConfigDBScan():
         s = str(i)
         config_db.delete_table("TEST_TYPE" + s)
 
+def test_ConfigDBFlush():
+    config_db = ConfigDBConnector()
+    config_db.connect(wait_for_init=False)
+    config_db.set_entry("TEST_PORT", "Ethernet111", {"alias": "etp1x"})
     client = config_db.get_redis_client(config_db.CONFIG_DB)
     client.flushdb()
+    allconfig = config_db.get_config()
+    assert len(allconfig) == 0

--- a/tests/test_redis_ut.py
+++ b/tests/test_redis_ut.py
@@ -244,6 +244,7 @@ def test_DBInterface():
 def test_ConfigDBConnector():
     config_db = ConfigDBConnector()
     config_db.connect(wait_for_init=False)
+    config_db.get_redis_client(config_db.CONFIG_DB).flushdb()
     config_db.set_entry("TEST_PORT", "Ethernet111", {"alias": "etp1x"})
     allconfig = config_db.get_config()
     assert allconfig["TEST_PORT"]["Ethernet111"]["alias"] == "etp1x"
@@ -260,6 +261,7 @@ def test_ConfigDBConnector():
 def test_ConfigDBPipeConnector():
     config_db = ConfigDBPipeConnector()
     config_db.connect(wait_for_init=False)
+    config_db.get_redis_client(config_db.CONFIG_DB).flushdb()
     config_db.set_entry("TEST_PORT", "Ethernet112", {"alias": "etp1x"})
     allconfig = config_db.get_config()
     assert allconfig["TEST_PORT"]["Ethernet112"]["alias"] == "etp1x"
@@ -285,6 +287,7 @@ def test_ConfigDBPipeConnector():
 def test_ConfigDBScan():
     config_db = ConfigDBPipeConnector()
     config_db.connect(wait_for_init=False)
+    config_db.get_redis_client(config_db.CONFIG_DB).flushdb()
     n = 1000
     for i in range(0, n):
         s = str(i)
@@ -307,6 +310,16 @@ def test_ConfigDBFlush():
     config_db.connect(wait_for_init=False)
     config_db.set_entry("TEST_PORT", "Ethernet111", {"alias": "etp1x"})
     client = config_db.get_redis_client(config_db.CONFIG_DB)
+
+    assert ConfigDBConnector.INIT_INDICATOR == "CONFIG_DB_INITIALIZED"
+    assert config_db.INIT_INDICATOR == "CONFIG_DB_INITIALIZED"
+
+    suc = client.set(config_db.INIT_INDICATOR, 1)
+    assert suc
+    # TODO: redis.get is not yet supported
+    # indicator = client.get(config_db.INIT_INDICATOR)
+    # assert indicator == '1'
+
     client.flushdb()
     allconfig = config_db.get_config()
     assert len(allconfig) == 0


### PR DESCRIPTION
Add missing functions for ConfigDBConnector, including
- ConfigDBConnector.get_redis_client(...)
- ConfigDBConnector.CONFIG_DB
- ConfigDBConnector.get_redis_client(...).flushdb()
- ConfigDBConnector.INIT_INDICATOR
- ConfigDBConnector.db_connect(...): support optional parameters

Tested in unit test:
1. this repo: add unit testcases for all the new functions.
2. sonic-config-engine
3. sonic-utilities

Tested in DUT:
1. `sudo config load_minigraph -y`
2. snmpwalk snmpagent on 1.3.6.1.4.1.9.9.187