### PR TITLE
[swss-common] Add MUX Metrics Table

### DIFF
--- a/common/schema.h
+++ b/common/schema.h
@@ -358,6 +358,7 @@ namespace swss {
 #define STATE_MUX_CABLE_TABLE_NAME                  "MUX_CABLE_TABLE"
 #define STATE_HW_MUX_CABLE_TABLE_NAME               "HW_MUX_CABLE_TABLE"
 #define STATE_MUX_LINKMGR_TABLE_NAME                "MUX_LINKMGR_TABLE"
+#define STATE_MUX_METRICS_TABLE_NAME                "MUX_METRICS_TABLE"
 
 #define STATE_SYSTEM_NEIGH_TABLE_NAME               "SYSTEM_NEIGH_TABLE"
 


### PR DESCRIPTION
MUX Metrics table will be used to collect metrics relevant to the
MUX hardware.

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>