### PR TITLE
[swig] allow threads

### DIFF
--- a/pyext/swsscommon.i
+++ b/pyext/swsscommon.i
@@ -46,6 +46,7 @@
 %include <exception.i>
 
 %exception {
+    Py_BEGIN_ALLOW_THREADS
     try
     {
         $action
@@ -55,6 +56,7 @@
     {
         SWIG_exception(SWIG_UnknownError, "unknown exception");
     }
+    Py_END_ALLOW_THREADS
 }
 
 %template(FieldValuePair) std::pair<std::string, std::string>;

--- a/pyext/swsscommon.i
+++ b/pyext/swsscommon.i
@@ -54,17 +54,27 @@
 %template(GetConfigResult) std::map<std::string, std::map<std::string, std::map<std::string, std::string>>>;
 
 %exception {
-    PyThreadState *_save;
-    _save = PyEval_SaveThread();
     try
     {
+        class PyThreadStateGuard
+        {
+            PyThreadState *m_save;
+        public:
+            PyThreadStateGuard()
+            {
+                m_save = PyEval_SaveThread();
+            }
+            ~PyThreadStateGuard()
+            {
+                PyEval_RestoreThread(m_save);
+            }
+        } thread_state_guard;
+
         $action
-        PyEval_RestoreThread(_save);
     }
     SWIG_CATCH_STDEXCEPT // catch std::exception derivatives
     catch (...)
     {
-        PyEval_RestoreThread(_save);
         SWIG_exception(SWIG_UnknownError, "unknown exception");
     }
 }

--- a/pyext/swsscommon.i
+++ b/pyext/swsscommon.i
@@ -45,20 +45,6 @@
 %include <stdint.i>
 %include <exception.i>
 
-%exception {
-    Py_BEGIN_ALLOW_THREADS
-    try
-    {
-        $action
-    }
-    SWIG_CATCH_STDEXCEPT // catch std::exception derivatives
-    catch (...)
-    {
-        SWIG_exception(SWIG_UnknownError, "unknown exception");
-    }
-    Py_END_ALLOW_THREADS
-}
-
 %template(FieldValuePair) std::pair<std::string, std::string>;
 %template(FieldValuePairs) std::vector<std::pair<std::string, std::string>>;
 %template(FieldValueMap) std::map<std::string, std::string>;
@@ -66,6 +52,22 @@
 %template(ScanResult) std::pair<int64_t, std::vector<std::string>>;
 %template(GetTableResult) std::map<std::string, std::map<std::string, std::string>>;
 %template(GetConfigResult) std::map<std::string, std::map<std::string, std::map<std::string, std::string>>>;
+
+%exception {
+    PyThreadState *_save;
+    _save = PyEval_SaveThread();
+    try
+    {
+        $action
+        PyEval_RestoreThread(_save);
+    }
+    SWIG_CATCH_STDEXCEPT // catch std::exception derivatives
+    catch (...)
+    {
+        PyEval_RestoreThread(_save);
+        SWIG_exception(SWIG_UnknownError, "unknown exception");
+    }
+}
 
 %pythoncode %{
     def _FieldValueMap__get(self, key, default=None):

--- a/tests/test_redis_ut.py
+++ b/tests/test_redis_ut.py
@@ -92,10 +92,12 @@ def test_SelectYield():
     test_thread.start()
 
     while True:
-        (state, c) = sel.select(1000)
-        print("select: state=", state, swsscommon.Select.OBJECT, state==swsscommon.Select.OBJECT)
+        # timeout 10s is too long and indicates thread hanging
+        (state, c) = sel.select(10000)
         if state == swsscommon.Select.OBJECT:
             break
+        elif state == swsscommon.Select.TIMEOUT:
+            assert False
 
     test_thread.join()
     (key, op, cfvs) = cst.pop()


### PR DESCRIPTION
By default, SWIG does not enable support for multithreaded Python applications. More specifically, the Python wrappers generated by SWIG will not release the Python's interpreter's Global Interpreter Lock (GIL) when wrapped C/C++ code is entered. Hence, while any of the wrapped C/C++ code is executing, the Python interpreter will not be able to run any other threads, even if the wrapped C/C++ code is waiting in a blocking call for something like network or disk IO.

ref: http://www.swig.org/Doc4.0/Python.html#Python_multithreaded
But the solution is for swig 4.0. The PR fix it in swig 3.0.
