### PR TITLE
[cherry-pick] Define `TC_TO_DSCP_MAP` for DSCP rewriting for tunnel traffic

### DIFF
--- a/common/schema.h
+++ b/common/schema.h
@@ -244,6 +244,7 @@ namespace swss {
 #define CFG_WRED_PROFILE_TABLE_NAME                 "WRED_PROFILE"
 #define CFG_QUEUE_TABLE_NAME                        "QUEUE"
 #define CFG_DOT1P_TO_TC_MAP_TABLE_NAME              "DOT1P_TO_TC_MAP"
+#define CFG_TC_TO_DSCP_MAP_TABLE_NAME               "TC_TO_DSCP_MAP"
 
 #define CFG_BUFFER_POOL_TABLE_NAME                  "BUFFER_POOL"
 #define CFG_BUFFER_PROFILE_TABLE_NAME               "BUFFER_PROFILE"
@@ -289,7 +290,7 @@ namespace swss {
 #define CFG_MCLAG_TABLE_NAME                        "MCLAG_DOMAIN"
 #define CFG_MCLAG_INTF_TABLE_NAME                   "MCLAG_INTERFACE"
 #define CFG_MCLAG_UNIQUE_IP_TABLE_NAME              "MCLAG_UNIQUE_IP"
-  
+
 #define CFG_PORT_STORM_CONTROL_TABLE_NAME           "PORT_STORM_CONTROL"
 
 #define CFG_RATES_TABLE_NAME                        "RATES"


### PR DESCRIPTION
This PR is to cherry-pick #600 to `202012` branch.

The cherry-pick is not clean as the macros in `master` branch diffs from `202012`.

Signed-off-by: bingwang <wang.bing@microsoft.com>