### PR TITLE
[ci] Parameterize pipeline and improve azure pipeline

### DIFF
--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -34,7 +34,6 @@ jobs:
   steps:
   - checkout: self
     clean: true
-  - template: template-get-source-branch.yml
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: ${{ parameters.swss_common_artifact_name }}
@@ -57,7 +56,7 @@ jobs:
       pipeline: Azure.sonic-buildimage.official.vs
       artifact: sonic-buildimage.vs
       runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/$(SOURCE_BRANCH)'
+      runBranch: 'refs/heads/$(BUILD_BRANCH)'
       path: $(Build.ArtifactStagingDirectory)/download
       patterns: '**/target/docker-sonic-vs.gz'
     displayName: "Download sonic-buildimage docker-sonic-vs"

--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -32,35 +32,44 @@ jobs:
     vmImage: 'ubuntu-20.04'
 
   steps:
+  - checkout: self
+    clean: true
+  - template: template-get-source-branch.yml
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: ${{ parameters.swss_common_artifact_name }}
-    displayName: "Download sonic swss common deb packages"
+      path: $(Build.ArtifactStagingDirectory)/download
+    displayName: "Download pre-stage built ${{ parameters.swss_common_artifact_name }}"
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: ${{ parameters.sairedis_artifact_name }}
-    displayName: "Download sonic sairedis deb packages"
+      path: $(Build.ArtifactStagingDirectory)/download
+    displayName: "Download pre-stage built ${{ parameters.sairedis_artifact_name }}"
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: ${{ parameters.swss_artifact_name }}
-    displayName: "Download sonic swss artifact"
+      path: $(Build.ArtifactStagingDirectory)/download
+    displayName: "Download pre-stage built ${{ parameters.swss_artifact_name }}"
   - task: DownloadPipelineArtifact@2
     inputs:
       source: specific
       project: build
-      pipeline: 142
+      pipeline: Azure.sonic-buildimage.official.vs
       artifact: sonic-buildimage.vs
       runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/202012'
-    displayName: "Download sonic buildimage"
+      runBranch: 'refs/heads/$(SOURCE_BRANCH)'
+      path: $(Build.ArtifactStagingDirectory)/download
+      patterns: '**/target/docker-sonic-vs.gz'
+    displayName: "Download sonic-buildimage docker-sonic-vs"
   - script: |
+      set -ex
       echo $(Build.DefinitionName).$(Build.BuildNumber)
 
-      docker load < ../target/docker-sonic-vs.gz
+      docker load < $(Build.ArtifactStagingDirectory)/download/target/docker-sonic-vs.gz
 
       mkdir -p .azure-pipelines/docker-sonic-vs/debs
 
-      cp -v ../*.deb .azure-pipelines/docker-sonic-vs/debs
+      cp -v $(Build.ArtifactStagingDirectory)/download/*.deb .azure-pipelines/docker-sonic-vs/debs
 
       pushd .azure-pipelines
 
@@ -69,6 +78,7 @@ jobs:
       popd
 
       docker save docker-sonic-vs:$(Build.DefinitionName).$(Build.BuildNumber) | gzip -c > $(Build.ArtifactStagingDirectory)/docker-sonic-vs.gz
+      rm -rf $(Build.ArtifactStagingDirectory)/download
     displayName: "Build docker-sonic-vs"
 
   - publish: $(Build.ArtifactStagingDirectory)/

--- a/.azure-pipelines/build-sairedis-template.yml
+++ b/.azure-pipelines/build-sairedis-template.yml
@@ -41,13 +41,21 @@ jobs:
   pool:
     ${{ if ne(parameters.pool, 'default') }}:
       name: ${{ parameters.pool }}
-    ${{ if eq(parameters.pool, 'default') }}:
+    ${{ else }}:
       vmImage: 'ubuntu-20.04'
 
   container:
     image: sonicdev-microsoft.azurecr.io:443/${{ parameters.sonic_slave }}:latest
 
   steps:
+  - checkout: sonic-sairedis
+    submodules: true
+    clean: true
+  - template: template-get-source-branch.yml
+  - script: |
+      set -ex
+      git checkout $(SOURCE_BRANCH)
+    displayName: Set up sonic-sairedis branch
   - script: |
       sudo apt-get install -qq -y \
         qtbase5-dev \
@@ -81,18 +89,21 @@ jobs:
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: ${{ parameters.swss_common_artifact_name }}
-    displayName: "Download sonic swss common deb packages"
+      path: $(Build.ArtifactStagingDirectory)/download
+    displayName: "Download pre-stage built ${{ parameters.swss_common_artifact_name }}"
   - script: |
-      sudo dpkg -i libswsscommon_1.0.0_${{ parameters.arch }}.deb
-      sudo dpkg -i libswsscommon-dev_1.0.0_${{ parameters.arch }}.deb
-    workingDirectory: $(Pipeline.Workspace)
+      set -ex
+      sudo dpkg -i download/libswsscommon_1.0.0_${{ parameters.arch }}.deb
+      sudo dpkg -i download/libswsscommon-dev_1.0.0_${{ parameters.arch }}.deb
+      rm -rf download || true
+    workingDirectory: $(Build.ArtifactStagingDirectory)
     displayName: "Install sonic swss Common"
-  - checkout: sonic-sairedis
-    path: s
-    submodules: true
   - script: |
+      set -ex
+      rm ../*.deb || true
       ./autogen.sh
-      fakeroot dpkg-buildpackage -b -us -uc -Tbinary-syncd-vs -j$(nproc) && cp ../*.deb .
+      fakeroot dpkg-buildpackage -b -us -uc -Tbinary-syncd-vs -j$(nproc)
+      mv ../*.deb .
     displayName: "Compile sonic sairedis"
   - script: |
       sudo cp azsyslog.conf /etc/rsyslog.conf

--- a/.azure-pipelines/build-sairedis-template.yml
+++ b/.azure-pipelines/build-sairedis-template.yml
@@ -55,6 +55,8 @@ jobs:
   - script: |
       set -ex
       git checkout $(SOURCE_BRANCH)
+      git submodule update
+      git status
     displayName: Set up sonic-sairedis branch
   - script: |
       sudo apt-get install -qq -y \

--- a/.azure-pipelines/build-sairedis-template.yml
+++ b/.azure-pipelines/build-sairedis-template.yml
@@ -51,10 +51,9 @@ jobs:
   - checkout: sonic-sairedis
     submodules: true
     clean: true
-  - template: template-get-source-branch.yml
   - script: |
       set -ex
-      git checkout $(SOURCE_BRANCH)
+      git checkout $(BUILD_BRANCH)
       git submodule update
       git status
     displayName: Set up sonic-sairedis branch

--- a/.azure-pipelines/build-swss-template.yml
+++ b/.azure-pipelines/build-swss-template.yml
@@ -97,15 +97,15 @@ jobs:
       path: $(Build.ArtifactStagingDirectory)/download
       artifact: common-lib
       patterns: |
-        libnl-3*.deb
-        libnl-genl*.deb
-        libnl-route*.deb
-        libnl-nf*.deb
+        target/debs/buster/libnl-3*.deb
+        target/debs/buster/libnl-genl*.deb
+        target/debs/buster/libnl-route*.deb
+        target/debs/buster/libnl-nf*.deb
     displayName: "Download common libs"
 
   - script: |
       set -ex
-      sudo dpkg -i $(ls download/*.deb)
+      sudo dpkg -i $(find ./download -name *.deb)
       rm -rf download || true
     workingDirectory: $(Build.ArtifactStagingDirectory)
     displayName: "Install libnl3, sonic swss common, and sairedis"

--- a/.azure-pipelines/build-swss-template.yml
+++ b/.azure-pipelines/build-swss-template.yml
@@ -21,6 +21,9 @@ parameters:
 - name: sonic_slave
   type: string
 
+- name: debian_version
+  type: string
+
 - name: sairedis_artifact_name
   type: string
 
@@ -97,10 +100,10 @@ jobs:
       path: $(Build.ArtifactStagingDirectory)/download
       artifact: common-lib
       patterns: |
-        target/debs/${{ parameters.debianVersion }}/libnl-3*.deb
-        target/debs/${{ parameters.debianVersion }}/libnl-genl*.deb
-        target/debs/${{ parameters.debianVersion }}/libnl-route*.deb
-        target/debs/${{ parameters.debianVersion }}/libnl-nf*.deb
+        target/debs/${{ parameters.debian_version }}/libnl-3*.deb
+        target/debs/${{ parameters.debian_version }}/libnl-genl*.deb
+        target/debs/${{ parameters.debian_version }}/libnl-route*.deb
+        target/debs/${{ parameters.debian_version }}/libnl-nf*.deb
     displayName: "Download common libs"
 
   - script: |

--- a/.azure-pipelines/build-swss-template.yml
+++ b/.azure-pipelines/build-swss-template.yml
@@ -52,6 +52,8 @@ jobs:
   - script: |
       set -ex
       git checkout $(SOURCE_BRANCH)
+      git submodule update
+      git status
     displayName: Set up sonic-swss branch
   - script: |
       sudo apt-get install -y libhiredis0.14 libhiredis-dev

--- a/.azure-pipelines/build-swss-template.yml
+++ b/.azure-pipelines/build-swss-template.yml
@@ -38,22 +38,26 @@ jobs:
   pool:
     ${{ if ne(parameters.pool, 'default') }}:
       name: ${{ parameters.pool }}
-    ${{ if eq(parameters.pool, 'default') }}:
+    ${{ else }}:
       vmImage: 'ubuntu-20.04'
 
   container:
     image: sonicdev-microsoft.azurecr.io:443/${{ parameters.sonic_slave }}:latest
 
   steps:
+  - checkout: sonic-swss
+    submodules: true
+    clean: true
+  - template: template-get-source-branch.yml
+  - script: |
+      set -ex
+      git checkout $(SOURCE_BRANCH)
+    displayName: Set up sonic-swss branch
   - script: |
       sudo apt-get install -y libhiredis0.14 libhiredis-dev
       sudo apt-get install -y libzmq5 libzmq3-dev
       sudo apt-get install -qq -y \
           libhiredis-dev \
-          libnl-3-dev \
-          libnl-genl-3-dev \
-          libnl-route-3-dev \
-          libnl-nf-3-dev \
           swig3.0
       sudo apt-get install -y libdbus-1-3
       sudo apt-get install -y libteam-dev \
@@ -63,30 +67,53 @@ jobs:
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: ${{ parameters.swss_common_artifact_name }}
-    displayName: "Download sonic swss common deb packages"
+      path: $(Build.ArtifactStagingDirectory)/download
+      patterns: |
+        libswsscommon_1.0.0_*.deb
+        libswsscommon-dev_1.0.0*.deb
+    displayName: "Download pre-stage built ${{ parameters.swss_common_artifact_name }}"
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: ${{ parameters.sairedis_artifact_name }}
-    displayName: "Download sonic sairedis deb packages"
+      path: $(Build.ArtifactStagingDirectory)/download
+      patterns: |
+        libsaivs_*.deb
+        libsaivs-dev_*.deb
+        libsairedis_*.deb
+        libsairedis-dev_*.deb
+        libsaimetadata_*.deb
+        libsaimetadata-dev_*.deb
+        syncd-vs_*.deb
+    displayName: "Download pre-stage built ${{ parameters.sairedis_artifact_name }}"
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      source: specific
+      project: build
+      pipeline: Azure.sonic-buildimage.common_libs
+      runVersion: 'latestFromBranch'
+      runBranch: 'refs/heads/$(SOURCE_BRANCH)'
+      path: $(Build.ArtifactStagingDirectory)/download
+      artifact: common-lib
+      patterns: |
+        libnl-3*.deb
+        libnl-genl*.deb
+        libnl-route*.deb
+        libnl-nf*.deb
+    displayName: "Download common libs"
+
   - script: |
-      sudo dpkg -i libswsscommon_1.0.0_${{ parameters.arch }}.deb
-      sudo dpkg -i libswsscommon-dev_1.0.0_${{ parameters.arch }}.deb
-      sudo dpkg -i libsaivs_*.deb
-      sudo dpkg -i libsaivs-dev_*.deb
-      sudo dpkg -i libsairedis_*.deb
-      sudo dpkg -i libsairedis-dev_*.deb
-      sudo dpkg -i libsaimetadata_*.deb
-      sudo dpkg -i libsaimetadata-dev_*.deb
-      sudo dpkg -i syncd-vs_*.deb
-    workingDirectory: $(Pipeline.Workspace)
-    displayName: "Install sonic swss common and sairedis"
-  - checkout: sonic-swss
-    path: s
-    submodules: true
+      set -ex
+      sudo dpkg -i $(ls download/*.deb)
+      rm -rf download || true
+    workingDirectory: $(Build.ArtifactStagingDirectory)
+    displayName: "Install libnl3, sonic swss common, and sairedis"
   - script: |
+      set -ex
+      rm ../*.deb || true
       ./autogen.sh
-      dpkg-buildpackage -us -uc -b -j$(nproc) && cp ../*.deb .
+      dpkg-buildpackage -us -uc -b -j$(nproc)
+      mv ../*.deb $(Build.ArtifactStagingDirectory)
     displayName: "Compile sonic swss"
-  - publish: $(System.DefaultWorkingDirectory)/
+  - publish: $(Build.ArtifactStagingDirectory)
     artifact: ${{ parameters.artifact_name }}
     displayName: "Archive swss debian packages"

--- a/.azure-pipelines/build-swss-template.yml
+++ b/.azure-pipelines/build-swss-template.yml
@@ -97,10 +97,10 @@ jobs:
       path: $(Build.ArtifactStagingDirectory)/download
       artifact: common-lib
       patterns: |
-        target/debs/buster/libnl-3*.deb
-        target/debs/buster/libnl-genl*.deb
-        target/debs/buster/libnl-route*.deb
-        target/debs/buster/libnl-nf*.deb
+        target/debs/${{ parameters.debianVersion }}/libnl-3*.deb
+        target/debs/${{ parameters.debianVersion }}/libnl-genl*.deb
+        target/debs/${{ parameters.debianVersion }}/libnl-route*.deb
+        target/debs/${{ parameters.debianVersion }}/libnl-nf*.deb
     displayName: "Download common libs"
 
   - script: |

--- a/.azure-pipelines/build-swss-template.yml
+++ b/.azure-pipelines/build-swss-template.yml
@@ -51,10 +51,9 @@ jobs:
   - checkout: sonic-swss
     submodules: true
     clean: true
-  - template: template-get-source-branch.yml
   - script: |
       set -ex
-      git checkout $(SOURCE_BRANCH)
+      git checkout $(BUILD_BRANCH)
       git submodule update
       git status
     displayName: Set up sonic-swss branch
@@ -96,7 +95,7 @@ jobs:
       project: build
       pipeline: Azure.sonic-buildimage.common_libs
       runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/$(SOURCE_BRANCH)'
+      runBranch: 'refs/heads/$(BUILD_BRANCH)'
       path: $(Build.ArtifactStagingDirectory)/download
       artifact: common-lib
       patterns: |

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -10,6 +10,7 @@ parameters:
   type: string
   values:
   - sonicbld
+  - sonic-common
   - default
   default: default
 

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -10,8 +10,6 @@ parameters:
   type: string
   values:
   - sonicbld
-  - sonicbld-arm64
-  - sonicbld-armhf
   - default
   default: default
 
@@ -29,18 +27,10 @@ parameters:
   type: boolean
   default: false
 
-- name: archive_gcov
-  type: boolean
-  default: false
-
 jobs:
 - job:
   displayName: ${{ parameters.arch }}
   timeoutInMinutes: ${{ parameters.timeout }}
-  variables:
-    DIFF_COVER_CHECK_THRESHOLD: 50
-    ${{ if eq(parameters.run_unit_test, true) }}:
-      DIFF_COVER_ENABLE: 'true'
 
   pool:
     ${{ if ne(parameters.pool, 'default') }}:
@@ -67,7 +57,7 @@ jobs:
       set -ex
       rm ../*.deb || true
       ./autogen.sh
-      fakeroot debian/rules DEB_CONFIGURE_EXTRA_FLAGS='--enable-code-coverage' CFLAGS="" CXXFLAGS="--coverage -fprofile-abs-path" LDFLAGS="--coverage -fprofile-abs-path" binary
+      dpkg-buildpackage -us -uc -b -j$(nproc)
       mv ../*.deb .
     displayName: "Compile sonic swss common with coverage enabled"
   - ${{ if eq(parameters.run_unit_test, true) }}:

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -63,16 +63,6 @@ jobs:
   - ${{ if eq(parameters.run_unit_test, true) }}:
     - script: |
         set -ex
-        git clone https://github.com/Spacetown/gcovr.git
-        cd gcovr/
-        git checkout origin/recursive_search_file
-        sudo pip3 install setuptools
-        sudo python3 setup.py install
-        cd ..
-        sudo rm -rf gcovr
-      displayName: "Install gcovr 5.0 with recursive fix"
-    - script: |
-        set -ex
         sudo pip install Pympler==0.8
         sudo apt-get install -y redis-server
         sudo sed -i 's/notify-keyspace-events ""/notify-keyspace-events AKE/' /etc/redis/redis.conf
@@ -86,24 +76,8 @@ jobs:
 
         ./tests/tests
         redis-cli FLUSHALL
-        pytest --cov=. --cov-report=xml
-        mv coverage.xml tests/coverage.xml
-        gcovr -r ./ -e ".*/swsscommon_wrap.cpp" --exclude-unreachable-branches --exclude-throw-branches -x --xml-pretty  -o coverage.xml
+        pytest
       displayName: "Run swss common unit tests"
   - publish: $(System.DefaultWorkingDirectory)/
     artifact: ${{ parameters.artifact_name }}
     displayName: "Archive swss common debian packages"
-  - ${{ if eq(parameters.archive_gcov, true) }}:
-    - script: |
-        set -ex
-        # Install .NET CORE
-        curl -sSL https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
-        sudo apt-add-repository https://packages.microsoft.com/debian/10/prod
-        sudo apt-get update
-        sudo apt-get install -y dotnet-sdk-5.0
-      displayName: "Install .NET CORE"
-    - task: PublishCodeCoverageResults@1
-      inputs:
-        codeCoverageTool: Cobertura
-        summaryFileLocation: '$(System.DefaultWorkingDirectory)/coverage.xml'
-      displayName: 'Publish test coverage'

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -60,7 +60,7 @@ jobs:
       ./autogen.sh
       dpkg-buildpackage -us -uc -b -j$(nproc)
       mv ../*.deb .
-    displayName: "Compile sonic swss common with coverage enabled"
+    displayName: "Compile sonic swss common"
   - ${{ if eq(parameters.run_unit_test, true) }}:
     - script: |
         set -ex

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -10,6 +10,8 @@ parameters:
   type: string
   values:
   - sonicbld
+  - sonicbld-arm64
+  - sonicbld-armhf
   - default
   default: default
 
@@ -27,21 +29,31 @@ parameters:
   type: boolean
   default: false
 
+- name: archive_gcov
+  type: boolean
+  default: false
+
 jobs:
 - job:
   displayName: ${{ parameters.arch }}
   timeoutInMinutes: ${{ parameters.timeout }}
+  variables:
+    DIFF_COVER_CHECK_THRESHOLD: 50
+    ${{ if eq(parameters.run_unit_test, true) }}:
+      DIFF_COVER_ENABLE: 'true'
 
   pool:
     ${{ if ne(parameters.pool, 'default') }}:
       name: ${{ parameters.pool }}
-    ${{ if eq(parameters.pool, 'default') }}:
+    ${{ else }}:
       vmImage: 'ubuntu-20.04'
 
   container:
     image: sonicdev-microsoft.azurecr.io:443/${{ parameters.sonic_slave }}:latest
 
   steps:
+  - checkout: self
+    clean: true
   - script: |
       sudo apt-get install -qq -y \
         libhiredis-dev \
@@ -52,11 +64,25 @@ jobs:
         swig3.0
     displayName: "Install dependencies"
   - script: |
+      set -ex
+      rm ../*.deb || true
       ./autogen.sh
-      dpkg-buildpackage -us -uc -b -j$(nproc) && cp ../*.deb .
-    displayName: "Compile sonic swss common"
+      fakeroot debian/rules DEB_CONFIGURE_EXTRA_FLAGS='--enable-code-coverage' CFLAGS="" CXXFLAGS="--coverage -fprofile-abs-path" LDFLAGS="--coverage -fprofile-abs-path" binary
+      mv ../*.deb .
+    displayName: "Compile sonic swss common with coverage enabled"
   - ${{ if eq(parameters.run_unit_test, true) }}:
     - script: |
+        set -ex
+        git clone https://github.com/Spacetown/gcovr.git
+        cd gcovr/
+        git checkout origin/recursive_search_file
+        sudo pip3 install setuptools
+        sudo python3 setup.py install
+        cd ..
+        sudo rm -rf gcovr
+      displayName: "Install gcovr 5.0 with recursive fix"
+    - script: |
+        set -ex
         sudo pip install Pympler==0.8
         sudo apt-get install -y redis-server
         sudo sed -i 's/notify-keyspace-events ""/notify-keyspace-events AKE/' /etc/redis/redis.conf
@@ -68,8 +94,26 @@ jobs:
         sudo dpkg -i libswsscommon_*.deb
         sudo dpkg -i python-swsscommon_*.deb
 
-        sudo ./tests/tests && redis-cli FLUSHALL && pytest
+        ./tests/tests
+        redis-cli FLUSHALL
+        pytest --cov=. --cov-report=xml
+        mv coverage.xml tests/coverage.xml
+        gcovr -r ./ -e ".*/swsscommon_wrap.cpp" --exclude-unreachable-branches --exclude-throw-branches -x --xml-pretty  -o coverage.xml
       displayName: "Run swss common unit tests"
   - publish: $(System.DefaultWorkingDirectory)/
     artifact: ${{ parameters.artifact_name }}
     displayName: "Archive swss common debian packages"
+  - ${{ if eq(parameters.archive_gcov, true) }}:
+    - script: |
+        set -ex
+        # Install .NET CORE
+        curl -sSL https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
+        sudo apt-add-repository https://packages.microsoft.com/debian/10/prod
+        sudo apt-get update
+        sudo apt-get install -y dotnet-sdk-5.0
+      displayName: "Install .NET CORE"
+    - task: PublishCodeCoverageResults@1
+      inputs:
+        codeCoverageTool: Cobertura
+        summaryFileLocation: '$(System.DefaultWorkingDirectory)/coverage.xml'
+      displayName: 'Publish test coverage'

--- a/.azure-pipelines/template-get-source-branch.yml
+++ b/.azure-pipelines/template-get-source-branch.yml
@@ -1,9 +1,0 @@
-steps:
-  - script: |
-      sourceBranch=$(Build.SourceBranchName)
-      if [[ "$(Build.Reason)" == "PullRequest" ]];then
-        sourceBranch=$(System.PullRequest.TargetBranch)
-      fi
-      echo "Download artifact branch: $sourceBranch"
-      echo "##vso[task.setvariable variable=SOURCE_BRANCH]$sourceBranch"
-    displayName: "Set SOURCE_BRANCH variable"

--- a/.azure-pipelines/template-get-source-branch.yml
+++ b/.azure-pipelines/template-get-source-branch.yml
@@ -1,0 +1,9 @@
+steps:
+  - script: |
+      sourceBranch=$(Build.SourceBranchName)
+      if [[ "$(Build.Reason)" == "PullRequest" ]];then
+        sourceBranch=$(System.PullRequest.TargetBranch)
+      fi
+      echo "Download artifact branch: $sourceBranch"
+      echo "##vso[task.setvariable variable=SOURCE_BRANCH]$sourceBranch"
+    displayName: "Set SOURCE_BRANCH variable"

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -26,7 +26,7 @@ jobs:
       set -ex
       cd sonic-swss
       git checkout $(SOURCE_BRANCH)
-    displayName: Set up sonic-sairedis branch
+    displayName: Set up sonic-swss branch
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: docker-sonic-vs

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -20,11 +20,10 @@ jobs:
   - checkout: sonic-swss
     clean: true
     displayName: "Checkout sonic-swss"
-  - template: template-get-source-branch.yml
   - script: |
       set -ex
       cd sonic-swss
-      git checkout $(SOURCE_BRANCH)
+      git checkout $(BUILD_BRANCH)
     displayName: Set up sonic-swss branch
   - task: DownloadPipelineArtifact@2
     inputs:

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -39,7 +39,7 @@ jobs:
     displayName: "Download pre-stage built sonic-swss-common.amd64.ubuntu20_04"
 
   - script: |
-      set -x
+      set -ex
       ls -l
       sudo sonic-swss-common/.azure-pipelines/build_and_install_module.sh
 
@@ -54,7 +54,7 @@ jobs:
     displayName: "Install dependencies"
 
   - script: |
-      set -x
+      set -ex
       sudo docker load -i $(Build.ArtifactStagingDirectory)/download/docker-sonic-vs.gz
       docker ps
       ip netns list

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -11,8 +11,7 @@ jobs:
   displayName: vstest
   timeoutInMinutes: ${{ parameters.timeout }}
 
-  pool:
-    vmImage: 'ubuntu-20.04'
+  pool: sonic-common
 
   steps:
   - checkout: self

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -21,6 +21,12 @@ jobs:
   - checkout: sonic-swss
     clean: true
     displayName: "Checkout sonic-swss"
+  - template: template-get-source-branch.yml
+  - script: |
+      set -ex
+      cd sonic-swss
+      git checkout $(SOURCE_BRANCH)
+    displayName: Set up sonic-sairedis branch
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: docker-sonic-vs

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -1,7 +1,7 @@
 parameters:
 - name: timeout
   type: number
-  default: 360
+  default: 180
 
 - name: log_artifact_name
   type: string
@@ -11,12 +11,10 @@ jobs:
   displayName: vstest
   timeoutInMinutes: ${{ parameters.timeout }}
 
-  pool: sonic-common
+  pool:
+    vmImage: 'ubuntu-20.04'
 
   steps:
-  - script: |
-      ls -A1 | xargs -I{} sudo rm -rf {}
-    displayName: "Clean workspace"
   - checkout: self
     clean: true
     displayName: "Checkout sonic-swss-common"

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -1,7 +1,7 @@
 parameters:
 - name: timeout
   type: number
-  default: 180
+  default: 360
 
 - name: log_artifact_name
   type: string
@@ -11,24 +11,28 @@ jobs:
   displayName: vstest
   timeoutInMinutes: ${{ parameters.timeout }}
 
-  pool:
-    vmImage: 'ubuntu-20.04'
+  pool: sonic-common
 
   steps:
+  - script: |
+      ls -A1 | xargs -I{} sudo rm -rf {}
+    displayName: "Clean workspace"
+  - checkout: self
+    clean: true
+    displayName: "Checkout sonic-swss-common"
+  - checkout: sonic-swss
+    clean: true
+    displayName: "Checkout sonic-swss"
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: docker-sonic-vs
-    displayName: "Download docker sonic vs image"
-
+      path: $(Build.ArtifactStagingDirectory)/download
+    displayName: "Download pre-stage built docker-sonic-vs"
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: sonic-swss-common.amd64.ubuntu20_04
-    displayName: "Download sonic swss common deb packages"
-
-  - checkout: self
-    displayName: "Checkout sonic-swss-common"
-  - checkout: sonic-swss
-    displayName: "Checkout sonic-swss"
+      path: $(Build.ArtifactStagingDirectory)/download
+    displayName: "Download pre-stage built sonic-swss-common.amd64.ubuntu20_04"
 
   - script: |
       set -x
@@ -36,8 +40,8 @@ jobs:
       sudo sonic-swss-common/.azure-pipelines/build_and_install_module.sh
 
       sudo apt-get install -y libhiredis0.14
-      sudo dpkg -i --force-confask,confnew ../libswsscommon_1.0.0_amd64.deb || apt-get install -f
-      sudo dpkg -i ../python3-swsscommon_1.0.0_amd64.deb
+      sudo dpkg -i --force-confask,confnew $(Build.ArtifactStagingDirectory)/download/libswsscommon_1.0.0_amd64.deb || apt-get install -f
+      sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/python3-swsscommon_1.0.0_amd64.deb
 
       # install packages for vs test
       sudo apt-get install -y net-tools bridge-utils vlan
@@ -47,11 +51,12 @@ jobs:
 
   - script: |
       set -x
-      sudo docker load -i ../docker-sonic-vs.gz
+      sudo docker load -i $(Build.ArtifactStagingDirectory)/download/docker-sonic-vs.gz
       docker ps
       ip netns list
       pushd sonic-swss/tests
       sudo py.test -v --force-flaky --junitxml=tr.xml --imgname=docker-sonic-vs:$(Build.DefinitionName).$(Build.BuildNumber)
+      rm -rf $(Build.ArtifactStagingDirectory)/download
     displayName: "Run vs tests"
 
   - task: PublishTestResults@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,7 +35,7 @@ resources:
     endpoint: build
 
 parameters:
-  - name: debian-version
+  - name: debianVersion
     value: string
     default: buster
 
@@ -73,7 +73,7 @@ stages:
     parameters:
       arch: amd64
       pool: sonic-common
-      sonic_slave: sonic-slave-${{ parameters.debian-version }}
+      sonic_slave: sonic-slave-${{ parameters.debianVersion }}
       artifact_name: sonic-swss-common
       run_unit_test: true
 
@@ -86,7 +86,7 @@ stages:
       arch: armhf
       timeout: 180
       pool: sonicbld
-      sonic_slave: sonic-slave-${{ parameters.debian-version }}-armhf
+      sonic_slave: sonic-slave-${{ parameters.debianVersion }}-armhf
       artifact_name: sonic-swss-common.armhf
 
   - template: .azure-pipelines/build-template.yml
@@ -94,7 +94,7 @@ stages:
       arch: arm64
       timeout: 180
       pool: sonicbld
-      sonic_slave: sonic-slave-${{ parameters.debian-version }}-arm64
+      sonic_slave: sonic-slave-${{ parameters.debianVersion }}-arm64
       artifact_name: sonic-swss-common.arm64
 
 - stage: BuildSairedis
@@ -104,7 +104,7 @@ stages:
   - template: .azure-pipelines/build-sairedis-template.yml
     parameters:
       arch: amd64
-      sonic_slave: sonic-slave-${{ parameters.debian-version }}
+      sonic_slave: sonic-slave-${{ parameters.debianVersion }}
       swss_common_artifact_name: sonic-swss-common
       artifact_name: sonic-sairedis
       syslog_artifact_name: sonic-sairedis.syslog
@@ -116,7 +116,7 @@ stages:
   - template: .azure-pipelines/build-swss-template.yml
     parameters:
       arch: amd64
-      sonic_slave: sonic-slave-${{ parameters.debian-version }}
+      sonic_slave: sonic-slave-${{ parameters.debianVersion }}
       swss_common_artifact_name: sonic-swss-common
       sairedis_artifact_name: sonic-sairedis
       artifact_name: sonic-swss

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,22 +54,13 @@ stages:
         sudo apt-get install -y python3-pip
         sudo pip3 install pytest
         sudo apt-get install -y python
-        sudo apt-get install cmake libgtest-dev libgmock-dev
+        sudo apt-get install cmake libgtest-dev
         cd /usr/src/gtest && sudo cmake . && sudo make
-        ARCH=$(dpkg --print-architecture)
-        set -x
-        sudo curl -fsSL -o /usr/local/bin/bazel \
-            https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-${ARCH}
-        sudo chmod 755 /usr/local/bin/bazel
       displayName: "Install dependencies"
     - script: |
         ./autogen.sh
         dpkg-buildpackage -rfakeroot -us -uc -b -j$(nproc) && cp ../*.deb .
       displayName: "Compile sonic swss common"
-    - script: |
-        bazel build //...
-        bazel test //...
-      displayName: "Compile and test all Bazel targets"
     - publish: $(System.DefaultWorkingDirectory)/
       artifact: sonic-swss-common.amd64.ubuntu20_04
       displayName: "Archive swss common debian packages"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,7 +36,7 @@ resources:
 
 parameters:
   - name: debianVersion
-    value: string
+    type: string
     default: buster
 
 stages:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,7 +35,7 @@ resources:
     endpoint: build
 
 parameters:
-  - name: debianVersion
+  - name: debian_version
     type: string
     default: buster
 
@@ -73,7 +73,7 @@ stages:
     parameters:
       arch: amd64
       pool: sonic-common
-      sonic_slave: sonic-slave-${{ parameters.debianVersion }}
+      sonic_slave: sonic-slave-${{ parameters.debian_version }}
       artifact_name: sonic-swss-common
       run_unit_test: true
 
@@ -86,7 +86,7 @@ stages:
       arch: armhf
       timeout: 180
       pool: sonicbld
-      sonic_slave: sonic-slave-${{ parameters.debianVersion }}-armhf
+      sonic_slave: sonic-slave-${{ parameters.debian_version }}-armhf
       artifact_name: sonic-swss-common.armhf
 
   - template: .azure-pipelines/build-template.yml
@@ -94,7 +94,7 @@ stages:
       arch: arm64
       timeout: 180
       pool: sonicbld
-      sonic_slave: sonic-slave-${{ parameters.debianVersion }}-arm64
+      sonic_slave: sonic-slave-${{ parameters.debian_version }}-arm64
       artifact_name: sonic-swss-common.arm64
 
 - stage: BuildSairedis
@@ -104,7 +104,7 @@ stages:
   - template: .azure-pipelines/build-sairedis-template.yml
     parameters:
       arch: amd64
-      sonic_slave: sonic-slave-${{ parameters.debianVersion }}
+      sonic_slave: sonic-slave-${{ parameters.debian_version }}
       swss_common_artifact_name: sonic-swss-common
       artifact_name: sonic-sairedis
       syslog_artifact_name: sonic-sairedis.syslog
@@ -116,10 +116,11 @@ stages:
   - template: .azure-pipelines/build-swss-template.yml
     parameters:
       arch: amd64
-      sonic_slave: sonic-slave-${{ parameters.debianVersion }}
+      sonic_slave: sonic-slave-${{ parameters.debian_version }}
       swss_common_artifact_name: sonic-swss-common
       sairedis_artifact_name: sonic-sairedis
       artifact_name: sonic-swss
+      debian_version: $${{ parameters.debian_version }}
 
 - stage: BuildDocker
   dependsOn: BuildSwss

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,9 +8,12 @@ pr:
 - 201???
 
 trigger:
-- master
-- 202???
-- 201???
+  batch: true
+  branches:
+    include:
+    - master
+    - 202???
+    - 201???
 
 # this part need to be set in UI
 schedules:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,6 +41,12 @@ parameters:
   - name: debian_version
     type: string
     default: buster
+variables:
+  - name: BUILD_BRANCH
+    ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+      value: $(System.PullRequest.TargetBranch)
+    ${{ else }}:
+      value: $(Build.SourceBranch)
 
 stages:
 - stage: Build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,6 +67,7 @@ stages:
   - template: .azure-pipelines/build-template.yml
     parameters:
       arch: amd64
+      pool: sonic-common
       sonic_slave: sonic-slave-buster
       artifact_name: sonic-swss-common
       run_unit_test: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,21 +2,34 @@
 # Build your C/C++ project with GCC using make.
 # Add steps that publish test results, save build artifacts, deploy, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/apps/c-cpp/gcc
+pr:
+- master
+- 202???
+- 201???
 
 trigger:
+- master
+- 202???
+- 201???
+
+# this part need to be set in UI
+schedules:
+- cron: "0 0 * * 6"
+  displayName: Weekly build
   branches:
     include:
-      - "*"
+    - master
+    - 202???
+    - 201???
+  always: true
 
 resources:
   repositories:
   - repository: sonic-sairedis
     type: github
-    ref: refs/heads/202012
     name: Azure/sonic-sairedis
     endpoint: build
   - repository: sonic-swss
-    ref: refs/heads/202012
     type: github
     name: Azure/sonic-swss
     endpoint: build
@@ -35,18 +48,28 @@ stages:
         sudo apt-get update
         sudo apt-get install -y make libtool m4 autoconf dh-exec debhelper cmake pkg-config \
                          libhiredis-dev libnl-3-dev libnl-genl-3-dev libnl-route-3-dev libnl-nf-3-dev swig3.0 \
-                         libpython2.7-dev libgtest-dev libboost-dev libboost1.71-dev
+                         libpython2.7-dev libboost-dev libboost1.71-dev
         sudo apt-get install -y sudo
         sudo apt-get install -y redis-server redis-tools
         sudo apt-get install -y python3-pip
         sudo pip3 install pytest
         sudo apt-get install -y python
-        sudo apt-get install cmake libgtest-dev
+        sudo apt-get install cmake libgtest-dev libgmock-dev
         cd /usr/src/gtest && sudo cmake . && sudo make
+        ARCH=$(dpkg --print-architecture)
+        set -x
+        sudo curl -fsSL -o /usr/local/bin/bazel \
+            https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-${ARCH}
+        sudo chmod 755 /usr/local/bin/bazel
       displayName: "Install dependencies"
     - script: |
+        ./autogen.sh
         dpkg-buildpackage -rfakeroot -us -uc -b -j$(nproc) && cp ../*.deb .
       displayName: "Compile sonic swss common"
+    - script: |
+        bazel build //...
+        bazel test //...
+      displayName: "Compile and test all Bazel targets"
     - publish: $(System.DefaultWorkingDirectory)/
       artifact: sonic-swss-common.amd64.ubuntu20_04
       displayName: "Archive swss common debian packages"
@@ -57,6 +80,7 @@ stages:
       sonic_slave: sonic-slave-buster
       artifact_name: sonic-swss-common
       run_unit_test: true
+      archive_gcov: true
 
 - stage: BuildArm
   dependsOn: Build
@@ -66,7 +90,7 @@ stages:
     parameters:
       arch: armhf
       timeout: 180
-      pool: sonicbld
+      pool: sonicbld-armhf
       sonic_slave: sonic-slave-buster-armhf
       artifact_name: sonic-swss-common.armhf
 
@@ -74,7 +98,7 @@ stages:
     parameters:
       arch: arm64
       timeout: 180
-      pool: sonicbld
+      pool: sonicbld-arm64
       sonic_slave: sonic-slave-buster-arm64
       artifact_name: sonic-swss-common.arm64
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,7 +58,6 @@ stages:
         cd /usr/src/gtest && sudo cmake . && sudo make
       displayName: "Install dependencies"
     - script: |
-        ./autogen.sh
         dpkg-buildpackage -rfakeroot -us -uc -b -j$(nproc) && cp ../*.deb .
       displayName: "Compile sonic swss common"
     - publish: $(System.DefaultWorkingDirectory)/
@@ -71,7 +70,6 @@ stages:
       sonic_slave: sonic-slave-buster
       artifact_name: sonic-swss-common
       run_unit_test: true
-      archive_gcov: true
 
 - stage: BuildArm
   dependsOn: Build
@@ -81,7 +79,7 @@ stages:
     parameters:
       arch: armhf
       timeout: 180
-      pool: sonicbld-armhf
+      pool: sonicbld
       sonic_slave: sonic-slave-buster-armhf
       artifact_name: sonic-swss-common.armhf
 
@@ -89,7 +87,7 @@ stages:
     parameters:
       arch: arm64
       timeout: 180
-      pool: sonicbld-arm64
+      pool: sonicbld
       sonic_slave: sonic-slave-buster-arm64
       artifact_name: sonic-swss-common.arm64
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,6 +34,11 @@ resources:
     name: Azure/sonic-swss
     endpoint: build
 
+parameters:
+  - name: debian-version
+    value: string
+    default: buster
+
 stages:
 - stage: Build
 
@@ -68,7 +73,7 @@ stages:
     parameters:
       arch: amd64
       pool: sonic-common
-      sonic_slave: sonic-slave-buster
+      sonic_slave: sonic-slave-${{ parameters.debian-version }}
       artifact_name: sonic-swss-common
       run_unit_test: true
 
@@ -81,7 +86,7 @@ stages:
       arch: armhf
       timeout: 180
       pool: sonicbld
-      sonic_slave: sonic-slave-buster-armhf
+      sonic_slave: sonic-slave-${{ parameters.debian-version }}-armhf
       artifact_name: sonic-swss-common.armhf
 
   - template: .azure-pipelines/build-template.yml
@@ -89,7 +94,7 @@ stages:
       arch: arm64
       timeout: 180
       pool: sonicbld
-      sonic_slave: sonic-slave-buster-arm64
+      sonic_slave: sonic-slave-${{ parameters.debian-version }}-arm64
       artifact_name: sonic-swss-common.arm64
 
 - stage: BuildSairedis
@@ -99,7 +104,7 @@ stages:
   - template: .azure-pipelines/build-sairedis-template.yml
     parameters:
       arch: amd64
-      sonic_slave: sonic-slave-buster
+      sonic_slave: sonic-slave-${{ parameters.debian-version }}
       swss_common_artifact_name: sonic-swss-common
       artifact_name: sonic-sairedis
       syslog_artifact_name: sonic-sairedis.syslog
@@ -111,7 +116,7 @@ stages:
   - template: .azure-pipelines/build-swss-template.yml
     parameters:
       arch: amd64
-      sonic_slave: sonic-slave-buster
+      sonic_slave: sonic-slave-${{ parameters.debian-version }}
       swss_common_artifact_name: sonic-swss-common
       sairedis_artifact_name: sonic-sairedis
       artifact_name: sonic-swss

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -120,7 +120,7 @@ stages:
       swss_common_artifact_name: sonic-swss-common
       sairedis_artifact_name: sonic-sairedis
       artifact_name: sonic-swss
-      debian_version: $${{ parameters.debian_version }}
+      debian_version: ${{ parameters.debian_version }}
 
 - stage: BuildDocker
   dependsOn: BuildSwss


### PR DESCRIPTION
1. Parameterize pipeline. When checkout new release branch, we don't need manually setup azp.
2. Use common lib pipeline instead of buildimage pipeline to get higher success rate.
3. Clean workspace when downloading external packages. This will ensure package version matching.