### PR TITLE
Improve SonicDBConfig initialize multiple time with same file will throw exception issue.

### DIFF
--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -80,6 +80,12 @@ void SonicDBConfig::initializeGlobalConfig(const string &file)
 
     if (m_global_init)
     {
+        if ((*m_global_config_file).compare(file) == 0)
+        {
+            SWSS_LOG_INFO("SonicDBConfig Global config is already initialized with %s", m_global_config_file);
+            return;
+        }
+
         SWSS_LOG_ERROR("SonicDBConfig Global config is already initialized");
         return;
     }
@@ -131,6 +137,7 @@ void SonicDBConfig::initializeGlobalConfig(const string &file)
                 {
                     // Make regular init also done
                     m_init = true;
+                    m_config_file = std::make_shared<std::string>(file);
                 }
 
                 inst_entry.clear();
@@ -159,6 +166,7 @@ void SonicDBConfig::initializeGlobalConfig(const string &file)
 
     // Set it as the global config file is already parsed and init done.
     m_global_init = true;
+    m_global_config_file = std::make_shared<std::string>(file);
 }
 
 void SonicDBConfig::initialize(const string &file)
@@ -172,6 +180,12 @@ void SonicDBConfig::initialize(const string &file)
 
     if (m_init)
     {
+        if ((*m_config_file).compare(file) == 0)
+        {
+            SWSS_LOG_INFO("SonicDBConfig already initialized with %s", m_config_file);
+            return;
+        }
+
         SWSS_LOG_ERROR("SonicDBConfig already initialized");
         throw runtime_error("SonicDBConfig already initialized");
     }
@@ -183,6 +197,7 @@ void SonicDBConfig::initialize(const string &file)
 
     // Set it as the config file is already parsed and init done.
     m_init = true;
+    m_config_file = std::make_shared<std::string>(file);
 }
 
 void SonicDBConfig::validateNamespace(const string &netns)
@@ -399,6 +414,8 @@ unordered_map<string, unordered_map<string, SonicDBInfo>> SonicDBConfig::m_db_in
 unordered_map<string, unordered_map<int, string>> SonicDBConfig::m_db_separator;
 bool SonicDBConfig::m_init = false;
 bool SonicDBConfig::m_global_init = false;
+std::shared_ptr<std::string> SonicDBConfig::m_config_file = std::make_shared<std::string>(EMPTY_CONFIG_FILE);
+std::shared_ptr<std::string> SonicDBConfig::m_global_config_file = std::make_shared<std::string>(EMPTY_CONFIG_FILE);
 
 constexpr const char *RedisContext::DEFAULT_UNIXSOCKET;
 

--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -82,11 +82,11 @@ void SonicDBConfig::initializeGlobalConfig(const string &file)
     {
         if ((*m_global_config_file).compare(file) == 0)
         {
-            SWSS_LOG_INFO("SonicDBConfig Global config is already initialized with %s", m_global_config_file);
+            SWSS_LOG_INFO("SonicDBConfig Global config is already initialized with same file %s", m_global_config_file);
             return;
         }
 
-        SWSS_LOG_ERROR("SonicDBConfig Global config is already initialized");
+        SWSS_LOG_ERROR(SonicDBConfig Global config is already initialized with another file %s", m_global_config_file);
         return;
     }
 
@@ -182,11 +182,11 @@ void SonicDBConfig::initialize(const string &file)
     {
         if ((*m_config_file).compare(file) == 0)
         {
-            SWSS_LOG_INFO("SonicDBConfig already initialized with %s", m_config_file);
+            SWSS_LOG_INFO("SonicDBConfig already initialized with same file %s", m_config_file);
             return;
         }
 
-        SWSS_LOG_ERROR("SonicDBConfig already initialized");
+        SWSS_LOG_ERROR("SonicDBConfig already initialized with another file %s", m_config_file);
         throw runtime_error("SonicDBConfig already initialized");
     }
 

--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -86,7 +86,7 @@ void SonicDBConfig::initializeGlobalConfig(const string &file)
             return;
         }
 
-        SWSS_LOG_ERROR(SonicDBConfig Global config is already initialized with another file %s", m_global_config_file);
+        SWSS_LOG_ERROR("SonicDBConfig Global config is already initialized with another file %s", m_global_config_file);
         return;
     }
 

--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -80,13 +80,13 @@ void SonicDBConfig::initializeGlobalConfig(const string &file)
 
     if (m_global_init)
     {
-        if ((*m_global_config_file).compare(file) == 0)
+        if (m_global_config_file->compare(file) == 0)
         {
-            SWSS_LOG_INFO("SonicDBConfig Global config is already initialized with same file %s", (*m_global_config_file).c_str());
+            SWSS_LOG_INFO("SonicDBConfig Global config is already initialized with same file %s", m_global_config_file->c_str());
             return;
         }
 
-        SWSS_LOG_ERROR("SonicDBConfig Global config is already initialized with another file %s", (*m_global_config_file).c_str());
+        SWSS_LOG_ERROR("SonicDBConfig Global config is already initialized with another file %s", m_global_config_file->c_str());
         return;
     }
 
@@ -180,13 +180,13 @@ void SonicDBConfig::initialize(const string &file)
 
     if (m_init)
     {
-        if ((*m_config_file).compare(file) == 0)
+        if (m_config_file->compare(file) == 0)
         {
-            SWSS_LOG_INFO("SonicDBConfig already initialized with same file %s", (*m_config_file).c_str());
+            SWSS_LOG_INFO("SonicDBConfig already initialized with same file %s", m_config_file->c_str());
             return;
         }
 
-        SWSS_LOG_ERROR("SonicDBConfig already initialized with another file %s", (*m_config_file).c_str());
+        SWSS_LOG_ERROR("SonicDBConfig already initialized with another file %s", m_config_file->c_str());
         throw runtime_error("SonicDBConfig already initialized");
     }
 

--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -82,11 +82,11 @@ void SonicDBConfig::initializeGlobalConfig(const string &file)
     {
         if ((*m_global_config_file).compare(file) == 0)
         {
-            SWSS_LOG_INFO("SonicDBConfig Global config is already initialized with same file %s", m_global_config_file);
+            SWSS_LOG_INFO("SonicDBConfig Global config is already initialized with same file %s", (*m_global_config_file).c_str());
             return;
         }
 
-        SWSS_LOG_ERROR("SonicDBConfig Global config is already initialized with another file %s", m_global_config_file);
+        SWSS_LOG_ERROR("SonicDBConfig Global config is already initialized with another file %s", (*m_global_config_file).c_str());
         return;
     }
 
@@ -182,11 +182,11 @@ void SonicDBConfig::initialize(const string &file)
     {
         if ((*m_config_file).compare(file) == 0)
         {
-            SWSS_LOG_INFO("SonicDBConfig already initialized with same file %s", m_config_file);
+            SWSS_LOG_INFO("SonicDBConfig already initialized with same file %s", (*m_config_file).c_str());
             return;
         }
 
-        SWSS_LOG_ERROR("SonicDBConfig already initialized with another file %s", m_config_file);
+        SWSS_LOG_ERROR("SonicDBConfig already initialized with another file %s", (*m_config_file).c_str());
         throw runtime_error("SonicDBConfig already initialized");
     }
 

--- a/common/dbconnector.h
+++ b/common/dbconnector.h
@@ -12,6 +12,7 @@
 #include "rediscommand.h"
 #include "redisreply.h"
 #define EMPTY_NAMESPACE std::string()
+#define EMPTY_CONFIG_FILE std::string()
 
 namespace swss {
 
@@ -92,6 +93,8 @@ private:
     static std::unordered_map<std::string, std::unordered_map<int, std::string>> m_db_separator;
     static bool m_init;
     static bool m_global_init;
+    static std::shared_ptr<std::string> m_config_file;
+    static std::shared_ptr<std::string> m_global_config_file;
     static void parseDatabaseConfig(const std::string &file,
                                     std::unordered_map<std::string, RedisInstInfo> &inst_entry,
                                     std::unordered_map<std::string, SonicDBInfo> &db_entry,

--- a/tests/redis_multi_db_ut.cpp
+++ b/tests/redis_multi_db_ut.cpp
@@ -13,11 +13,15 @@ extern string existing_file;
 
 TEST(DBConnector, multi_db_test)
 {
-    // load local config file again, should throw exception with init already done
+    // load same local config file again, should not throw exception with init already done
+    cout<<"INIT: loading same local config file again"<<endl;
+    SonicDBConfig::initialize(existing_file);
+    
+    // load different global config file again, should throw exception with init already done
     try
     {
-        cout<<"INIT: loading local config file again"<<endl;
-        SonicDBConfig::initialize(existing_file);
+        cout<<"INIT: loading different local config file again"<<endl;
+        SonicDBConfig::initialize("./tests/redis_multi_db_ut_config/other_database_local.json");
     }
     catch (exception &e)
     {

--- a/tests/redis_multi_ns_ut.cpp
+++ b/tests/redis_multi_ns_ut.cpp
@@ -18,11 +18,15 @@ TEST(DBConnector, multi_ns_test)
     vector<string> namespaces;
     vector<string> ns_names;
 
-    // load global config file again, should throw exception with init already done
+    // load same global config file again, should not throw exception with init already done
+    cout<<"INIT: loading same global config file again"<<endl;
+    SonicDBConfig::initializeGlobalConfig(global_existing_file);
+    
+    // load different global config file again, should throw exception with init already done
     try
     {
-        cout<<"INIT: loading local config file again"<<endl;
-        SonicDBConfig::initializeGlobalConfig(global_existing_file);
+        cout<<"INIT: loading different global config file again"<<endl;
+        SonicDBConfig::initializeGlobalConfig("./tests/redis_multi_db_ut_config/other_database_global.json");
     }
     catch (exception &e)
     {


### PR DESCRIPTION
When swich sonic-py-common from use swss-sdk to use swss-common, some service crash, for example snmp agent.
This is because those the code of those service initialize SonicDBConfig multiple times in their code and sonic-py-common.

So add new data member to SonicDBConfig, when config already initialized with same file, not throw exception.