### PR TITLE
Add a function to SonicDBConfig to get DB instance list

### DIFF
--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -209,6 +209,14 @@ void SonicDBConfig::validateNamespace(const string &netns)
     }
 }
 
+unordered_map<std::string, std::unordered_map<std::string, SonicDBInfo>> SonicDBConfig::getInstanceList(const std::string &netns)
+{
+    if (!m_init)
+        initialize(DEFAULT_SONIC_DB_CONFIG_FILE);
+    validateNamespace(netns);
+    return m_db_info;
+}
+
 SonicDBInfo& SonicDBConfig::getDbInfo(const std::string &dbName, const std::string &netns)
 {
     std::lock_guard<std::recursive_mutex> guard(m_db_info_mutex);

--- a/common/dbconnector.h
+++ b/common/dbconnector.h
@@ -60,6 +60,7 @@ public:
 #endif
 
     static void validateNamespace(const std::string &netns);
+    static std::unordered_map<std::string, std::unordered_map<std::string, SonicDBInfo>> getInstanceList(const std::string &netns = EMPTY_NAMESPACE);
     static std::string getDbInst(const std::string &dbName, const std::string &netns = EMPTY_NAMESPACE);
     static int getDbId(const std::string &dbName, const std::string &netns = EMPTY_NAMESPACE);
     static std::string getSeparator(const std::string &dbName, const std::string &netns = EMPTY_NAMESPACE);


### PR DESCRIPTION
Add a new get function to obtain DB instances. This is to be used by some utility scripts.

Dependent PR in sonic-buildimage which will use this: https://github.com/Azure/sonic-buildimage/pull/6844