### PR TITLE
modify the logger for more flexable change of log level

### DIFF
--- a/common/logger.cpp
+++ b/common/logger.cpp
@@ -141,11 +141,11 @@ void Logger::linkToDb(const std::string &dbName, const PriorityChangeNotify& pri
     linkToDbWithOutput(dbName, prioNotify, defPrio, swssOutputNotify, "SYSLOG");
 }
 
-void Logger::linkToDbNative(const std::string &dbName)
+void Logger::linkToDbNative(const std::string &dbName, const std::string& defPrio)
 {
     auto& logger = getInstance();
 
-    linkToDb(dbName, swssPrioNotify, "NOTICE");
+    linkToDb(dbName, swssPrioNotify, defPrio);
     logger.m_settingThread.reset(new std::thread(&Logger::settingThread, &logger));
 }
 

--- a/common/logger.cpp
+++ b/common/logger.cpp
@@ -141,7 +141,7 @@ void Logger::linkToDb(const std::string &dbName, const PriorityChangeNotify& pri
     linkToDbWithOutput(dbName, prioNotify, defPrio, swssOutputNotify, "SYSLOG");
 }
 
-void Logger::linkToDbNative(const std::string &dbName, const std::string& defPrio)
+void Logger::linkToDbNative(const std::string &dbName, const char * defPrio)
 {
     auto& logger = getInstance();
 

--- a/common/logger.h
+++ b/common/logger.h
@@ -79,7 +79,7 @@ public:
     static void linkToDbWithOutput(const std::string &dbName, const PriorityChangeNotify& prioNotify, const std::string& defPrio, const OutputChangeNotify& outputNotify, const std::string& defOutput);
     static void linkToDb(const std::string &dbName, const PriorityChangeNotify& notify, const std::string& defPrio);
     // Must be called after all linkToDb to start select from DB
-    static void linkToDbNative(const std::string &dbName);
+    static void linkToDbNative(const std::string &dbName, const std::string& defPrio="NOTICE");
     void write(Priority prio, const char *fmt, ...)
 #ifdef __GNUC__
         __attribute__ ((format (printf, 3, 4)))

--- a/common/logger.h
+++ b/common/logger.h
@@ -79,7 +79,7 @@ public:
     static void linkToDbWithOutput(const std::string &dbName, const PriorityChangeNotify& prioNotify, const std::string& defPrio, const OutputChangeNotify& outputNotify, const std::string& defOutput);
     static void linkToDb(const std::string &dbName, const PriorityChangeNotify& notify, const std::string& defPrio);
     // Must be called after all linkToDb to start select from DB
-    static void linkToDbNative(const std::string &dbName, const std::string& defPrio="NOTICE");
+    static void linkToDbNative(const std::string &dbName, const char * defPrio="NOTICE");
     void write(Priority prio, const char *fmt, ...)
 #ifdef __GNUC__
         __attribute__ ((format (printf, 3, 4)))


### PR DESCRIPTION
add extra parameter  to  linkToDbNative , which is default to "NOTICE" to allow  daemons to set their own log level easily.
Example:
 Logger::linkToDbNative("portsyncd"); // by default "NOTICE"

 Logger::linkToDbNative("portsyncd", "INFO"); //explicit "INFO"
