### PR TITLE
selectabletimer: add mutex to start() and stop()

### DIFF
--- a/common/selectabletimer.cpp
+++ b/common/selectabletimer.cpp
@@ -21,7 +21,7 @@ SelectableTimer::SelectableTimer(const timespec& interval, int pri)
         SWSS_LOG_THROW("failed to create timerfd, errno: %s", strerror(errno));
     }
     setInterval(interval);
-    m_alive = false;
+    m_running = false;
 }
 
 SelectableTimer::~SelectableTimer()
@@ -38,7 +38,7 @@ SelectableTimer::~SelectableTimer()
 void SelectableTimer::start()
 {
     m_mutex.lock();
-    if (!m_alive)
+    if (!m_running)
     {
         // Set the timer interval and the timer is automatically started
         int rc = timerfd_settime(m_tfd, 0, &m_interval, NULL);
@@ -48,7 +48,7 @@ void SelectableTimer::start()
         }
         else
         {
-            m_alive = true;
+            m_running = true;
         }
     }
     m_mutex.unlock();
@@ -57,7 +57,7 @@ void SelectableTimer::start()
 void SelectableTimer::stop()
 {
     m_mutex.lock();
-    if (m_alive)
+    if (m_running)
     {
         // Set the timer interval and the timer is automatically started
         int rc = timerfd_settime(m_tfd, 0, &m_zero, NULL);
@@ -67,7 +67,7 @@ void SelectableTimer::stop()
         }
         else
         {
-            m_alive = false;
+            m_running = false;
         }
     }
     m_mutex.unlock();

--- a/common/selectabletimer.h
+++ b/common/selectabletimer.h
@@ -24,7 +24,7 @@ public:
 
 private:
     std::mutex m_mutex;
-    bool m_alive;
+    bool m_running;
     int m_tfd;
     itimerspec m_interval;
     itimerspec m_zero;

--- a/common/selectabletimer.h
+++ b/common/selectabletimer.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 #include <limits>
+#include <mutex>
 #include <sys/timerfd.h>
 #include "selectable.h"
 
@@ -22,6 +23,8 @@ public:
     uint64_t readData() override;
 
 private:
+    std::mutex m_mutex;
+    bool m_alive;
     int m_tfd;
     itimerspec m_interval;
     itimerspec m_zero;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -35,6 +35,7 @@ tests_SOURCES = redis_ut.cpp                \
                 boolean_ut.cpp              \
                 status_code_util_test.cpp   \
                 saiaclschema_ut.cpp         \
+                timer_ut.cpp                \
                 main.cpp
 
 tests_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(LIBNL_CFLAGS)

--- a/tests/redis_ut.cpp
+++ b/tests/redis_ut.cpp
@@ -653,42 +653,6 @@ TEST(DBConnector, selectableevent)
     EXPECT_EQ(value, 2);
 }
 
-TEST(DBConnector, selectabletimer)
-{
-    timespec interval = { .tv_sec = 1, .tv_nsec = 0 };
-    SelectableTimer timer(interval);
-
-    Select s;
-    s.addSelectable(&timer);
-    Selectable *sel;
-    int result;
-
-    // Wait a non started timer
-    result = s.select(&sel, 2000);
-    ASSERT_EQ(result, Select::TIMEOUT);
-
-    // Wait long enough so we got timer notification first
-    timer.start();
-    result = s.select(&sel, 2000);
-    ASSERT_EQ(result, Select::OBJECT);
-    ASSERT_EQ(sel, &timer);
-
-    // Wait short so we got select timeout first
-    result = s.select(&sel, 10);
-    ASSERT_EQ(result, Select::TIMEOUT);
-
-    // Wait long enough so we got timer notification first
-    result = s.select(&sel, 10000);
-    ASSERT_EQ(result, Select::OBJECT);
-    ASSERT_EQ(sel, &timer);
-
-    // Reset and wait long enough so we got timer notification first
-    timer.reset();
-    result = s.select(&sel, 10000);
-    ASSERT_EQ(result, Select::OBJECT);
-    ASSERT_EQ(sel, &timer);
-}
-
 TEST(Table, basic)
 {
     TableBasicTest("TABLE_UT_TEST", true);

--- a/tests/timer_ut.cpp
+++ b/tests/timer_ut.cpp
@@ -1,0 +1,61 @@
+#include <iostream>
+
+#include "common/dbconnector.h"
+#include "common/consumertable.h"
+#include "common/notificationconsumer.h"
+#include "common/select.h"
+#include "common/selectableevent.h"
+#include "common/selectabletimer.h"
+#include "common/subscriberstatetable.h"
+#include "common/netmsg.h"
+#include "common/netlink.h"
+#include "gtest/gtest.h"
+
+using namespace std;
+using namespace swss;
+
+TEST(TIMER, selectabletimer)
+{
+    timespec interval = { .tv_sec = 1, .tv_nsec = 0 };
+    SelectableTimer timer(interval);
+
+    Select s;
+    s.addSelectable(&timer);
+    Selectable *sel;
+    int result;
+
+    // Wait a non started timer
+    result = s.select(&sel, 2000);
+    ASSERT_EQ(result, Select::TIMEOUT);
+
+    // Wait long enough so we got timer notification first
+    timer.start();
+    result = s.select(&sel, 2000);
+    ASSERT_EQ(result, Select::OBJECT);
+    ASSERT_EQ(sel, &timer);
+
+    // Wait short so we got select timeout first
+    result = s.select(&sel, 10);
+    ASSERT_EQ(result, Select::TIMEOUT);
+
+    // Wait long enough so we got timer notification first
+    result = s.select(&sel, 10000);
+    ASSERT_EQ(result, Select::OBJECT);
+    ASSERT_EQ(sel, &timer);
+
+    // Reset and wait long enough so we got timer notification first
+    timer.reset();
+    result = s.select(&sel, 10000);
+    ASSERT_EQ(result, Select::OBJECT);
+    ASSERT_EQ(sel, &timer);
+
+    // Check if the timer gets reset by subsequent timer.start()
+    for (int t = 0; t < 2000; ++t)
+    {
+        timer.start();
+        usleep(1000);
+    }
+    result = s.select(&sel, 1);
+    ASSERT_EQ(result, Select::OBJECT);
+    ASSERT_EQ(sel, &timer);
+}

--- a/tests/timer_ut.cpp
+++ b/tests/timer_ut.cpp
@@ -1,14 +1,5 @@
-#include <iostream>
-
-#include "common/dbconnector.h"
-#include "common/consumertable.h"
-#include "common/notificationconsumer.h"
 #include "common/select.h"
-#include "common/selectableevent.h"
 #include "common/selectabletimer.h"
-#include "common/subscriberstatetable.h"
-#include "common/netmsg.h"
-#include "common/netlink.h"
 #include "gtest/gtest.h"
 
 using namespace std;


### PR DESCRIPTION
Add mutex protection to avoid having the timer expiration reset due to
subsequent calls of start()

Avoid having the timer expiration reset due to subsequent calls of start()

Add mutex protection to start() and stop()

Signed-off-by: Dante Su <dante.su@broadcom.com>