### PR TITLE
Convert return value of get_all function in SonicV2Connector to dict

### DIFF
--- a/common/sonicv2connector.h
+++ b/common/sonicv2connector.h
@@ -88,7 +88,7 @@ private:
             return self.getNamespace()
 
         def get_all(self, db_name, _hash, blocking=False):
-            return dict(super().get_all(db_name, _hash, blocking))
+            return dict(super(SonicV2Connector, self).get_all(db_name, _hash, blocking))
 %}
 #endif
 }

--- a/common/sonicv2connector.h
+++ b/common/sonicv2connector.h
@@ -86,6 +86,9 @@ private:
         @property
         def namespace(self):
             return self.getNamespace()
+
+        def get_all(self, db_name, _hash, blocking=False):
+            return dict(super().get_all(db_name, _hash, blocking))
 %}
 #endif
 }

--- a/tests/test_redis_ut.py
+++ b/tests/test_redis_ut.py
@@ -4,6 +4,7 @@ from threading import Thread
 from pympler.tracker import SummaryTracker
 from swsscommon import swsscommon
 from swsscommon.swsscommon import ConfigDBPipeConnector, DBInterface, SonicV2Connector, SonicDBConfig, ConfigDBConnector
+import json
 
 existing_file = "./tests/redis_multi_db_ut_config/database_config.json"
 
@@ -148,6 +149,10 @@ def test_DBInterface():
     fvs = db.get_all("TEST_DB", "key0")
     assert "field1" in fvs
     assert fvs["field1"] == "value2"
+    try:
+        json.dumps(fvs)
+    except:
+        assert False, 'Unexpected exception raised in json dumps'
 
     # Test keys
     ks = db.keys("TEST_DB", "key*");


### PR DESCRIPTION
The function `get_all` in `SonicV2Connector` returns a FieldValueMap which is not json serializable. This object type will cause failures in fast reboot dump. Converting the object to a dictionary to avoid fast reboot failures.