### PR TITLE
Change sonic-buildimage.vs artifact source from CI build to official build

### DIFF
--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -48,7 +48,7 @@ jobs:
     inputs:
       source: specific
       project: build
-      pipeline: 1
+      pipeline: 142
       artifact: sonic-buildimage.vs
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/202012'


### PR DESCRIPTION
Change reference from CI build to official build. This PR will unblock the PR checker of swss-common in 202012 branch.