### PR TITLE
[202012][schema] Add vnet route tunnel and advertise network tables for state_db

### DIFF
--- a/common/schema.h
+++ b/common/schema.h
@@ -377,6 +377,9 @@ namespace swss {
 
 #define STATE_BFD_SESSION_TABLE_NAME                "BFD_SESSION_TABLE"
 #define STATE_ROUTE_TABLE_NAME                      "ROUTE_TABLE"
+#define STATE_VNET_RT_TUNNEL_TABLE_NAME             "VNET_ROUTE_TUNNEL_TABLE"
+#define STATE_ADVERTISE_NETWORK_TABLE_NAME          "ADVERTISE_NETWORK_TABLE"
+
 /***** MISC *****/
 
 #define IPV4_NAME "IPv4"


### PR DESCRIPTION
Taking the changes in https://github.com/Azure/sonic-swss-common/pull/560 to 202012 branch

Add vnet route tunnel and advertise network tables for state_db in swss-common schema