### PR TITLE
Fix azure pipeline DownloadPipelineArtifact source branch

### DIFF
--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -51,7 +51,7 @@ jobs:
       pipeline: 1
       artifact: sonic-buildimage.vs
       runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/master'
+      runBranch: 'refs/heads/202012'
     displayName: "Download sonic buildimage"
   - script: |
       echo $(Build.DefinitionName).$(Build.BuildNumber)


### PR DESCRIPTION
We should use 202012 branch to download `sonic-buildimage.vs`