### PR TITLE
nlohmann_json: Port memory leak fix from nlohmann/json repo

### DIFF
--- a/common/json.hpp
+++ b/common/json.hpp
@@ -4686,8 +4686,7 @@ class basic_json
         // add element to array (move semantics)
         assert(m_value.array != nullptr);
         m_value.array->push_back(std::move(val));
-        // invalidate object
-        val.m_type = value_t::null;
+        // if val is moved from, basic_json move constructor marks it null so we do not call the destructor
     }
 
     /*!


### PR DESCRIPTION
Was seeing below crash because of exception from json array push_back call invoked as part of CRM polling in armhf environment. 
With following fix https://github.com/nlohmann/json/pull/2025 , issue is resolved. Porting the same to swss-common repo.
Issue: https://github.com/nlohmann/json/issues/1971 

root@sonic:/etc/sonic# gdb /usr/bin/orchagent orchagent.1613753738.36.core
GNU gdb (Debian 8.2.1-2+b3) 8.2.1
Copyright (C) 2018 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "arm-linux-gnueabihf".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from /usr/bin/orchagent...(no debugging symbols found)...done.
[New LWP 36]
[New LWP 51]
[New LWP 148]
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/arm-linux-gnueabihf/libthread_db.so.1".
Core was generated by `/usr/bin/orchagent -d /var/log/swss -b 8192 -s -m 50:E0:EF:51:27:D1'.
Program terminated with signal SIGABRT, Aborted.
#0  __libc_do_syscall () at ../sysdeps/unix/sysv/linux/arm/libc-do-syscall.S:47
47      ../sysdeps/unix/sysv/linux/arm/libc-do-syscall.S: No such file or directory.
[Current thread is 1 (Thread 0xb6f53010 (LWP 36))]
(gdb) bt
#0  __libc_do_syscall () at ../sysdeps/unix/sysv/linux/arm/libc-do-syscall.S:47
#1  0xb68b80ae in __libc_signal_restore_set (set=0xbe92d09c)
    at ../sysdeps/unix/sysv/linux/internal-signals.h:84
#2  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:48
#3  0xb68aa1f2 in __GI_abort () at abort.c:79
#4  0xb6aa3888 in __gnu_cxx::__verbose_terminate_handler() () from /usr/lib/arm-linux-gnueabihf/libstdc++.so.6
#5  0xb6aa21ec in ?? () from /usr/lib/arm-linux-gnueabihf/libstdc++.so.6
#6  0xb6aa2242 in std::terminate() () from /usr/lib/arm-linux-gnueabihf/libstdc++.so.6
#7  0xb6aa247c in __cxa_throw () from /usr/lib/arm-linux-gnueabihf/libstdc++.so.6
#8  0xb6bffa78 in nlohmann::basic_json<std::map, std::vector, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, long long, unsigned long long, double, std::allocator>::push_back(nlohmann::basic_json<std::map, std::vector, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, long long, unsigned long long, double, std::allocator> const&) ()
   from /usr/lib/arm-linux-gnueabihf/libsaimetadata.so.0
#9  0xb6bf5458 in sai_serialize_acl_resource_list[abi:cxx11](_sai_acl_resource_list_t const&, bool) ()
   from /usr/lib/arm-linux-gnueabihf/libsaimetadata.so.0
#10 0xb6bf588e in sai_serialize_attr_value[abi:cxx11](_sai_attr_metadata_t const&, _sai_attribute_t const&, bool) () from /usr/lib/arm-linux-gnueabihf/libsaimetadata.so.0
#11 0xb6beaf1e in saimeta::SaiAttributeList::serialize_attr_list[abi:cxx11](_sai_object_type_t, unsigned int, _sai_attribute_t const*, bool) () from /usr/lib/arm-linux-gnueabihf/libsaimetadata.so.0
#12 0xb6e51862 in sairedis::RedisRemoteSaiInterface::get(_sai_object_type_t, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, unsigned int, _sai_attribute_t*) ()
   from /usr/lib/arm-linux-gnueabihf/libsairedis.so.0
#13 0xb6e51aac in sairedis::RedisRemoteSaiInterface::get(_sai_object_type_t, unsigned long long, unsigned int, _sai_attribute_t*) () from /usr/lib/arm-linux-gnueabihf/libsairedis.so.0
#14 0xb6c0f42e in saimeta::Meta::get(_sai_object_type_t, unsigned long long, unsigned int, _sai_attribute_t*)
    () from /usr/lib/arm-linux-gnueabihf/libsaimetadata.so.0
#15 0xb6e3be34 in sairedis::Sai::get(_sai_object_type_t, unsigned long long, unsigned int, _sai_attribute_t*)
    () from /usr/lib/arm-linux-gnueabihf/libsairedis.so.0
#16 0xb6e3777c in ?? () from /usr/lib/arm-linux-gnueabihf/libsairedis.so.0
--Type <RET> for more, q to quit, c to continue without paging--
#17 0x004ef016 in ?? ()
#18 0x004ef32a in ?? ()
#19 0x0044f818 in ?? ()
#20 0x00432f44 in ?? ()
#21 0xb68aa524 in __libc_start_main (main=0x4328ad, argc=8, argv=0xbe92dc84, init=<optimized out>,
    fini=0x54bc2d, rtld_fini=0xb6f466c5 <_dl_fini>, stack_end=0xbe92dc84) at libc-start.c:308
#22 0x00448d38 in ?? ()
Backtrace stopped: previous frame identical to this frame (corrupt stack?)
(gdb) root@sonic:/home/admin#


