### PR TITLE
Add link manager cable and config table for active-active dualtor mode

### DIFF
--- a/common/schema.h
+++ b/common/schema.h
@@ -354,6 +354,8 @@ namespace swss {
 
 #define CFG_MUX_CABLE_TABLE_NAME                    "MUX_CABLE"
 #define CFG_MUX_LINKMGR_TABLE_NAME                  "MUX_LINKMGR"
+#define CFG_LINKMGR_CABLE_TABLE_NAME                "LINKMGR_CABLE"
+#define CFG_LINKMGR_TABLE_NAME                      "LINK_MANAGER"
 
 #define CFG_PEER_SWITCH_TABLE_NAME                  "PEER_SWITCH"
 


### PR DESCRIPTION
To further support active-active dualtor mode, add the following link manager related table names:
* `LINKMGR_CABLE`: stores per-port server details only for active-active dualtor mode
* `LINK_MANAGER`: stores link manager related configs, this table will replace `MUX_LINKMGR`.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>