### PR TITLE
[swig] Implement TableEntryPoppable.pops()

### DIFF
--- a/common/table.h
+++ b/common/table.h
@@ -113,6 +113,8 @@ public:
     /* Get multiple pop elements */
     virtual void pops(std::deque<KeyOpFieldsValuesTuple> &vkco, const std::string &prefix = EMPTY_PREFIX) = 0;
 
+    /* Get multiple pop elements (only for SWIG usage) */
+    /* TODO: current swig 3.0 does not support std::tuple, remove after future support */
     void pops(std::vector<std::string> &keys, std::vector<std::string> &ops, std::vector<std::vector<FieldValueTuple>> &fvss, const std::string &prefix = EMPTY_PREFIX)
     {
         std::deque<KeyOpFieldsValuesTuple> vkco;
@@ -131,6 +133,13 @@ public:
         }
     }
 };
+
+#ifdef SWIG
+%pythoncode %{
+    def transpose_pops(m):
+        return [tuple(m[j][i] for j in range(len(m))) for i in range(len(m[0]))]
+%}
+#endif
 
 class TableConsumable : public TableBase, public TableEntryPoppable, public RedisSelect {
 public:

--- a/common/table.h
+++ b/common/table.h
@@ -112,6 +112,24 @@ public:
 
     /* Get multiple pop elements */
     virtual void pops(std::deque<KeyOpFieldsValuesTuple> &vkco, const std::string &prefix = EMPTY_PREFIX) = 0;
+
+    void pops(std::vector<std::string> &keys, std::vector<std::string> &ops, std::vector<std::vector<FieldValueTuple>> &fvss, const std::string &prefix = EMPTY_PREFIX)
+    {
+        std::deque<KeyOpFieldsValuesTuple> vkco;
+        pops(vkco);
+
+        keys.clear();
+        ops.clear();
+        fvss.clear();
+        while(!vkco.empty())
+        {
+            auto& kco = vkco.front();
+            keys.emplace_back(kfvKey(kco));
+            ops.emplace_back(kfvOp(kco));
+            fvss.emplace_back(kfvFieldsValues(kco));
+            vkco.pop_front();
+        }
+    }
 };
 
 class TableConsumable : public TableBase, public TableEntryPoppable, public RedisSelect {

--- a/pyext/swsscommon.i
+++ b/pyext/swsscommon.i
@@ -79,6 +79,15 @@
     }
 }
 
+%template(FieldValuePair) std::pair<std::string, std::string>;
+%template(FieldValuePairs) std::vector<std::pair<std::string, std::string>>;
+%template(FieldValuePairsList) std::vector<std::vector<std::pair<std::string, std::string>>>;
+%template(FieldValueMap) std::map<std::string, std::string>;
+%template(VectorString) std::vector<std::string>;
+%template(ScanResult) std::pair<int64_t, std::vector<std::string>>;
+%template(GetTableResult) std::map<std::string, std::map<std::string, std::string>>;
+%template(GetConfigResult) std::map<std::string, std::map<std::string, std::map<std::string, std::string>>>;
+
 %pythoncode %{
     def _FieldValueMap__get(self, key, default=None):
         if key in self:
@@ -138,11 +147,16 @@ T castSelectableObj(swss::Selectable *temp)
     %template(hgetall) hgetall<std::map<std::string, std::string>>;
 }
 
+%ignore swss::TableEntryPoppable::pops(std::deque<KeyOpFieldsValuesTuple> &, const std::string &);
 %apply std::vector<std::string>& OUTPUT {std::vector<std::string> &keys};
+%apply std::vector<std::string>& OUTPUT {std::vector<std::string> &ops};
+%apply std::vector<std::vector<std::pair<std::string, std::string>>>& OUTPUT {std::vector<std::vector<std::pair<std::string, std::string>>> &fvss};
 %apply std::vector<std::pair<std::string, std::string>>& OUTPUT {std::vector<std::pair<std::string, std::string>> &ovalues};
 %apply std::string& OUTPUT {std::string &value};
 %include "table.h"
 %clear std::vector<std::string> &keys;
+%clear std::vector<std::string> &ops;
+%clear std::vector<std::vector<std::pair<std::string, std::string>>> &fvss;
 %clear std::vector<std::pair<std::string, std::string>> &values;
 %clear std::string &value;
 

--- a/tests/test_redis_ut.py
+++ b/tests/test_redis_ut.py
@@ -4,7 +4,7 @@ import pytest
 from threading import Thread
 from pympler.tracker import SummaryTracker
 from swsscommon import swsscommon
-from swsscommon.swsscommon import ConfigDBPipeConnector, DBInterface, SonicV2Connector, SonicDBConfig, ConfigDBConnector, SonicDBConfig
+from swsscommon.swsscommon import ConfigDBPipeConnector, DBInterface, SonicV2Connector, SonicDBConfig, ConfigDBConnector, SonicDBConfig, transpose_pops
 import json
 
 existing_file = "./tests/redis_multi_db_ut_config/database_config.json"
@@ -17,15 +17,23 @@ def test_ProducerTable():
     db = swsscommon.DBConnector("APPL_DB", 0, True)
     ps = swsscommon.ProducerTable(db, "abc")
     cs = swsscommon.ConsumerTable(db, "abc")
-    fvs = swsscommon.FieldValuePairs([('a','b')])
+    fvs = swsscommon.FieldValuePairs([('a','b'), ('c', 'd')])
     ps.set("bbb", fvs)
-    entries = cs.pops()
-    assert len(entries) == 1
+    ps.delete("cccc")
+    entries = transpose_pops(cs.pops())
+    assert len(entries) == 2
+
     (key, op, cfvs) = entries[0]
     assert key == "bbb"
     assert op == "SET"
-    assert len(cfvs) == 1
+    assert len(cfvs) == 2
     assert cfvs[0] == ('a', 'b')
+    assert cfvs[1] == ('c', 'd')
+
+    (key, op, cfvs) = entries[1]
+    assert key == "cccc"
+    assert op == "DEL"
+    assert len(cfvs) == 0
 
 def test_ProducerStateTable():
     db = swsscommon.DBConnector("APPL_DB", 0, True)

--- a/tests/test_redis_ut.py
+++ b/tests/test_redis_ut.py
@@ -19,7 +19,9 @@ def test_ProducerTable():
     cs = swsscommon.ConsumerTable(db, "abc")
     fvs = swsscommon.FieldValuePairs([('a','b')])
     ps.set("bbb", fvs)
-    (key, op, cfvs) = cs.pop()
+    entries = cs.pops()
+    assert len(entries) == 1
+    (key, op, cfvs) = entries[0]
     assert key == "bbb"
     assert op == "SET"
     assert len(cfvs) == 1


### PR DESCRIPTION
Due to the SWIG limitation on tuples, it's not straightforward to wrap the C++ `TableEntryPoppable::pops()`. Here I implement a workaround `TableEntryPoppable.pops()` which returns a tuple of 3 arrays, and another helper function to transpose the result to emulate the behavior of C++ `TableEntryPoppable::pops()`.

Tested in unit test.