### PR TITLE
Exclude *.a files from python deb packages

### DIFF
--- a/debian/python-swsscommon.install
+++ b/debian/python-swsscommon.install
@@ -1,1 +1,3 @@
-usr/lib/python2.7/dist-packages/swsscommon/*
+usr/lib/python2.7/dist-packages/swsscommon/*.py*
+usr/lib/python2.7/dist-packages/swsscommon/*.so*
+usr/lib/python2.7/dist-packages/swsscommon/*.la*

--- a/debian/python3-swsscommon.install
+++ b/debian/python3-swsscommon.install
@@ -1,1 +1,3 @@
-usr/lib/python3/dist-packages/swsscommon/*
+usr/lib/python3/dist-packages/swsscommon/*.py*
+usr/lib/python3/dist-packages/swsscommon/*.so*
+usr/lib/python3/dist-packages/swsscommon/*.la*


### PR DESCRIPTION
The file `_swsscommon.a` in the python deb packages takes > 33 MB, and it is not used.
Remove it to save disk space.