### PR TITLE
[ci] Parameterize pipeline and improve azure pipeline

### DIFF
--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -34,7 +34,6 @@ jobs:
   steps:
   - checkout: self
     clean: true
-  - template: template-get-source-branch.yml
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: ${{ parameters.swss_common_artifact_name }}
@@ -57,7 +56,7 @@ jobs:
       pipeline: Azure.sonic-buildimage.official.vs
       artifact: sonic-buildimage.vs
       runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/$(SOURCE_BRANCH)'
+      runBranch: 'refs/heads/$(BUILD_BRANCH)'
       path: $(Build.ArtifactStagingDirectory)/download
       patterns: '**/target/docker-sonic-vs.gz'
     displayName: "Download sonic-buildimage docker-sonic-vs"

--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -32,35 +32,44 @@ jobs:
     vmImage: 'ubuntu-20.04'
 
   steps:
+  - checkout: self
+    clean: true
+  - template: template-get-source-branch.yml
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: ${{ parameters.swss_common_artifact_name }}
-    displayName: "Download sonic swss common deb packages"
+      path: $(Build.ArtifactStagingDirectory)/download
+    displayName: "Download pre-stage built ${{ parameters.swss_common_artifact_name }}"
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: ${{ parameters.sairedis_artifact_name }}
-    displayName: "Download sonic sairedis deb packages"
+      path: $(Build.ArtifactStagingDirectory)/download
+    displayName: "Download pre-stage built ${{ parameters.sairedis_artifact_name }}"
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: ${{ parameters.swss_artifact_name }}
-    displayName: "Download sonic swss artifact"
+      path: $(Build.ArtifactStagingDirectory)/download
+    displayName: "Download pre-stage built ${{ parameters.swss_artifact_name }}"
   - task: DownloadPipelineArtifact@2
     inputs:
       source: specific
       project: build
-      pipeline: 1
+      pipeline: Azure.sonic-buildimage.official.vs
       artifact: sonic-buildimage.vs
       runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/master'
-    displayName: "Download sonic buildimage"
+      runBranch: 'refs/heads/$(SOURCE_BRANCH)'
+      path: $(Build.ArtifactStagingDirectory)/download
+      patterns: '**/target/docker-sonic-vs.gz'
+    displayName: "Download sonic-buildimage docker-sonic-vs"
   - script: |
+      set -ex
       echo $(Build.DefinitionName).$(Build.BuildNumber)
 
-      docker load < ../target/docker-sonic-vs.gz
+      docker load < $(Build.ArtifactStagingDirectory)/download/target/docker-sonic-vs.gz
 
       mkdir -p .azure-pipelines/docker-sonic-vs/debs
 
-      cp -v ../*.deb .azure-pipelines/docker-sonic-vs/debs
+      cp -v $(Build.ArtifactStagingDirectory)/download/*.deb .azure-pipelines/docker-sonic-vs/debs
 
       pushd .azure-pipelines
 
@@ -69,6 +78,7 @@ jobs:
       popd
 
       docker save docker-sonic-vs:$(Build.DefinitionName).$(Build.BuildNumber) | gzip -c > $(Build.ArtifactStagingDirectory)/docker-sonic-vs.gz
+      rm -rf $(Build.ArtifactStagingDirectory)/download
     displayName: "Build docker-sonic-vs"
 
   - publish: $(Build.ArtifactStagingDirectory)/

--- a/.azure-pipelines/build-sairedis-template.yml
+++ b/.azure-pipelines/build-sairedis-template.yml
@@ -41,13 +41,21 @@ jobs:
   pool:
     ${{ if ne(parameters.pool, 'default') }}:
       name: ${{ parameters.pool }}
-    ${{ if eq(parameters.pool, 'default') }}:
+    ${{ else }}:
       vmImage: 'ubuntu-20.04'
 
   container:
     image: sonicdev-microsoft.azurecr.io:443/${{ parameters.sonic_slave }}:latest
 
   steps:
+  - checkout: sonic-sairedis
+    submodules: true
+    clean: true
+  - template: template-get-source-branch.yml
+  - script: |
+      set -ex
+      git checkout $(SOURCE_BRANCH)
+    displayName: Set up sonic-sairedis branch
   - script: |
       sudo apt-get install -qq -y \
         qtbase5-dev \
@@ -81,18 +89,20 @@ jobs:
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: ${{ parameters.swss_common_artifact_name }}
-    displayName: "Download sonic swss common deb packages"
+      path: $(Build.ArtifactStagingDirectory)/download
+    displayName: "Download pre-stage built deb packages"
   - script: |
+      set -ex
       sudo dpkg -i libswsscommon_1.0.0_${{ parameters.arch }}.deb
       sudo dpkg -i libswsscommon-dev_1.0.0_${{ parameters.arch }}.deb
-    workingDirectory: $(Pipeline.Workspace)
+    workingDirectory: $(Build.ArtifactStagingDirectory)/download
     displayName: "Install sonic swss Common"
-  - checkout: sonic-sairedis
-    path: s
-    submodules: true
   - script: |
+      set -ex
+      rm ../*.deb || true
       ./autogen.sh
-      fakeroot dpkg-buildpackage -b -us -uc -Tbinary-syncd-vs -j$(nproc) && cp ../*.deb .
+      fakeroot dpkg-buildpackage -b -us -uc -Tbinary-syncd-vs -j$(nproc)
+      mv ../*.deb .
     displayName: "Compile sonic sairedis"
   - script: |
       sudo cp azsyslog.conf /etc/rsyslog.conf

--- a/.azure-pipelines/build-sairedis-template.yml
+++ b/.azure-pipelines/build-sairedis-template.yml
@@ -90,12 +90,13 @@ jobs:
     inputs:
       artifact: ${{ parameters.swss_common_artifact_name }}
       path: $(Build.ArtifactStagingDirectory)/download
-    displayName: "Download pre-stage built deb packages"
+    displayName: "Download pre-stage built ${{ parameters.swss_common_artifact_name }}"
   - script: |
       set -ex
-      sudo dpkg -i libswsscommon_1.0.0_${{ parameters.arch }}.deb
-      sudo dpkg -i libswsscommon-dev_1.0.0_${{ parameters.arch }}.deb
-    workingDirectory: $(Build.ArtifactStagingDirectory)/download
+      sudo dpkg -i download/libswsscommon_1.0.0_${{ parameters.arch }}.deb
+      sudo dpkg -i download/libswsscommon-dev_1.0.0_${{ parameters.arch }}.deb
+      rm -rf download || true
+    workingDirectory: $(Build.ArtifactStagingDirectory)
     displayName: "Install sonic swss Common"
   - script: |
       set -ex

--- a/.azure-pipelines/build-sairedis-template.yml
+++ b/.azure-pipelines/build-sairedis-template.yml
@@ -55,6 +55,8 @@ jobs:
   - script: |
       set -ex
       git checkout $(SOURCE_BRANCH)
+      git submodule update
+      git status
     displayName: Set up sonic-sairedis branch
   - script: |
       sudo apt-get install -qq -y \

--- a/.azure-pipelines/build-sairedis-template.yml
+++ b/.azure-pipelines/build-sairedis-template.yml
@@ -51,10 +51,9 @@ jobs:
   - checkout: sonic-sairedis
     submodules: true
     clean: true
-  - template: template-get-source-branch.yml
   - script: |
       set -ex
-      git checkout $(SOURCE_BRANCH)
+      git checkout $(BUILD_BRANCH)
       git submodule update
       git status
     displayName: Set up sonic-sairedis branch

--- a/.azure-pipelines/build-swss-template.yml
+++ b/.azure-pipelines/build-swss-template.yml
@@ -97,15 +97,15 @@ jobs:
       path: $(Build.ArtifactStagingDirectory)/download
       artifact: common-lib
       patterns: |
-        libnl-3*.deb
-        libnl-genl*.deb
-        libnl-route*.deb
-        libnl-nf*.deb
+        target/debs/bullseye/libnl-3*.deb
+        target/debs/bullseye/libnl-genl*.deb
+        target/debs/bullseye/libnl-route*.deb
+        target/debs/bullseye/libnl-nf*.deb
     displayName: "Download common libs"
 
   - script: |
       set -ex
-      sudo dpkg -i $(ls download/*.deb)
+      sudo dpkg -i $(find ./download -name *.deb)
       rm -rf download || true
     workingDirectory: $(Build.ArtifactStagingDirectory)
     displayName: "Install libnl3, sonic swss common, and sairedis"

--- a/.azure-pipelines/build-swss-template.yml
+++ b/.azure-pipelines/build-swss-template.yml
@@ -82,14 +82,16 @@ jobs:
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/$(SOURCE_BRANCH)'
       path: $(Build.ArtifactStagingDirectory)/download
+      patterns: |
+        libnl-3*.deb
+        libnl-genl*.deb
+        libnl-route*.deb
+        libnl-nf*.deb
     displayName: "Download common libs"
 
   - script: |
       set -ex
-      find download -name libnl*.deb | xargs -i sudo dpkg -i {}
-      find download -name libswsscommon*.deb | xargs -i sudo dpkg -i {}
-      find download -name libsai*.deb | xargs -i sudo dpkg -i {}
-      find download -name syncd-vs_*.deb | xargs -i sudo dpkg -i {}
+      sudo dpkg -i $(ls download/*.deb)
     workingDirectory: $(Build.ArtifactStagingDirectory)
     displayName: "Install libnl3, sonic swss common, and sairedis"
   - script: |

--- a/.azure-pipelines/build-swss-template.yml
+++ b/.azure-pipelines/build-swss-template.yml
@@ -52,6 +52,8 @@ jobs:
   - script: |
       set -ex
       git checkout $(SOURCE_BRANCH)
+      git submodule update
+      git status
     displayName: Set up sonic-swss branch
   - script: |
       sudo apt-get install -y libhiredis0.14 libhiredis-dev

--- a/.azure-pipelines/build-swss-template.yml
+++ b/.azure-pipelines/build-swss-template.yml
@@ -68,12 +68,23 @@ jobs:
     inputs:
       artifact: ${{ parameters.swss_common_artifact_name }}
       path: $(Build.ArtifactStagingDirectory)/download
-    displayName: "Download sonic swss common deb packages"
+      patterns: |
+        libswsscommon_1.0.0_*.deb
+        libswsscommon-dev_1.0.0*.deb
+    displayName: "Download pre-stage built ${{ parameters.swss_common_artifact_name }}"
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: ${{ parameters.sairedis_artifact_name }}
       path: $(Build.ArtifactStagingDirectory)/download
-    displayName: "Download sonic sairedis deb packages"
+      patterns: |
+        libsaivs_*.deb
+        libsaivs-dev_*.deb
+        libsairedis_*.deb
+        libsairedis-dev_*.deb
+        libsaimetadata_*.deb
+        libsaimetadata-dev_*.deb
+        syncd-vs_*.deb
+    displayName: "Download pre-stage built ${{ parameters.sairedis_artifact_name }}"
   - task: DownloadPipelineArtifact@2
     inputs:
       source: specific
@@ -93,6 +104,7 @@ jobs:
   - script: |
       set -ex
       sudo dpkg -i $(ls download/*.deb)
+      rm -rf download || true
     workingDirectory: $(Build.ArtifactStagingDirectory)
     displayName: "Install libnl3, sonic swss common, and sairedis"
   - script: |

--- a/.azure-pipelines/build-swss-template.yml
+++ b/.azure-pipelines/build-swss-template.yml
@@ -21,6 +21,9 @@ parameters:
 - name: sonic_slave
   type: string
 
+- name: debian_version
+  type: string
+
 - name: sairedis_artifact_name
   type: string
 
@@ -97,10 +100,10 @@ jobs:
       path: $(Build.ArtifactStagingDirectory)/download
       artifact: common-lib
       patterns: |
-        target/debs/bullseye/libnl-3*.deb
-        target/debs/bullseye/libnl-genl*.deb
-        target/debs/bullseye/libnl-route*.deb
-        target/debs/bullseye/libnl-nf*.deb
+        target/debs/${{ parameters.debian_version }}/libnl-3*.deb
+        target/debs/${{ parameters.debian_version }}/libnl-genl*.deb
+        target/debs/${{ parameters.debian_version }}/libnl-route*.deb
+        target/debs/${{ parameters.debian_version }}/libnl-nf*.deb
     displayName: "Download common libs"
 
   - script: |

--- a/.azure-pipelines/build-swss-template.yml
+++ b/.azure-pipelines/build-swss-template.yml
@@ -38,13 +38,21 @@ jobs:
   pool:
     ${{ if ne(parameters.pool, 'default') }}:
       name: ${{ parameters.pool }}
-    ${{ if eq(parameters.pool, 'default') }}:
+    ${{ else }}:
       vmImage: 'ubuntu-20.04'
 
   container:
     image: sonicdev-microsoft.azurecr.io:443/${{ parameters.sonic_slave }}:latest
 
   steps:
+  - checkout: sonic-swss
+    submodules: true
+    clean: true
+  - template: template-get-source-branch.yml
+  - script: |
+      set -ex
+      git checkout $(SOURCE_BRANCH)
+    displayName: Set up sonic-swss branch
   - script: |
       sudo apt-get install -y libhiredis0.14 libhiredis-dev
       sudo apt-get install -y libzmq5 libzmq3-dev
@@ -59,47 +67,38 @@ jobs:
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: ${{ parameters.swss_common_artifact_name }}
+      path: $(Build.ArtifactStagingDirectory)/download
     displayName: "Download sonic swss common deb packages"
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: ${{ parameters.sairedis_artifact_name }}
+      path: $(Build.ArtifactStagingDirectory)/download
     displayName: "Download sonic sairedis deb packages"
   - task: DownloadPipelineArtifact@2
     inputs:
       source: specific
       project: build
-      pipeline: 1
-      artifact: sonic-buildimage.vs
+      pipeline: Azure.sonic-buildimage.common_libs
       runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/master'
-    displayName: "Download sonic buildimage"
+      runBranch: 'refs/heads/$(SOURCE_BRANCH)'
+      path: $(Build.ArtifactStagingDirectory)/download
+    displayName: "Download common libs"
+
   - script: |
-      sudo dpkg -i target/debs/buster/libnl-3-200_*.deb
-      sudo dpkg -i target/debs/buster/libnl-3-dev_*.deb
-      sudo dpkg -i target/debs/buster/libnl-genl-3-200_*.deb
-      sudo dpkg -i target/debs/buster/libnl-genl-3-dev_*.deb
-      sudo dpkg -i target/debs/buster/libnl-route-3-200_*.deb
-      sudo dpkg -i target/debs/buster/libnl-route-3-dev_*.deb
-      sudo dpkg -i target/debs/buster/libnl-nf-3-200_*.deb
-      sudo dpkg -i target/debs/buster/libnl-nf-3-dev_*.deb
-      sudo dpkg -i libswsscommon_1.0.0_${{ parameters.arch }}.deb
-      sudo dpkg -i libswsscommon-dev_1.0.0_${{ parameters.arch }}.deb
-      sudo dpkg -i libsaivs_*.deb
-      sudo dpkg -i libsaivs-dev_*.deb
-      sudo dpkg -i libsairedis_*.deb
-      sudo dpkg -i libsairedis-dev_*.deb
-      sudo dpkg -i libsaimetadata_*.deb
-      sudo dpkg -i libsaimetadata-dev_*.deb
-      sudo dpkg -i syncd-vs_*.deb
-    workingDirectory: $(Pipeline.Workspace)
+      set -ex
+      find download -name libnl*.deb | xargs -i sudo dpkg -i {}
+      find download -name libswsscommon*.deb | xargs -i sudo dpkg -i {}
+      find download -name libsai*.deb | xargs -i sudo dpkg -i {}
+      find download -name syncd-vs_*.deb | xargs -i sudo dpkg -i {}
+    workingDirectory: $(Build.ArtifactStagingDirectory)
     displayName: "Install libnl3, sonic swss common, and sairedis"
-  - checkout: sonic-swss
-    path: s
-    submodules: true
   - script: |
+      set -ex
+      rm ../*.deb || true
       ./autogen.sh
-      dpkg-buildpackage -us -uc -b -j$(nproc) && cp ../*.deb .
+      dpkg-buildpackage -us -uc -b -j$(nproc)
+      mv ../*.deb $(Build.ArtifactStagingDirectory)
     displayName: "Compile sonic swss"
-  - publish: $(System.DefaultWorkingDirectory)/
+  - publish: $(Build.ArtifactStagingDirectory)
     artifact: ${{ parameters.artifact_name }}
     displayName: "Archive swss debian packages"

--- a/.azure-pipelines/build-swss-template.yml
+++ b/.azure-pipelines/build-swss-template.yml
@@ -82,6 +82,7 @@ jobs:
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/$(SOURCE_BRANCH)'
       path: $(Build.ArtifactStagingDirectory)/download
+      artifact: common-lib
       patterns: |
         libnl-3*.deb
         libnl-genl*.deb

--- a/.azure-pipelines/build-swss-template.yml
+++ b/.azure-pipelines/build-swss-template.yml
@@ -51,10 +51,9 @@ jobs:
   - checkout: sonic-swss
     submodules: true
     clean: true
-  - template: template-get-source-branch.yml
   - script: |
       set -ex
-      git checkout $(SOURCE_BRANCH)
+      git checkout $(BUILD_BRANCH)
       git submodule update
       git status
     displayName: Set up sonic-swss branch
@@ -96,7 +95,7 @@ jobs:
       project: build
       pipeline: Azure.sonic-buildimage.common_libs
       runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/$(SOURCE_BRANCH)'
+      runBranch: 'refs/heads/$(BUILD_BRANCH)'
       path: $(Build.ArtifactStagingDirectory)/download
       artifact: common-lib
       patterns: |

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -45,13 +45,15 @@ jobs:
   pool:
     ${{ if ne(parameters.pool, 'default') }}:
       name: ${{ parameters.pool }}
-    ${{ if eq(parameters.pool, 'default') }}:
+    ${{ else }}:
       vmImage: 'ubuntu-20.04'
 
   container:
     image: sonicdev-microsoft.azurecr.io:443/${{ parameters.sonic_slave }}:latest
 
   steps:
+  - checkout: self
+    clean: true
   - script: |
       sudo apt-get install -qq -y \
         libhiredis-dev \
@@ -63,8 +65,10 @@ jobs:
     displayName: "Install dependencies"
   - script: |
       set -ex
+      rm ../*.deb || true
       ./autogen.sh
-      fakeroot debian/rules DEB_CONFIGURE_EXTRA_FLAGS='--enable-code-coverage' CFLAGS="" CXXFLAGS="--coverage -fprofile-abs-path" LDFLAGS="--coverage -fprofile-abs-path" binary && cp ../*.deb .
+      fakeroot debian/rules DEB_CONFIGURE_EXTRA_FLAGS='--enable-code-coverage' CFLAGS="" CXXFLAGS="--coverage -fprofile-abs-path" LDFLAGS="--coverage -fprofile-abs-path" binary
+      mv ../*.deb .
     displayName: "Compile sonic swss common with coverage enabled"
   - ${{ if eq(parameters.run_unit_test, true) }}:
     - script: |

--- a/.azure-pipelines/template-get-source-branch.yml
+++ b/.azure-pipelines/template-get-source-branch.yml
@@ -1,9 +1,0 @@
-steps:
-  - script: |
-      sourceBranch=$(Build.SourceBranchName)
-      if [[ "$(Build.Reason)" == "PullRequest" ]];then
-        sourceBranch=$(System.PullRequest.TargetBranch)
-      fi
-      echo "Download artifact branch: $sourceBranch"
-      echo "##vso[task.setvariable variable=SOURCE_BRANCH]$sourceBranch"
-    displayName: "Set SOURCE_BRANCH variable"

--- a/.azure-pipelines/template-get-source-branch.yml
+++ b/.azure-pipelines/template-get-source-branch.yml
@@ -1,0 +1,9 @@
+steps:
+  - script: |
+      sourceBranch=$(Build.SourceBranchName)
+      if [[ "$(Build.Reason)" == "PullRequest" ]];then
+        sourceBranch=$(System.PullRequest.TargetBranch)
+      fi
+      echo "Download artifact branch: $sourceBranch"
+      echo "##vso[task.setvariable variable=SOURCE_BRANCH]$sourceBranch"
+    displayName: "Set SOURCE_BRANCH variable"

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -28,7 +28,7 @@ jobs:
       set -ex
       cd sonic-swss
       git checkout $(SOURCE_BRANCH)
-    displayName: Set up sonic-sairedis branch
+    displayName: Set up sonic-swss branch
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: docker-sonic-vs

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -14,9 +14,6 @@ jobs:
   pool: sonic-common
 
   steps:
-  - script: |
-      ls -A1 | xargs -I{} sudo rm -rf {}
-    displayName: "Clean workspace"
   - checkout: self
     clean: true
     displayName: "Checkout sonic-swss-common"

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -20,11 +20,10 @@ jobs:
   - checkout: sonic-swss
     clean: true
     displayName: "Checkout sonic-swss"
-  - template: template-get-source-branch.yml
   - script: |
       set -ex
       cd sonic-swss
-      git checkout $(SOURCE_BRANCH)
+      git checkout $(BUILD_BRANCH)
     displayName: Set up sonic-swss branch
   - task: DownloadPipelineArtifact@2
     inputs:

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -18,20 +18,21 @@ jobs:
       ls -A1 | xargs -I{} sudo rm -rf {}
     displayName: "Clean workspace"
   - checkout: self
+    clean: true
+    displayName: "Checkout sonic-swss-common"
+  - checkout: sonic-swss
+    clean: true
+    displayName: "Checkout sonic-swss"
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: docker-sonic-vs
-    displayName: "Download docker sonic vs image"
-
+      path: $(Build.ArtifactStagingDirectory)/download
+    displayName: "Download pre-stage built docker-sonic-vs"
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: sonic-swss-common.amd64.ubuntu20_04
-    displayName: "Download sonic swss common deb packages"
-
-  - checkout: self
-    displayName: "Checkout sonic-swss-common"
-  - checkout: sonic-swss
-    displayName: "Checkout sonic-swss"
+      path: $(Build.ArtifactStagingDirectory)/download
+    displayName: "Download pre-stage built sonic-swss-common.amd64.ubuntu20_04"
 
   - script: |
       set -x
@@ -39,9 +40,11 @@ jobs:
       sudo sonic-swss-common/.azure-pipelines/build_and_install_module.sh
 
       sudo apt-get install -y libhiredis0.14
-      sudo dpkg -i --force-confask,confnew ../libswsscommon_1.0.0_amd64.deb || apt-get install -f
-      sudo dpkg -i ../python3-swsscommon_1.0.0_amd64.deb
-
+      pushd $(Build.ArtifactStagingDirectory)
+      find download -name libswsscommon*.deb | xargs -i sudo dpkg -i --force-confask,confnew {}
+      apt-get install -f
+      find download -name python3-swsscommon*.deb | xargs -i sudo dpkg -i {}
+      popd
       # install packages for vs test
       sudo apt-get install -y net-tools bridge-utils vlan
       sudo apt-get install -y python3-pip
@@ -50,11 +53,12 @@ jobs:
 
   - script: |
       set -x
-      sudo docker load -i ../docker-sonic-vs.gz
+      sudo docker load -i $(Build.ArtifactStagingDirectory)/download/docker-sonic-vs.gz
       docker ps
       ip netns list
       pushd sonic-swss/tests
       sudo py.test -v --force-flaky --junitxml=tr.xml --imgname=docker-sonic-vs:$(Build.DefinitionName).$(Build.BuildNumber)
+      rm -rf $(Build.ArtifactStagingDirectory)/download
     displayName: "Run vs tests"
 
   - task: PublishTestResults@2

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -41,7 +41,7 @@ jobs:
     displayName: "Download pre-stage built sonic-swss-common.amd64.ubuntu20_04"
 
   - script: |
-      set -x
+      set -ex
       ls -l
       sudo sonic-swss-common/.azure-pipelines/build_and_install_module.sh
 
@@ -56,7 +56,7 @@ jobs:
     displayName: "Install dependencies"
 
   - script: |
-      set -x
+      set -ex
       sudo docker load -i $(Build.ArtifactStagingDirectory)/download/docker-sonic-vs.gz
       docker ps
       ip netns list

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -23,6 +23,11 @@ jobs:
   - checkout: sonic-swss
     clean: true
     displayName: "Checkout sonic-swss"
+  - template: template-get-source-branch.yml
+  - script: |
+      set -ex
+      git checkout $(SOURCE_BRANCH)
+    displayName: Set up sonic-sairedis branch
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: docker-sonic-vs

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -40,11 +40,9 @@ jobs:
       sudo sonic-swss-common/.azure-pipelines/build_and_install_module.sh
 
       sudo apt-get install -y libhiredis0.14
-      pushd $(Build.ArtifactStagingDirectory)
-      find download -name libswsscommon*.deb | xargs -i sudo dpkg -i --force-confask,confnew {}
-      apt-get install -f
-      find download -name python3-swsscommon*.deb | xargs -i sudo dpkg -i {}
-      popd
+      sudo dpkg -i --force-confask,confnew $(Build.ArtifactStagingDirectory)/download/libswsscommon_1.0.0_amd64.deb || apt-get install -f
+      sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/python3-swsscommon_1.0.0_amd64.deb
+
       # install packages for vs test
       sudo apt-get install -y net-tools bridge-utils vlan
       sudo apt-get install -y python3-pip

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -26,6 +26,7 @@ jobs:
   - template: template-get-source-branch.yml
   - script: |
       set -ex
+      cd sonic-swss
       git checkout $(SOURCE_BRANCH)
     displayName: Set up sonic-sairedis branch
   - task: DownloadPipelineArtifact@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,7 @@ resources:
 parameters:
   - name: debian_version
     type: string
-    default: buster
+    default: bullseye
 
 stages:
 - stage: Build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,7 +35,7 @@ resources:
     endpoint: build
 
 parameters:
-  - name: debian-version
+  - name: debianVersion
     type: string
     default: bullseye
 
@@ -82,7 +82,7 @@ stages:
   - template: .azure-pipelines/build-template.yml
     parameters:
       arch: amd64
-      sonic_slave: sonic-slave-${{ parameters.debian-version }}
+      sonic_slave: sonic-slave-${{ parameters.debianVersion }}
       artifact_name: sonic-swss-common
       run_unit_test: true
       archive_gcov: true
@@ -96,7 +96,7 @@ stages:
       arch: armhf
       timeout: 180
       pool: sonicbld-armhf
-      sonic_slave: sonic-slave-${{ parameters.debian-version }}-armhf
+      sonic_slave: sonic-slave-${{ parameters.debianVersion }}-armhf
       artifact_name: sonic-swss-common.armhf
 
   - template: .azure-pipelines/build-template.yml
@@ -104,7 +104,7 @@ stages:
       arch: arm64
       timeout: 180
       pool: sonicbld-arm64
-      sonic_slave: sonic-slave-${{ parameters.debian-version }}-arm64
+      sonic_slave: sonic-slave-${{ parameters.debianVersion }}-arm64
       artifact_name: sonic-swss-common.arm64
 
 - stage: BuildSairedis
@@ -114,7 +114,7 @@ stages:
   - template: .azure-pipelines/build-sairedis-template.yml
     parameters:
       arch: amd64
-      sonic_slave: sonic-slave-${{ parameters.debian-version }}
+      sonic_slave: sonic-slave-${{ parameters.debianVersion }}
       swss_common_artifact_name: sonic-swss-common
       artifact_name: sonic-sairedis
       syslog_artifact_name: sonic-sairedis.syslog
@@ -126,7 +126,7 @@ stages:
   - template: .azure-pipelines/build-swss-template.yml
     parameters:
       arch: amd64
-      sonic_slave: sonic-slave-${{ parameters.debian-version }}
+      sonic_slave: sonic-slave-${{ parameters.debianVersion }}
       swss_common_artifact_name: sonic-swss-common
       sairedis_artifact_name: sonic-sairedis
       artifact_name: sonic-swss

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,7 @@ resources:
 parameters:
   - name: debian_version
     type: string
-    default: bullseye
+    default: buster
 
 stages:
 - stage: Build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,6 +34,11 @@ resources:
     name: Azure/sonic-swss
     endpoint: build
 
+parameters:
+  - name: debian-version
+    value: string
+    default: bullseye
+
 stages:
 - stage: Build
 
@@ -77,7 +82,7 @@ stages:
   - template: .azure-pipelines/build-template.yml
     parameters:
       arch: amd64
-      sonic_slave: sonic-slave-buster
+      sonic_slave: sonic-slave-${{ parameters.debian-version }}
       artifact_name: sonic-swss-common
       run_unit_test: true
       archive_gcov: true
@@ -91,7 +96,7 @@ stages:
       arch: armhf
       timeout: 180
       pool: sonicbld-armhf
-      sonic_slave: sonic-slave-buster-armhf
+      sonic_slave: sonic-slave-${{ parameters.debian-version }}-armhf
       artifact_name: sonic-swss-common.armhf
 
   - template: .azure-pipelines/build-template.yml
@@ -99,7 +104,7 @@ stages:
       arch: arm64
       timeout: 180
       pool: sonicbld-arm64
-      sonic_slave: sonic-slave-buster-arm64
+      sonic_slave: sonic-slave-${{ parameters.debian-version }}-arm64
       artifact_name: sonic-swss-common.arm64
 
 - stage: BuildSairedis
@@ -109,7 +114,7 @@ stages:
   - template: .azure-pipelines/build-sairedis-template.yml
     parameters:
       arch: amd64
-      sonic_slave: sonic-slave-buster
+      sonic_slave: sonic-slave-${{ parameters.debian-version }}
       swss_common_artifact_name: sonic-swss-common
       artifact_name: sonic-sairedis
       syslog_artifact_name: sonic-sairedis.syslog
@@ -121,7 +126,7 @@ stages:
   - template: .azure-pipelines/build-swss-template.yml
     parameters:
       arch: amd64
-      sonic_slave: sonic-slave-buster
+      sonic_slave: sonic-slave-${{ parameters.debian-version }}
       swss_common_artifact_name: sonic-swss-common
       sairedis_artifact_name: sonic-sairedis
       artifact_name: sonic-swss

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,7 +35,7 @@ resources:
     endpoint: build
 
 parameters:
-  - name: debianVersion
+  - name: debian_version
     type: string
     default: buster
 
@@ -82,7 +82,7 @@ stages:
   - template: .azure-pipelines/build-template.yml
     parameters:
       arch: amd64
-      sonic_slave: sonic-slave-${{ parameters.debianVersion }}
+      sonic_slave: sonic-slave-${{ parameters.debian_version }}
       artifact_name: sonic-swss-common
       run_unit_test: true
       archive_gcov: true
@@ -96,7 +96,7 @@ stages:
       arch: armhf
       timeout: 180
       pool: sonicbld-armhf
-      sonic_slave: sonic-slave-${{ parameters.debianVersion }}-armhf
+      sonic_slave: sonic-slave-${{ parameters.debian_version }}-armhf
       artifact_name: sonic-swss-common.armhf
 
   - template: .azure-pipelines/build-template.yml
@@ -104,7 +104,7 @@ stages:
       arch: arm64
       timeout: 180
       pool: sonicbld-arm64
-      sonic_slave: sonic-slave-${{ parameters.debianVersion }}-arm64
+      sonic_slave: sonic-slave-${{ parameters.debian_version }}-arm64
       artifact_name: sonic-swss-common.arm64
 
 - stage: BuildSairedis
@@ -114,7 +114,7 @@ stages:
   - template: .azure-pipelines/build-sairedis-template.yml
     parameters:
       arch: amd64
-      sonic_slave: sonic-slave-${{ parameters.debianVersion }}
+      sonic_slave: sonic-slave-${{ parameters.debian_version }}
       swss_common_artifact_name: sonic-swss-common
       artifact_name: sonic-sairedis
       syslog_artifact_name: sonic-sairedis.syslog
@@ -126,10 +126,11 @@ stages:
   - template: .azure-pipelines/build-swss-template.yml
     parameters:
       arch: amd64
-      sonic_slave: sonic-slave-${{ parameters.debianVersion }}
+      sonic_slave: sonic-slave-${{ parameters.debian_version }}
       swss_common_artifact_name: sonic-swss-common
       sairedis_artifact_name: sonic-sairedis
       artifact_name: sonic-swss
+      debian_version: ${{ parameters.debian_version }}
 
 - stage: BuildDocker
   dependsOn: BuildSwss

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,9 +8,12 @@ pr:
 - 201???
 
 trigger:
-- master
-- 202???
-- 201???
+  batch: true
+  branches:
+    include:
+    - master
+    - 202???
+    - 201???
 
 # this part need to be set in UI
 schedules:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,7 +36,7 @@ resources:
 
 parameters:
   - name: debian-version
-    value: string
+    type: string
     default: bullseye
 
 stages:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,6 +41,12 @@ parameters:
   - name: debian_version
     type: string
     default: buster
+variables:
+  - name: BUILD_BRANCH
+    ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+      value: $(System.PullRequest.TargetBranch)
+    ${{ else }}:
+      value: $(Build.SourceBranch)
 
 stages:
 - stage: Build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,11 +2,26 @@
 # Build your C/C++ project with GCC using make.
 # Add steps that publish test results, save build artifacts, deploy, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/apps/c-cpp/gcc
+pr:
+- master
+- 202???
+- 201???
 
 trigger:
+- master
+- 202???
+- 201???
+
+# this part need to be set in UI
+schedules:
+- cron: "0 0 * * 6"
+  displayName: Weekly build
   branches:
     include:
-      - "*"
+    - master
+    - 202???
+    - 201???
+  always: true
 
 resources:
   repositories:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,7 @@ resources:
 parameters:
   - name: debianVersion
     type: string
-    default: bullseye
+    default: buster
 
 stages:
 - stage: Build


### PR DESCRIPTION
1. Parameterize pipeline. When checkout new release branch, we don't need manually setup azp.
2. Use common lib pipeline instead of buildimage pipeline to get higher success rate.
3. Clean workspace when downloading external packages. This will ensure package version matching.