### PR TITLE
Add default route table name

### DIFF
--- a/common/schema.h
+++ b/common/schema.h
@@ -414,7 +414,8 @@ namespace swss {
 #define STATE_BUFFER_PROFILE_TABLE_NAME             "BUFFER_PROFILE_TABLE"
 #define STATE_DHCPv6_COUNTER_TABLE_NAME             "DHCPv6_COUNTER_TABLE"
 
-#define STATE_BFD_SESSION_TABLE                     "BFD_SESSION_TABLE"
+#define STATE_BFD_SESSION_TABLE_NAME                "BFD_SESSION_TABLE"
+#define STATE_DEFAULT_ROUTE_TABLE_NAME              "DEFAULT_ROUTE_TABLE"
 
 /***** MISC *****/
 


### PR DESCRIPTION
1. Add default route table name to State DB
2. Fix to follow the naming convention for BFD