### PR TITLE
[dbconnector] Initialize redisContext

### DIFF
--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -404,10 +404,12 @@ constexpr const char *RedisContext::DEFAULT_UNIXSOCKET;
 
 RedisContext::~RedisContext()
 {
-    redisFree(m_conn);
+    if(m_conn)
+        redisFree(m_conn);
 }
 
 RedisContext::RedisContext()
+    : m_conn(NULL)
 {
 }
 


### PR DESCRIPTION
Issue: When /var/run/redis/sonic-db/database_config.json file is missing,
          RedisContext destructor calls redisFree on invalid pointer.

Fix:     Initialize redisContext to NULL in order to avoid deallocating an
          invalid memory address when RedisContext destructor is being called.