### PR TITLE
[netlink] refill netlink cache when failing to get the link object by name

### DIFF
--- a/common/linkcache.cpp
+++ b/common/linkcache.cpp
@@ -77,5 +77,13 @@ string LinkCache::ifindexToName(int ifindex)
 
 struct rtnl_link* LinkCache::getLinkByName(const char *name)
 {
-    return rtnl_link_get_by_name(m_link_cache, name);
+    struct rtnl_link* link = NULL;
+    link = rtnl_link_get_by_name(m_link_cache, name);
+    if(NULL == link)
+    {
+        /* Trying to refill cache */
+        nl_cache_refill(m_nl_sock ,m_link_cache);
+        link = rtnl_link_get_by_name(m_link_cache, name);
+    }
+    return link;
 }


### PR DESCRIPTION
**Why I did it**
The getLinkByName may fail because of the outdated netlink cache

**How I did it**
Refill the netlink cache when we fail to get link object.

**How to verify it**

**Description for the changelog**


**A picture of a cute animal (not mandatory but encouraged)**
