### PR TITLE
[gearbox] Update GB_ASIC_DB separator to ':'

### DIFF
--- a/common/database_config.json
+++ b/common/database_config.json
@@ -64,17 +64,17 @@
         },
         "GB_ASIC_DB" : {
             "id" : 9,
-            "separator": "|",
+            "separator": ":",
             "instance" : "redis"
         },
         "GB_COUNTERS_DB" : {
             "id" : 10,
-            "separator": "|",
+            "separator": ":",
             "instance" : "redis"
         },
         "GB_FLEX_COUNTER_DB" : {
             "id" : 11,
-            "separator": "|",
+            "separator": ":",
             "instance" : "redis"
         },
         "CHASSIS_APP_DB" : {


### PR DESCRIPTION
Since ASIC_DB, as well its COUNTER_DB, FLEX_COUNTER_DB always use separator ':', GB_ASIC_DB should use same. We use same sairedis interface/logic to update ASIC_DB and GB_ASIC_DB.