### PR TITLE
Revert "Revert "[TableBase] Make channel name from both table name and databa…"

### DIFF
--- a/common/consumerstatetable.cpp
+++ b/common/consumerstatetable.cpp
@@ -24,7 +24,7 @@ ConsumerStateTable::ConsumerStateTable(DBConnector *db, const std::string &table
         watch.checkStatusOK();
         multi();
         enqueue(std::string("SCARD ") + getKeySetName(), REDIS_REPLY_INTEGER);
-        subscribe(m_db, getChannelName());
+        subscribe(m_db, getChannelName(m_db->getDbId()));
         bool succ = exec();
         if (succ) break;
     }

--- a/common/consumertable.cpp
+++ b/common/consumertable.cpp
@@ -28,7 +28,7 @@ ConsumerTable::ConsumerTable(DBConnector *db, const string &tableName, int popBa
         watch.checkStatusOK();
         multi();
         enqueue(string("LLEN ") + getKeyValueOpQueueTableName(), REDIS_REPLY_INTEGER);
-        subscribe(m_db, getChannelName());
+        subscribe(m_db, getChannelName(m_db->getDbId()));
         enqueue(string("LLEN ") + getKeyValueOpQueueTableName(), REDIS_REPLY_INTEGER);
         bool succ = exec();
         if (succ) break;

--- a/common/producerstatetable.cpp
+++ b/common/producerstatetable.cpp
@@ -92,7 +92,7 @@ void ProducerStateTable::set(const string &key, const vector<FieldValueTuple> &v
     args.emplace_back("EVALSHA");
     args.emplace_back(m_shaSet);
     args.emplace_back(to_string(values.size() + 2));
-    args.emplace_back(getChannelName());
+    args.emplace_back(getChannelName(m_pipe->getDbId()));
     args.emplace_back(getKeySetName());
 
     args.insert(args.end(), values.size(), getStateHashPrefix() + getKeyName(key));
@@ -133,7 +133,7 @@ void ProducerStateTable::del(const string &key, const string &op /*= DEL_COMMAND
     args.emplace_back("EVALSHA");
     args.emplace_back(m_shaDel);
     args.emplace_back("4");
-    args.emplace_back(getChannelName());
+    args.emplace_back(getChannelName(m_pipe->getDbId()));
     args.emplace_back(getKeySetName());
     args.emplace_back(getStateHashPrefix() + getKeyName(key));
     args.emplace_back(getDelKeySetName());
@@ -307,7 +307,7 @@ void ProducerStateTable::apply_temp_view()
     args.emplace_back("EVALSHA");
     args.emplace_back(m_shaApplyView);
     args.emplace_back(to_string(m_tempViewState.size() + 3));
-    args.emplace_back(getChannelName());
+    args.emplace_back(getChannelName(m_pipe->getDbId()));
     args.emplace_back(getKeySetName());
     args.emplace_back(getDelKeySetName());
 

--- a/common/producertable.cpp
+++ b/common/producertable.cpp
@@ -73,7 +73,7 @@ void ProducerTable::enqueueDbChange(const string &key, const string &value, cons
         "EVALSHA %s 2 %s %s %s %s %s %s",
         m_shaEnque.c_str(),
         getKeyValueOpQueueTableName().c_str(),
-        getChannelName().c_str(),
+        getChannelName(m_pipe->getDbId()).c_str(),
         key.c_str(),
         value.c_str(),
         op.c_str(),

--- a/common/table.h
+++ b/common/table.h
@@ -78,6 +78,18 @@ public:
     }
 
     std::string getChannelName() { return m_tableName + "_CHANNEL"; }
+
+    /* Return tagged channel name */
+    std::string getChannelName(const std::string &tag)
+    {
+        return m_tableName + "_CHANNEL" + "@" + tag;
+    }
+
+    /* Return tagged channel name, most likely tag number could be dbId */
+    std::string getChannelName(int tag)
+    {
+        return getChannelName(std::to_string(tag));
+    }
 private:
     static const std::string TABLE_NAME_SEPARATOR_COLON;
     static const std::string TABLE_NAME_SEPARATOR_VBAR;


### PR DESCRIPTION
Reverts Azure/sonic-swss-common#574

The real cause is fixed at https://github.com/Azure/sonic-sairedis/pull/995. Continue to commit bd4d0ce again.