### PR TITLE
Added support for setting TTL on a Table managed entry.

### DIFF
--- a/common/rediscommand.cpp
+++ b/common/rediscommand.cpp
@@ -88,6 +88,12 @@ void RedisCommand::formatHDEL(const std::string& key, const std::vector<std::str
     formatArgv(static_cast<int>(args.size()), args.data(), NULL);
 }
 
+/* Format EXPIRE key field command */
+void RedisCommand::formatEXPIRE(const std::string& key, const int32_t& ttl)
+{
+    return format("EXPIRE %s %d", key.c_str(), ttl);
+}
+
 const char *RedisCommand::c_str() const
 {
     return temp;

--- a/common/rediscommand.cpp
+++ b/common/rediscommand.cpp
@@ -94,6 +94,12 @@ void RedisCommand::formatEXPIRE(const std::string& key, const int64_t& ttl)
     return format("EXPIRE %s %lld", key.c_str(), ttl);
 }
 
+/* Format TTL key command */
+void RedisCommand::formatTTL(const std::string& key)
+{
+    return format("TTL %s", key.c_str());
+}
+
 const char *RedisCommand::c_str() const
 {
     return temp;

--- a/common/rediscommand.cpp
+++ b/common/rediscommand.cpp
@@ -89,7 +89,7 @@ void RedisCommand::formatHDEL(const std::string& key, const std::vector<std::str
 }
 
 /* Format EXPIRE key field command */
-void RedisCommand::formatEXPIRE(const std::string& key, const int& ttl)
+void RedisCommand::formatEXPIRE(const std::string& key, const int64_t& ttl)
 {
     return format("EXPIRE %s %d", key.c_str(), ttl);
 }

--- a/common/rediscommand.cpp
+++ b/common/rediscommand.cpp
@@ -91,7 +91,7 @@ void RedisCommand::formatHDEL(const std::string& key, const std::vector<std::str
 /* Format EXPIRE key field command */
 void RedisCommand::formatEXPIRE(const std::string& key, const int64_t& ttl)
 {
-    return format("EXPIRE %s %d", key.c_str(), ttl);
+    return format("EXPIRE %s %lld", key.c_str(), ttl);
 }
 
 const char *RedisCommand::c_str() const

--- a/common/rediscommand.cpp
+++ b/common/rediscommand.cpp
@@ -89,7 +89,7 @@ void RedisCommand::formatHDEL(const std::string& key, const std::vector<std::str
 }
 
 /* Format EXPIRE key field command */
-void RedisCommand::formatEXPIRE(const std::string& key, const int32_t& ttl)
+void RedisCommand::formatEXPIRE(const std::string& key, const int& ttl)
 {
     return format("EXPIRE %s %d", key.c_str(), ttl);
 }

--- a/common/rediscommand.h
+++ b/common/rediscommand.h
@@ -51,7 +51,7 @@ public:
     void formatHDEL(const std::string& key, const std::vector<std::string>& fields);
 
     /* Format EXPIRE key field command */
-    void formatEXPIRE(const std::string& key, const int& ttl);
+    void formatEXPIRE(const std::string& key, const int64_t& ttl);
 
     const char *c_str() const;
 

--- a/common/rediscommand.h
+++ b/common/rediscommand.h
@@ -51,7 +51,7 @@ public:
     void formatHDEL(const std::string& key, const std::vector<std::string>& fields);
 
     /* Format EXPIRE key field command */
-    void formatEXPIRE(const std::string& key, const int32_t& ttl);
+    void formatEXPIRE(const std::string& key, const int& ttl);
 
     const char *c_str() const;
 

--- a/common/rediscommand.h
+++ b/common/rediscommand.h
@@ -50,6 +50,9 @@ public:
     /* Format HDEL key multiple fields command */
     void formatHDEL(const std::string& key, const std::vector<std::string>& fields);
 
+    /* Format EXPIRE key field command */
+    void formatEXPIRE(const std::string& key, const int32_t& ttl);
+
     const char *c_str() const;
 
     size_t length() const;

--- a/common/rediscommand.h
+++ b/common/rediscommand.h
@@ -50,8 +50,11 @@ public:
     /* Format HDEL key multiple fields command */
     void formatHDEL(const std::string& key, const std::vector<std::string>& fields);
 
-    /* Format EXPIRE key field command */
+    /* Format EXPIRE key ttl command */
     void formatEXPIRE(const std::string& key, const int64_t& ttl);
+
+    /* Format TTL key command */
+    void formatTTL(const std::string& key);
 
     const char *c_str() const;
 

--- a/common/table.cpp
+++ b/common/table.cpp
@@ -138,6 +138,36 @@ void Table::set(const string &key, const vector<FieldValueTuple> &values,
     }
 }
 
+void Table::set(const string &key, const vector<FieldValueTuple> &values,
+                const int32_t &ttl, const string& /*op*/, const string& /*prefix*/)
+{
+    if (values.size() == 0)
+        return;
+
+    RedisCommand cmd;
+    cmd.formatHMSET(getKeyName(key), values.begin(), values.end());
+
+    m_pipe->push(cmd, REDIS_REPLY_STATUS);
+
+    if (!m_buffered)
+    {
+        m_pipe->flush();
+    }
+
+    if (ttl != DEFAULT_DB_TTL)
+    {
+      // Configure the expire time for the entry that was just added
+      cmd.formatEXPIRE(getKeyName(key), ttl);
+
+      m_pipe->push(cmd, REDIS_REPLY_INTEGER);
+
+      if (!m_buffered)
+      {
+          m_pipe->flush();
+      }
+    }
+}
+
 void Table::del(const string &key, const string& /* op */, const string& /*prefix*/)
 {
     RedisCommand del_key;

--- a/common/table.cpp
+++ b/common/table.cpp
@@ -132,10 +132,6 @@ void Table::set(const string &key, const vector<FieldValueTuple> &values,
     cmd.formatHMSET(getKeyName(key), values.begin(), values.end());
 
     m_pipe->push(cmd, REDIS_REPLY_STATUS);
-    if (!m_buffered)
-    {
-        m_pipe->flush();
-    }
 
     if (ttl != DEFAULT_DB_TTL)
     {
@@ -143,11 +139,10 @@ void Table::set(const string &key, const vector<FieldValueTuple> &values,
       cmd.formatEXPIRE(getKeyName(key), ttl);
 
       m_pipe->push(cmd, REDIS_REPLY_INTEGER);
-
-      if (!m_buffered)
-      {
-          m_pipe->flush();
-      }
+    }
+    if (!m_buffered)
+    {
+        m_pipe->flush();
     }
 }
 

--- a/common/table.cpp
+++ b/common/table.cpp
@@ -123,7 +123,7 @@ void Table::hset(const string &key, const std::string &field, const std::string 
 }
 
 void Table::set(const string &key, const vector<FieldValueTuple> &values,
-                const int &ttl, const string& /*op*/, const string& /*prefix*/)
+                const string& /*op*/, const string& /*prefix*/, const int64_t &ttl)
 {
     if (values.size() == 0)
         return;

--- a/common/table.cpp
+++ b/common/table.cpp
@@ -142,27 +142,20 @@ void Table::set(const string &key, const vector<FieldValueTuple> &values,
 //       to existing set() command once sonic-swss's mock_table.cpp and other
 //       dependencies can be updated to use the extended new default set())
 void Table::set(const string &key, const vector<FieldValueTuple> &values,
-                const int64_t &ttl, const string& /*op*/, const string& /*prefix*/)
+                const string &op, const string &prefix, const int64_t &ttl)
 {
-    if (values.size() == 0)
-        return;
-
-    RedisCommand cmd;
-    // @Qi Luo not directly reusing default set() here as it will require we
-    // do a 2nd ->flush() call again.
-    cmd.formatHMSET(getKeyName(key), values.begin(), values.end());
-
-    m_pipe->push(cmd, REDIS_REPLY_STATUS);
-
+    set(key, values, op, prefix);
+    
     if (ttl != DEFAULT_DB_TTL)
     {
         // Configure the expire time for the entry that was just added
+        RedisCommand cmd;
         cmd.formatEXPIRE(getKeyName(key), ttl);
         m_pipe->push(cmd, REDIS_REPLY_INTEGER);
-    }
-    if (!m_buffered)
-    {
-        m_pipe->flush();
+        if (!m_buffered)
+        {
+            m_pipe->flush();
+        }
     }
 }
 

--- a/common/table.cpp
+++ b/common/table.cpp
@@ -123,7 +123,7 @@ void Table::hset(const string &key, const std::string &field, const std::string 
 }
 
 void Table::set(const string &key, const vector<FieldValueTuple> &values,
-                const string& /*op*/, const string& /*prefix*/)
+                const int &ttl, const string& /*op*/, const string& /*prefix*/)
 {
     if (values.size() == 0)
         return;
@@ -132,23 +132,6 @@ void Table::set(const string &key, const vector<FieldValueTuple> &values,
     cmd.formatHMSET(getKeyName(key), values.begin(), values.end());
 
     m_pipe->push(cmd, REDIS_REPLY_STATUS);
-    if (!m_buffered)
-    {
-        m_pipe->flush();
-    }
-}
-
-void Table::set(const string &key, const vector<FieldValueTuple> &values,
-                const int32_t &ttl, const string& /*op*/, const string& /*prefix*/)
-{
-    if (values.size() == 0)
-        return;
-
-    RedisCommand cmd;
-    cmd.formatHMSET(getKeyName(key), values.begin(), values.end());
-
-    m_pipe->push(cmd, REDIS_REPLY_STATUS);
-
     if (!m_buffered)
     {
         m_pipe->flush();

--- a/common/table.h
+++ b/common/table.h
@@ -181,10 +181,10 @@ public:
 
     /* Set an entry in the DB directly and configure ttl for it (op not in use) */
     virtual void set(const std::string &key,
-                     const std::vector<FieldValueTuple> &values,
-                     const int64_t &ttl, 
-                     const std::string &op = "",
-                     const std::string &prefix = EMPTY_PREFIX);   
+                     const std::vector<FieldValueTuple> &values, 
+                     const std::string &op,
+                     const std::string &prefix,
+                     const int64_t &ttl);   
 
     /* Delete an entry in the table */
     virtual void del(const std::string &key,

--- a/common/table.h
+++ b/common/table.h
@@ -176,9 +176,9 @@ public:
     /* Set an entry in the DB directly and configure its TTL, if provided (op not in use) */
     virtual void set(const std::string &key,
                      const std::vector<FieldValueTuple> &values,
-                     const int &ttl = DEFAULT_DB_TTL,
                      const std::string &op = "",
-                     const std::string &prefix = EMPTY_PREFIX);
+                     const std::string &prefix = EMPTY_PREFIX,
+                     const int64_t &ttl = DEFAULT_DB_TTL);
 
     /* Delete an entry in the table */
     virtual void del(const std::string &key,

--- a/common/table.h
+++ b/common/table.h
@@ -170,11 +170,21 @@ public:
     Table(RedisPipeline *pipeline, const std::string &tableName, bool buffered);
     ~Table() override;
 
+    /* The default time to live for a DB entry is infinite */
+    static constexpr int DEFAULT_DB_TTL = -1;
+
     /* Set an entry in the DB directly (op not in use) */
     virtual void set(const std::string &key,
                      const std::vector<FieldValueTuple> &values,
                      const std::string &op = "",
                      const std::string &prefix = EMPTY_PREFIX);
+    /* Set an entry in the DB directly and configure ttl for it (op not in use) */
+    virtual void set(const std::string &key,
+                     const std::vector<FieldValueTuple> &values,
+                     const int32_t &ttl, 
+                     const std::string &op = "",
+                     const std::string &prefix = EMPTY_PREFIX);    
+
     /* Delete an entry in the table */
     virtual void del(const std::string &key,
                      const std::string &op = "",

--- a/common/table.h
+++ b/common/table.h
@@ -164,26 +164,21 @@ public:
     void getContent(std::vector<KeyOpFieldsValuesTuple> &tuples);
 };
 
+/* The default time to live for a DB entry is infinite */
+static constexpr int DEFAULT_DB_TTL = -1;
+
 class Table : public TableBase, public TableEntryEnumerable {
 public:
     Table(const DBConnector *db, const std::string &tableName);
     Table(RedisPipeline *pipeline, const std::string &tableName, bool buffered);
     ~Table() override;
 
-    /* The default time to live for a DB entry is infinite */
-    static constexpr int DEFAULT_DB_TTL = -1;
-
-    /* Set an entry in the DB directly (op not in use) */
+    /* Set an entry in the DB directly and configure its TTL, if provided (op not in use) */
     virtual void set(const std::string &key,
                      const std::vector<FieldValueTuple> &values,
+                     const int &ttl = DEFAULT_DB_TTL,
                      const std::string &op = "",
                      const std::string &prefix = EMPTY_PREFIX);
-    /* Set an entry in the DB directly and configure ttl for it (op not in use) */
-    virtual void set(const std::string &key,
-                     const std::vector<FieldValueTuple> &values,
-                     const int32_t &ttl, 
-                     const std::string &op = "",
-                     const std::string &prefix = EMPTY_PREFIX);    
 
     /* Delete an entry in the table */
     virtual void del(const std::string &key,

--- a/common/table.h
+++ b/common/table.h
@@ -173,17 +173,25 @@ public:
     Table(RedisPipeline *pipeline, const std::string &tableName, bool buffered);
     ~Table() override;
 
-    /* Set an entry in the DB directly and configure its TTL, if provided (op not in use) */
+    /* Set an entry in the DB directly (op not in use) */
     virtual void set(const std::string &key,
                      const std::vector<FieldValueTuple> &values,
                      const std::string &op = "",
-                     const std::string &prefix = EMPTY_PREFIX,
-                     const int64_t &ttl = DEFAULT_DB_TTL);
+                     const std::string &prefix = EMPTY_PREFIX);
+
+    /* Set an entry in the DB directly and configure ttl for it (op not in use) */
+    virtual void set(const std::string &key,
+                     const std::vector<FieldValueTuple> &values,
+                     const int64_t &ttl, 
+                     const std::string &op = "",
+                     const std::string &prefix = EMPTY_PREFIX);   
 
     /* Delete an entry in the table */
     virtual void del(const std::string &key,
                      const std::string &op = "",
                      const std::string &prefix = EMPTY_PREFIX);
+    /* Get the configured ttl value for key */
+    bool ttl(const std::string &key, int64_t &reply_value);
 
 #ifdef SWIG
     // SWIG interface file (.i) globally rename map C++ `del` to python `delete`,

--- a/common/table.h
+++ b/common/table.h
@@ -165,7 +165,7 @@ public:
 };
 
 /* The default time to live for a DB entry is infinite */
-static constexpr int DEFAULT_DB_TTL = -1;
+static constexpr int64_t DEFAULT_DB_TTL = -1;
 
 class Table : public TableBase, public TableEntryEnumerable {
 public:

--- a/tests/redis_ut.cpp
+++ b/tests/redis_ut.cpp
@@ -735,8 +735,8 @@ TEST(Table, ttl_test)
     cout << "Set key [a] field_1:1 field_2:2 field_3:3 infinite ttl" << endl;
     cout << "Set key [b] field_1:1 field_2:2 field_3:3 200 seconds ttl" << endl;
 
-    t.set(key_1, values, initial_a_ttl);
-    t.set(key_2, values, initial_b_ttl);
+    t.set(key_1, values, "", "", initial_a_ttl);
+    t.set(key_2, values, "", "", initial_b_ttl);
     t.flush();
  
     cout << "- Step 2. GET_TTL_VALUES" << endl;


### PR DESCRIPTION
[table.h/rediscommand.h] 
* Updated table.h with a new set() routine capable of also setting TTL on an entry.
* Updated rediscommand.h with the EXPIRE command

 Signed-off-by: Cosmin Jinga <v-cjinga@microsoft.com>