### PR TITLE
Include database ID in channel name

### DIFF
--- a/common/table.h
+++ b/common/table.h
@@ -77,7 +77,8 @@ public:
         return m_tableSeparator;
     }
 
-    std::string getChannelName() { return m_tableName + "_CHANNEL"; }
+    std::string getChannelName() { return m_tableName + "_CHANNEL" +
+        + "@" + std::to_string(dbId); }
 private:
     static const std::string TABLE_NAME_SEPARATOR_COLON;
     static const std::string TABLE_NAME_SEPARATOR_VBAR;


### PR DESCRIPTION
Include database ID in channel name. Sometime one same table name can be used in different databases, then only table name can not identify its corresponding channel.