### PR TITLE
[schema] Rename CBF config tables

### DIFF
--- a/common/schema.h
+++ b/common/schema.h
@@ -261,6 +261,8 @@ namespace swss {
 #define CFG_WRED_PROFILE_TABLE_NAME                 "WRED_PROFILE"
 #define CFG_QUEUE_TABLE_NAME                        "QUEUE"
 #define CFG_DOT1P_TO_TC_MAP_TABLE_NAME              "DOT1P_TO_TC_MAP"
+#define CFG_DSCP_TO_FC_MAP_TABLE_NAME               "DSCP_TO_FC_MAP"
+#define CFG_EXP_TO_FC_MAP_TABLE_NAME                "EXP_TO_FC_MAP"
 
 #define CFG_BUFFER_POOL_TABLE_NAME                  "BUFFER_POOL"
 #define CFG_BUFFER_PROFILE_TABLE_NAME               "BUFFER_PROFILE"
@@ -340,9 +342,6 @@ namespace swss {
 #define CFG_CHASSIS_MODULE_TABLE                    "CHASSIS_MODULE"
 
 #define CFG_DHCP_TABLE                              "DHCP_RELAY"
-
-#define CFG_DSCP_TO_FC_MAP_TABLE_NAME               "DSCP_TO_FC_MAP_TABLE"
-#define CFG_EXP_TO_FC_MAP_TABLE_NAME                "EXP_TO_FC_MAP_TABLE"
 
 /***** STATE DATABASE *****/
 


### PR DESCRIPTION
* Renamed DSCP_TO_FC_MAP and EXP_TO_FC_MAP tables to be in line with the
other QoS map tables

Signed-off-by: Alexandru Banu <v-albanu@microsoft.com>