### PR TITLE
[swss-common] Remove object type argument from json array() constructor call

### DIFF
--- a/common/json.hpp
+++ b/common/json.hpp
@@ -1612,7 +1612,7 @@ class basic_json
     static basic_json array(std::initializer_list<basic_json> init =
                                 std::initializer_list<basic_json>())
     {
-        return basic_json(init, false, value_t::array);
+        return basic_json(init, false);
     }
 
     /*!

--- a/tests/json_ut.cpp
+++ b/tests/json_ut.cpp
@@ -75,3 +75,12 @@ TEST(JSON, test)
     }
     file.close();
 }
+
+TEST(JSON, Array)
+{
+    json arr = json::array();
+    json::array_t a;
+    json arr1(a);
+    EXPECT_TRUE(arr.is_array());
+    EXPECT_TRUE(arr1.is_array());
+}


### PR DESCRIPTION


Default value set to value_t::array in constructor.
Issue: https://github.com/Azure/sonic-sairedis/issues/801

Signed-off-by: Rajkumar Pennadam Ramamoorthy <rpennadamram@marvell.com>