### PR TITLE
[ConfigDBConnector] typed_to_raw lowercase bool values according to orchanged expectations

### DIFF
--- a/common/configdb.h
+++ b/common/configdb.h
@@ -145,6 +145,8 @@ protected:
                 value = typed_data[key]
                 if type(value) is list:
                     raw_data[key+'@'] = ','.join(value)
+                elif type(value) is bool:
+                    raw_data[key] = 'true' if value else 'false'
                 else:
                     raw_data[key] = str(value)
             return raw_data


### PR DESCRIPTION
The original issue is that we observe "Parse error: Can't parse boolean value 'True'" syslog and improper cleanup during test_vrf2_fwd_pkts_with_ttl_1 run. 
More specifically applying this config:
```
{
    "VRF": {
        "Vrf1": {
            "v4": true,
            "v6": true,
            "ttl_action": "trap",
            "ip_opt_action": "trap"
        },
        "Vrf2": {
            "v4": true,
            "v6": true,
            "ttl_action": "trap",
            "ip_opt_action": "trap"
        }
    }
}
```
`sudo config load -y vrf_restore.json`

produces the following swss record:
`2022-05-16.13:36:51.280587|VRF_TABLE:Vrf2|SET|ip_opt_action:trap|ttl_action:trap|v4:True|v6:True
`
True/False breaks orchagend expectations on lowercase bool values.

Signed-off-by: Volodymyr Boyko <volodymyrx.boiko@intel.com>