### PR TITLE
Use build profiles instead of distro version for Python 2 binding build

### DIFF
--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -64,7 +64,7 @@ jobs:
   - script: |
       set -ex
       ./autogen.sh
-      fakeroot debian/rules DEB_CONFIGURE_EXTRA_FLAGS='--enable-code-coverage' CFLAGS="" CXXFLAGS="--coverage -fprofile-abs-path" LDFLAGS="--coverage -fprofile-abs-path" DEB_BUILD_PROFILES=python2 binary && cp ../*.deb .
+      fakeroot debian/rules DEB_CONFIGURE_EXTRA_FLAGS='--enable-code-coverage' CFLAGS="" CXXFLAGS="--coverage -fprofile-abs-path" LDFLAGS="--coverage -fprofile-abs-path" binary && cp ../*.deb .
     displayName: "Compile sonic swss common with coverage enabled"
   - ${{ if eq(parameters.run_unit_test, true) }}:
     - script: |

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -64,7 +64,7 @@ jobs:
   - script: |
       set -ex
       ./autogen.sh
-      fakeroot debian/rules DEB_CONFIGURE_EXTRA_FLAGS='--enable-code-coverage' CFLAGS="" CXXFLAGS="--coverage -fprofile-abs-path" LDFLAGS="--coverage -fprofile-abs-path" binary && cp ../*.deb .
+      fakeroot debian/rules DEB_CONFIGURE_EXTRA_FLAGS='--enable-code-coverage' CFLAGS="" CXXFLAGS="--coverage -fprofile-abs-path" LDFLAGS="--coverage -fprofile-abs-path" DEB_BUILD_PROFILES=python2 binary && cp ../*.deb .
     displayName: "Compile sonic swss common with coverage enabled"
   - ${{ if eq(parameters.run_unit_test, true) }}:
     - script: |

--- a/debian/control
+++ b/debian/control
@@ -25,6 +25,7 @@ Description: This package contains development files for Switch State Service.
 
 Package: python-swsscommon
 Architecture: any
+Build-Profiles: <python2>
 Depends: ${shlibs:Depends}, ${misc:Pre-Depends}
 Section: libs
 Description: This package contains Switch State Service common Python2 library.

--- a/debian/control
+++ b/debian/control
@@ -25,7 +25,7 @@ Description: This package contains development files for Switch State Service.
 
 Package: python-swsscommon
 Architecture: any
-Build-Profiles: <python2>
+Build-Profiles: <!nopython2>
 Depends: ${shlibs:Depends}, ${misc:Pre-Depends}
 Section: libs
 Description: This package contains Switch State Service common Python2 library.

--- a/debian/python-swsscommon.dirs
+++ b/debian/python-swsscommon.dirs
@@ -1,0 +1,1 @@
+usr/lib/python2.7

--- a/debian/python-swsscommon.install
+++ b/debian/python-swsscommon.install
@@ -1,0 +1,1 @@
+usr/lib/python2.7/dist-packages/swsscommon/*

--- a/debian/rules
+++ b/debian/rules
@@ -23,9 +23,9 @@ DOPACKAGES = $(shell dh_listpackages)
 # For Debian jessie, stretch, and buster, and Ubuntu bionic and focal, build
 # Python 2 bindings. This is controlled by the build profile being used.
 ifneq (,$(filter python-swsscommon,$(DOPACKAGES)))
-DEB_CONFIGURE_EXTRA_FLAGS += --enable-python2
+CONFIGURE_ARGS += --enable-python2
 else
-DEB_CONFIGURE_EXTRA_FLAGS += --disable-python2
+CONFIGURE_ARGS += --disable-python2
 endif
 
 # main packaging script based on dh7 syntax
@@ -35,7 +35,7 @@ endif
 # dh_make generated override targets
 # This is example for Cmake (See https://bugs.debian.org/641051 )
 override_dh_auto_configure:
-	dh_auto_configure -- $(DEB_CONFIGURE_EXTRA_FLAGS)
+	dh_auto_configure -- $(CONFIGURE_ARGS) $(DEB_CONFIGURE_EXTRA_FLAGS)
 #	-DCMAKE_LIBRARY_PATH=$(DEB_HOST_MULTIARCH)
 
 override_dh_clean:

--- a/debian/rules
+++ b/debian/rules
@@ -18,12 +18,14 @@ include /usr/share/dpkg/default.mk
 
 DEBIAN_DIST_CODENAME := $(shell lsb_release -sc | sed -e 's/\#/ /g')
 
+DOPACKAGES = $(shell dh_listpackages)
+
 # For Debian jessie, stretch, and buster, and Ubuntu bionic and focal, build
-# Python 2 bindings.
-ifneq (,$(filter jessie stretch buster bionic focal,$(DEBIAN_DIST_CODENAME)))
-CONFIGURE_ARGS = --enable-python2
+# Python 2 bindings. This is controlled by the build profile being used.
+ifneq (,$(filter python-swsscommon,$(DOPACKAGES)))
+DEB_CONFIGURE_EXTRA_FLAGS += --enable-python2
 else
-CONFIGURE_ARGS = --disable-python2
+DEB_CONFIGURE_EXTRA_FLAGS += --disable-python2
 endif
 
 # main packaging script based on dh7 syntax
@@ -35,16 +37,6 @@ endif
 override_dh_auto_configure:
 	dh_auto_configure -- $(DEB_CONFIGURE_EXTRA_FLAGS)
 #	-DCMAKE_LIBRARY_PATH=$(DEB_HOST_MULTIARCH)
-
-override_dh_auto_configure:
-	dh_auto_configure -- $(CONFIGURE_ARGS)
-
-override_dh_auto_install:
-	dh_auto_install
-	if [ -d debian/tmp/usr/lib/python2.7/dist-packages/swsscommon ]; then \
-		dh_installdirs --package=python-swsscommon /usr/lib/python2.7/dist-packages/swsscommon/ ; \
-		cp -a debian/tmp/usr/lib/python2.7/dist-packages/swsscommon/* debian/python-swsscommon/usr/lib/python2.7/dist-packages/swsscommon/ ; \
-	fi
 
 override_dh_clean:
 	dh_clean


### PR DESCRIPTION
Instead of using the distro version to determine if the Python 2
bindings should be built, use deb profiles instead to specify if they
should be built or not. The main reason of this is that normal .install
and .dirs files can be used for both the Python 2 and Python 3 bindings,
instead of .install/.dir files for Python 3 and debian/rules for Python
2.

More details on build profiles are [here](https://wiki.debian.org/BuildProfileSpec).

Signed-off-by: Saikrishna Arcot <sarcot@microsoft.com>