### PR TITLE
Support for in-band-mgmt via management VRF.

### DIFF
--- a/common/schema.h
+++ b/common/schema.h
@@ -211,6 +211,7 @@ namespace swss {
 #define CFG_SWITCH_TABLE_NAME      "SWITCH"
 #define CFG_VRF_TABLE_NAME         "VRF"
 #define CFG_CRM_TABLE_NAME         "CRM"
+#define CFG_MGMT_VRF_TABLE_NAME    "MGMT_VRF_CONFIG"
 
 #define CFG_DHCP_SERVER_TABLE_NAME   "DHCP_SERVER"
 #define CFG_NTP_SERVER_TABLE_NAME    "NTP_SERVER"


### PR DESCRIPTION
Signed-off-by: Venkatesan Mahalingam <venkatesan_mahalinga@dell.com>

Please refer [HLD](https://github.com/Azure/SONiC/pull/638) and [swss](https://github.com/Azure/sonic-swss/pull/1707) PRs for more information.

What I did

Support for in-band-mgmt via management VRF

Why I did it
Other than eth0, mgmt VRF should have in-band L3 interfaces as well.

How I verified it
In-progress
