### PR TITLE
Update README for gmock

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ Install build dependencies:
 
     sudo apt-get install make libtool m4 autoconf dh-exec debhelper cmake pkg-config \
                          libhiredis-dev libnl-3-dev libnl-genl-3-dev libnl-route-3-dev \
-                         libnl-nf-3-dev swig3.0 libpython2.7-dev libpython3-dev libgtest-dev \
-                         libboost-dev
+                         libnl-nf-3-dev swig3.0 libpython2.7-dev libpython3-dev \
+                         libgtest-dev libgmock-dev libboost-dev
 
-Install Google Test DEB package:
+Build and Install Google Test and Mock from DEB source packages:
 
     cd /usr/src/gtest && sudo cmake . && sudo make
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ stages:
         sudo apt-get update
         sudo apt-get install -y make libtool m4 autoconf dh-exec debhelper cmake pkg-config \
                          libhiredis-dev libnl-3-dev libnl-genl-3-dev libnl-route-3-dev libnl-nf-3-dev swig3.0 \
-                         libpython2.7-dev libgtest-dev libboost-dev libboost1.71-dev
+                         libpython2.7-dev libboost-dev libboost1.71-dev
         sudo apt-get install -y sudo
         sudo apt-get install -y redis-server redis-tools
         sudo apt-get install -y python3-pip


### PR DESCRIPTION
Updating the README to reflect the new dependency. Also, removing duplicate libgtest-dev from the azure-pipeline script.