### PR TITLE
Make nlohmann::json namespace visibility hidden

### DIFF
--- a/common/json.hpp
+++ b/common/json.hpp
@@ -48,7 +48,7 @@ Licensed under the MIT License <http://opensource.org/licenses/MIT>.
 @see https://github.com/nlohmann
 @since version 1.0.0
 */
-namespace nlohmann
+namespace nlohmann __attribute__ ((visibility ("hidden")))
 {
 
 


### PR DESCRIPTION
Potential fix for armhf architecture to make json symbols local

Original issue described here: https://github.com/Azure/sonic-sairedis/issues/801