### PR TITLE
[configure.ac] Add the option of passing libnl path to configure script

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,9 +14,6 @@ AM_PATH_PYTHON
 AM_PATH_PYTHON3
 
 AC_CHECK_LIB([hiredis], [redisConnect])
-PKG_CHECK_MODULES([LIBNL], [libnl-3.0 libnl-genl-3.0 libnl-route-3.0 libnl-nf-3.0])
-        CFLAGS="$CFLAGS $LIBNL_CFLAGS"
-        LIBS="$LIBS $LIBNL_LIBS"
 
 LDFLAGS="-Wl,--no-undefined $LDFLAGS"
 AC_SUBST([LDFLAGS])
@@ -30,6 +27,35 @@ AC_ARG_ENABLE(debug,
 esac],[debug=false])
 AM_CONDITIONAL(DEBUG, test x$debug = xtrue)
 AM_CONDITIONAL(ARCH64, test `getconf LONG_BIT` = "64")
+
+AC_ARG_WITH(libnl-3.0-inc,
+[  --with-libnl-3.0-inc=DIR
+                           prefix where libnl-3.0 includes are installed],
+[AC_SUBST(CPPFLAGS, "$CPPFLAGS -I${withval}")
+ AC_SUBST(LIBNL_INC_DIR, "${withval}")])
+
+AC_ARG_WITH(libnl-3.0-lib,
+[  --with-libnl-3.0-lib=DIR
+                           prefix where libnl-3.0 libraries are installed],
+[AC_SUBST(LDFLAGS, "$LDFLAGS -L${withval}")
+ AC_SUBST(LIBNL_LIB_DIR, "${withval}")])
+
+AC_ARG_WITH(libnl-3.0-usr-lib,
+[  --with-libnl-3.0-usr-lib=DIR
+                           prefix where libnl-3.0 libraries are installed],
+[AC_SUBST(LDFLAGS, "$LDFLAGS -L${withval}")
+ AC_SUBST(LIBNL_USR_LIB_DIR, "${withval}")])
+
+if test "${with_libnl_3_0_inc+set}" = set; then
+    AC_CHECK_LIB([nl-3], [nl_addr_alloc])
+    AC_CHECK_LIB([nl-genl-3], [nl_socket_get_cb])
+    AC_CHECK_LIB([nl-route-3], [nl_object_alloc])
+    AC_CHECK_LIB([nl-nf-3], [nfnl_connect])
+else
+    PKG_CHECK_MODULES([LIBNL], [libnl-3.0 libnl-genl-3.0 libnl-route-3.0 libnl-nf-3.0])
+            CFLAGS="$CFLAGS $LIBNL_CFLAGS"
+            LIBS="$LIBS $LIBNL_LIBS"
+fi
 
 AC_PATH_PROG(SWIG, [swig3.0])
 


### PR DESCRIPTION
MPLS feature in sonic-buildimage requires a libnl patch to be applied before building libnl. Since this build is not installed in usual locations (/usr/lib/..) LGTM analysis fails. This change gives the option of passing libnl library location to 'configure' script and generate libraries to be linked.

In case the options are not passed, the configure script defaults to earlier behavior where it checks for LIBNL in usual locations.

```
root@samaddik-vm-01:/var/sonic/src/sonic-swss/sonic-swss-common# env | grep LGTM
LGTM_WORKSPACE=/lgtm                                                                                                                                                                                                                                                           
LGTM=/lgtm                                                                                                                                                                                                                                                                     
root@samaddik-vm-01:/var/sonic/src/sonic-swss/sonic-swss-common# ./configure   --with-libnl-3.0-inc=$LGTM_WORKSPACE/usr/include/libnl3 --with-libnl-3.0-lib=$LGTM_WORKSPACE/lib/x86_64-linux-gnu --with-libnl-3.0-usr-lib=$LGTM_WORKSPACE/usr/lib/x86_64-linux-gnu             
checking for a BSD-compatible install... /usr/bin/install -c
checking whether build environment is sane... yes
checking for a thread-safe mkdir -p... /bin/mkdir -p
checking for gawk... gawk                      
checking whether make sets $(MAKE)... yes                                   
.
.
checking for python3 extension module directory... ${exec_prefix}/lib/python3/dist-packages
checking for redisConnect in -lhiredis... yes
checking for nl_addr_alloc in -lnl-3... yes
checking for nl_socket_get_cb in -lnl-genl-3... yes
checking for nl_object_alloc in -lnl-route-3... yes
checking for nfnl_connect in -lnl-nf-3... yes
checking for swig3.0... /usr/bin/swig3.0
checking that generated files are newer than configure... done
configure: creating ./config.status
config.status: creating Makefile
.
.

root@samaddik-vm-01:/var/sonic/src/sonic-swss/sonic-swss-common# find . -name Makefile | xargs grep ^LIBS
./tests/Makefile:LIBS = -lnl-nf-3 -lnl-route-3 -lnl-genl-3 -lnl-3 -lhiredis 
./Makefile:LIBS = -lnl-nf-3 -lnl-route-3 -lnl-genl-3 -lnl-3 -lhiredis 
./pyext/Makefile:LIBS = -lnl-nf-3 -lnl-route-3 -lnl-genl-3 -lnl-3 -lhiredis 
./pyext/py3/Makefile:LIBS = -lnl-nf-3 -lnl-route-3 -lnl-genl-3 -lnl-3 -lhiredis 
./pyext/py2/Makefile:LIBS = -lnl-nf-3 -lnl-route-3 -lnl-genl-3 -lnl-3 -lhiredis 
./common/Makefile:LIBS = -lnl-nf-3 -lnl-route-3 -lnl-genl-3 -lnl-3 -lhiredis 
root@samaddik-vm-01:/var/sonic/src/sonic-swss/sonic-swss-common# 
```

If options are not provided PKG_CHECK_MODULES will check for libnl and fail if not found.

```
configure:12270: checking pkg-config is at least version 0.9.0                                                                                                                                                                                                                                                                                                            
configure:12273: result: yes                                                                                                                                                                                                                                                                                                                                              
configure:12283: checking for LIBNL                                                                                                                                                                                                                                                                                                                                       
configure:12290: $PKG_CONFIG --exists --print-errors "libnl-3.0 libnl-genl-3.0 libnl-route-3.0 libnl-nf-3.0"                                                                                                                                                                                                                                                              
Package libnl-3.0 was not found in the pkg-config search path.                                                                                                                                                                                                                                                                                                            
Perhaps you should add the directory containing `libnl-3.0.pc'                                                                                                                                                                                                                                                                                                            
to the PKG_CONFIG_PATH environment variable                                                                                                                                                                                                                                                                                                                               
No package 'libnl-3.0' found                                                                                                                                                                                                                                                                                                                                              
Package libnl-genl-3.0 was not found in the pkg-config search path.                                                                                                                                                                                                                                                                                                       
Perhaps you should add the directory containing `libnl-genl-3.0.pc'                                                                                                                                                                                                                                                                                                       
to the PKG_CONFIG_PATH environment variable                                                                                                                                                                                                                                                                                                                               
No package 'libnl-genl-3.0' found                                                                                                                                                                                                                                                                                                                                         
Package libnl-route-3.0 was not found in the pkg-config search path.                                                                                                                                                                                                                                                                                                      
Perhaps you should add the directory containing `libnl-route-3.0.pc'                                                                                                                                                                                                                                                                                                      
to the PKG_CONFIG_PATH environment variable                                                                                                                                                                                                                                                                                                                               
No package 'libnl-route-3.0' found                                                                                                                                                                                                                                                                                                                                        
Package libnl-nf-3.0 was not found in the pkg-config search path.                                                                                                                                                                                                                                                                                                         
.
.
.
```