### PR TITLE
[swig] translate SonicV2Connector::keys return type from C++ vector<string> to Python list

### DIFF
--- a/common/sonicv2connector.h
+++ b/common/sonicv2connector.h
@@ -89,6 +89,9 @@ private:
 
         def get_all(self, db_name, _hash, blocking=False):
             return dict(super(SonicV2Connector, self).get_all(db_name, _hash, blocking))
+
+        def keys(self, *args, **kwargs):
+            return list(super(SonicV2Connector, self).keys(*args, **kwargs))
 %}
 #endif
 }

--- a/tests/test_redis_ut.py
+++ b/tests/test_redis_ut.py
@@ -158,6 +158,7 @@ def test_DBInterface():
     ks = db.keys("TEST_DB", "key*");
     assert len(ks) == 1
     ks = db.keys("TEST_DB", u"key*");
+    ks.sort(reverse=True)
     assert len(ks) == 1
 
     # Test del

--- a/tests/test_redis_ut.py
+++ b/tests/test_redis_ut.py
@@ -145,6 +145,8 @@ def test_DBInterface():
     assert db.TEST_DB == 'TEST_DB'
     assert db.namespace == ''
     db.connect("TEST_DB")
+    redisclient = db.get_redis_client("TEST_DB")
+    redisclient.flushdb()
     db.set("TEST_DB", "key0", "field1", "value2")
     fvs = db.get_all("TEST_DB", "key0")
     assert "field1" in fvs
@@ -155,11 +157,19 @@ def test_DBInterface():
         assert False, 'Unexpected exception raised in json dumps'
 
     # Test keys
-    ks = db.keys("TEST_DB", "key*");
+    ks = db.keys("TEST_DB", "key*")
     assert len(ks) == 1
-    ks = db.keys("TEST_DB", u"key*");
+    ks = db.keys("TEST_DB", u"key*")
+    assert len(ks) == 1
+
+    # Test keys could be sorted in place
+    db.set("TEST_DB", "key11", "field1", "value2")
+    db.set("TEST_DB", "key12", "field1", "value2")
+    db.set("TEST_DB", "key13", "field1", "value2")
+    ks = db.keys("TEST_DB", "key*")
+    ks0 = ks
     ks.sort(reverse=True)
-    assert len(ks) == 1
+    assert ks == sorted(ks0, reverse=True)
 
     # Test del
     db.set("TEST_DB", "key3", "field4", "value5")
@@ -169,7 +179,6 @@ def test_DBInterface():
     assert deleted == 0
 
     # Test pubsub
-    redisclient = db.get_redis_client("TEST_DB")
     pubsub = redisclient.pubsub()
     dbid = db.get_dbid("TEST_DB")
     pubsub.psubscribe("__keyspace@{}__:pub_key*".format(dbid))

--- a/tests/test_redis_ut.py
+++ b/tests/test_redis_ut.py
@@ -170,6 +170,7 @@ def test_DBInterface():
     ks0 = ks
     ks.sort(reverse=True)
     assert ks == sorted(ks0, reverse=True)
+    assert isinstance(ks, list)
 
     # Test del
     db.set("TEST_DB", "key3", "field4", "value5")


### PR DESCRIPTION
This is to fix a bug after replacing swsssdk with swsscommon.

```
$ show reboot-cause history                                          
Traceback (most recent call last):
  File "/usr/local/bin/show", line 8, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/show/reboot_cause.py", line 51, in history
    table_keys.sort(reverse=True)
AttributeError: 'tuple' object has no attribute 'sort'
```