### PR TITLE
[VS test] Increase test timeout

### DIFF
--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -1,7 +1,7 @@
 parameters:
 - name: timeout
   type: number
-  default: 180
+  default: 240
 
 - name: log_artifact_name
   type: string


### PR DESCRIPTION
Signed-off-by: Sudharsan Dhamal Gopalarathnam <sudharsand@nvidia.com>

Increase test timeout to 240mts from 180mts
Started observing the following error:

##[error]The job running on agent Azure Pipelines 5 ran longer than the maximum time of 180 minutes. For more information, see https://go.microsoft.com/fwlink/?linkid=2077134

Same as Azure/sonic-swss#1988