### PR TITLE
Follow hiredis to update timeout

### DIFF
--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -419,11 +419,11 @@ RedisContext::RedisContext(const RedisContext &other)
     const char *unixPath = octx->unix_sock.path;
     if (unixPath)
     {
-        initContext(unixPath, octx->timeout);
+        initContext(unixPath, octx->connect_timeout);
     }
     else
     {
-        initContext(octx->tcp.host, octx->tcp.port, octx->timeout);
+        initContext(octx->tcp.host, octx->tcp.port, octx->connect_timeout);
     }
 }
 


### PR DESCRIPTION
Hiredis updated its hiredis.h file on [27 Jul 2020](https://github.com/redis/hiredis/commit/38b5ae543f5c99eb4ccabbe277770fc6bc81226f) with the time_out name of the redisContext structure connect_timeout. This will cause sonic-swss-common to compile unsuccessfully on a computer with the latest hiredis installed.