### PR TITLE
Update to make getNamespaces() API at par with get_ns_list() in swsssdk

### DIFF
--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -363,13 +363,12 @@ vector<string> SonicDBConfig::getNamespaces()
     vector<string> list;
     std::lock_guard<std::recursive_mutex> guard(m_db_info_mutex);
 
-    if (!m_global_init)
-        initializeGlobalConfig();
+    if (!m_init)
+        initialize(DEFAULT_SONIC_DB_CONFIG_FILE);
 
-    // This API returns back non-empty namespaces.
+    // This API returns back all namespaces including '' representing global ns.
     for (auto it = m_inst_info.cbegin(); it != m_inst_info.cend(); ++it) {
-        if(!((it->first).empty()))
-            list.push_back(it->first);
+        list.push_back(it->first);
     }
 
     return list;

--- a/tests/redis_multi_ns_ut.cpp
+++ b/tests/redis_multi_ns_ut.cpp
@@ -67,8 +67,8 @@ TEST(DBConnector, multi_ns_test)
             else
             {
                 ns_name = element["namespace"];
-                namespaces.push_back(ns_name);
             }
+            namespaces.push_back(ns_name);
 
             // parse config file
             ifstream i(local_file);


### PR DESCRIPTION
Update to make getNamespaces() API at par with the get_ns_list() in swsssdk. So this API 
1. Will give back all namespaces including the global namespace ('')
2. Will not preload the Global database_config.json. The application should call SonicDBConfig::initializeGlobalConfig explicity.