### PR TITLE
Change PubSub::listen() exist on both SIGTERM and SIGINT and add Python signal handler support.

### DIFF
--- a/common/configdb.h
+++ b/common/configdb.h
@@ -94,7 +94,7 @@ protected:
             if init_data_handler:
                 init_data_handler(init_callback_data)
 
-            while not SignalHandlerHelper.checkSignal(SIGNAL_INT):
+            while not (SignalHandlerHelper.checkSignal(SIGNAL_INT) or SignalHandlerHelper.checkSignal(SIGNAL_TERM)):
                 item = self.pubsub.listen_message()
                 if 'type' not in item:
                     # When timeout or cancelled, item will not contains 'type' 

--- a/common/configdb.h
+++ b/common/configdb.h
@@ -94,7 +94,8 @@ protected:
             if init_data_handler:
                 init_data_handler(init_callback_data)
 
-            while not (SignalHandlerHelper.checkSignal(SIGNAL_INT) or SignalHandlerHelper.checkSignal(SIGNAL_TERM)):
+            while not (SignalHandlerHelper.checkSignal(SIGNAL_INT) or
+                        SignalHandlerHelper.checkSignal(SIGNAL_TERM)):
                 item = self.pubsub.listen_message()
                 if 'type' not in item:
                     # When timeout or cancelled, item will not contains 'type' 

--- a/common/pubsub.cpp
+++ b/common/pubsub.cpp
@@ -101,7 +101,7 @@ MessageResultPair PubSub::get_message_internal(double timeout)
             throw RedisError("Failed to select", m_subscribe->getContext());
 
         case Select::TIMEOUT:
-        case Select::SIGNALINT:
+        case Select::SIGNAL:
             return ret;
 
         case Select::OBJECT:
@@ -135,7 +135,7 @@ std::map<std::string, std::string> PubSub::listen_message()
     for (;;)
     {
         ret = get_message_internal(GET_MESSAGE_INTERVAL);
-        if (!ret.second.empty() || ret.first == Select::SIGNALINT)
+        if (!ret.second.empty() || ret.first == Select::SIGNAL)
         {
             break;
         }

--- a/common/select.h
+++ b/common/select.h
@@ -30,7 +30,7 @@ public:
         OBJECT = 0,
         ERROR = 1,
         TIMEOUT = 2,
-        SIGNALINT = 3,// Read operation interrupted by SIGINT
+        SIGNAL = 3,// Read operation interrupted by SIGNAL
     };
 
     int select(Selectable **c, int timeout = -1);

--- a/common/signalhandlerhelper.cpp
+++ b/common/signalhandlerhelper.cpp
@@ -6,6 +6,7 @@ using namespace swss;
 
 std::map<int, bool> SignalHandlerHelper::m_signalStatusMapping;
 std::map<int, SigActionPair> SignalHandlerHelper::m_sigActionMapping;
+std::map<int, std::shared_ptr<SignalCallbackBase>> SignalHandlerHelper::m_sigCallbackMapping;
 
 void SignalHandlerHelper::registerSignalHandler(int signalNumber)
 {
@@ -33,6 +34,12 @@ void SignalHandlerHelper::registerSignalHandler(int signalNumber)
     m_sigActionMapping[signalNumber] = sig_action_pair;
 }
 
+void SignalHandlerHelper::registerSignalHandler(int signalNumber, std::shared_ptr<SignalCallbackBase> callback)
+{
+    m_sigCallbackMapping[signalNumber] = callback;
+    SignalHandlerHelper::registerSignalHandler(signalNumber);
+}
+
 void SignalHandlerHelper::restoreSignalHandler(int signalNumber)
 {
     auto result = m_sigActionMapping.find(signalNumber);
@@ -44,13 +51,21 @@ void SignalHandlerHelper::restoreSignalHandler(int signalNumber)
     }
 
     auto *old_action = &result->second.second;
-
     sigaction(signalNumber, old_action, NULL);
+
+    m_sigCallbackMapping.erase(signalNumber);
 }
 
 void SignalHandlerHelper::onSignal(int signalNumber)
 {
     m_signalStatusMapping[signalNumber] = true;
+
+    auto result = m_sigCallbackMapping.find(signalNumber);
+    if (result != m_sigCallbackMapping.end())
+    {
+        SWSS_LOG_DEBUG("call python signal handler for signal: %d.",signalNumber);
+        result->second->onSignal(signalNumber);
+    }
 }
 
 bool SignalHandlerHelper::checkSignal(int signalNumber)

--- a/pyext/py2/Makefile.am
+++ b/pyext/py2/Makefile.am
@@ -1,12 +1,18 @@
 SWIG_SOURCES = ../swsscommon.i
+SWIG_SIGNAL_SOURCES = ../signal.i
 
-pkgpython_PYTHON = swsscommon.py __init__.py
-pkgpyexec_LTLIBRARIES = _swsscommon.la
+pkgpython_PYTHON = swsscommon.py __init__.py signal.py
+pkgpyexec_LTLIBRARIES = _swsscommon.la _signal.la
 
 _swsscommon_la_SOURCES = swsscommon_wrap.cpp
 _swsscommon_la_CPPFLAGS = -std=c++11 -I../../common -I/usr/include/python$(PYTHON_VERSION)
 _swsscommon_la_LDFLAGS = -module
 _swsscommon_la_LIBADD = ../../common/libswsscommon.la -lpython$(PYTHON_VERSION)
+
+_signal_la_SOURCES = signal_wrap.cpp
+_signal_la_CPPFLAGS = -std=c++11 -I../../common -I/usr/include/python$(PYTHON_VERSION)
+_signal_la_LDFLAGS = -module
+_signal_la_LIBADD = ../../common/libswsscommon.la -lpython$(PYTHON_VERSION)
 
 SWIG_FLAG = -Wall -c++ -python -keyword
 if ARCH64
@@ -16,4 +22,7 @@ endif
 swsscommon_wrap.cpp: $(SWIG_SOURCES)
 	$(SWIG) $(SWIG_FLAG) -I../../common -o $@ $<
 
-CLEANFILES = swsscommon_wrap.cpp
+signal_wrap.cpp: $(SWIG_SIGNAL_SOURCES)
+	$(SWIG) $(SWIG_FLAG) -threads -I../../common -o $@ $<
+
+CLEANFILES = swsscommon_wrap.cpp signal_wrap.cpp

--- a/pyext/py3/Makefile.am
+++ b/pyext/py3/Makefile.am
@@ -1,12 +1,18 @@
 SWIG_SOURCES = ../swsscommon.i
+SWIG_SIGNAL_SOURCES = ../signal.i
 
-pkgpython3_PYTHON = swsscommon.py __init__.py
-pkgpy3exec_LTLIBRARIES = _swsscommon.la
+pkgpython3_PYTHON = swsscommon.py __init__.py signal.py
+pkgpy3exec_LTLIBRARIES = _swsscommon.la _signal.la
 
 _swsscommon_la_SOURCES = swsscommon_wrap.cpp
 _swsscommon_la_CPPFLAGS = -std=c++11 -I../../common -I/usr/include/python$(PYTHON3_VERSION)
 _swsscommon_la_LDFLAGS = -module
 _swsscommon_la_LIBADD = ../../common/libswsscommon.la $(PYTHON3_BLDLIBRARY)
+
+_signal_la_SOURCES = signal_wrap.cpp
+_signal_la_CPPFLAGS = -std=c++11 -I../../common -I/usr/include/python$(PYTHON3_VERSION)
+_signal_la_LDFLAGS = -module
+_signal_la_LIBADD = ../../common/libswsscommon.la $(PYTHON3_BLDLIBRARY)
 
 SWIG_FLAG = -Wall -c++ -python -keyword
 if ARCH64
@@ -16,4 +22,7 @@ endif
 swsscommon_wrap.cpp: $(SWIG_SOURCES)
 	$(SWIG) $(SWIG_FLAG) -I../../common -o $@ $<
 
-CLEANFILES = swsscommon_wrap.cpp
+signal_wrap.cpp: $(SWIG_SIGNAL_SOURCES)
+	$(SWIG) $(SWIG_FLAG) -threads -I../../common -o $@ $<
+
+CLEANFILES = swsscommon_wrap.cpp signal_wrap.cpp

--- a/pyext/signal.i
+++ b/pyext/signal.i
@@ -1,0 +1,30 @@
+%module signal
+// Enable directors feature for signal callback
+// Enable threads feature, because signal handler need cross threads.
+%module(directors="1","threads"=1) signal
+
+%rename(delete) del;
+
+%{
+// ref: http://www.swig.org/Doc3.0/Python.html
+// A Python 2 string is not a unicode string by default and should a Unicode
+// string be passed to C/C++ it will fail to convert to a C/C++ string (char *
+// or std::string types). The Python 2 behavior can be made more like Python 3
+// by defining SWIG_PYTHON_2_UNICODE when compiling the generated C/C++ code.
+// Unicode strings will be successfully accepted and converted from UTF-8, but
+// note that they are returned as a normal Python 2 string
+#define SWIG_PYTHON_2_UNICODE
+
+#include "signalhandlerhelper.h"
+%}
+
+%include <std_string.i>
+%include <std_map.i>
+%include <std_shared_ptr.i>
+%include <typemaps.i>
+%include <stdint.i>
+%include <exception.i>
+
+%shared_ptr(swss::SignalCallbackBase)
+%feature("director") swss::SignalCallbackBase;
+%include "signalhandlerhelper.h"

--- a/pyext/swsscommon.i
+++ b/pyext/swsscommon.i
@@ -1,5 +1,11 @@
 %module swsscommon
 
+// ConfigDBConnector using signal.SignalHandlerHelper
+%pythoncode %{
+from .signal import SignalHandlerHelper, SIGNAL_INT, SIGNAL_TERM
+%}
+
+
 %rename(delete) del;
 
 %{
@@ -19,7 +25,6 @@
 #include "pubsub.h"
 #include "select.h"
 #include "selectable.h"
-#include "signalhandlerhelper.h"
 #include "rediscommand.h"
 #include "table.h"
 #include "redispipeline.h"
@@ -155,7 +160,6 @@ T castSelectableObj(swss::Selectable *temp)
 %include "pubsub.h"
 %include "selectable.h"
 %include "select.h"
-%include "signalhandlerhelper.h"
 %include "rediscommand.h"
 %include "redispipeline.h"
 %include "redisselect.h"

--- a/tests/test_redis_ut.py
+++ b/tests/test_redis_ut.py
@@ -12,7 +12,8 @@ existing_file = "./tests/redis_multi_db_ut_config/database_config.json"
 
 @pytest.fixture(scope="session", autouse=True)
 def prepare(request):
-    SonicDBConfig.initialize(existing_file)
+    if not SonicDBConfig.isInit():
+        SonicDBConfig.initialize(existing_file)
 
 def test_ProducerTable():
     db = swsscommon.DBConnector("APPL_DB", 0, True)

--- a/tests/test_signalhandler_ut.py
+++ b/tests/test_signalhandler_ut.py
@@ -1,8 +1,11 @@
 import signal
 import os
 import pytest
+import time
+import threading
+
 from swsscommon import swsscommon
-from swsscommon.swsscommon import SignalHandlerHelper
+from swsscommon.swsscommon import SignalHandlerHelper, SonicV2Connector
 
 def dummy_signal_handler(signum, stack):
     # ignore signal so UT will not break
@@ -31,3 +34,33 @@ def test_SignalHandler():
     os.kill(os.getpid(), signal.SIGUSR1)
     happened = SignalHandlerHelper.checkSignal(signal.SIGUSR1)
     assert happened == False
+
+def pubsub_thread():
+    connector =swsscommon.ConfigDBConnector()
+    connector.subscribe('A', lambda a: None)
+    connector.connect()
+    connector.listen()
+
+def check_signal_can_break_pubsub(signalId):
+    signal.signal(signal.SIGUSR1, dummy_signal_handler)
+    SignalHandlerHelper.resetSignal(signalId)
+
+    test_thread = threading.Thread(target=pubsub_thread)
+    test_thread.start()
+
+    # check thread is running
+    time.sleep(2)
+    assert test_thread.is_alive() == True
+
+    # send SIGTERM and SIGINT will break test case, so send SIGUSR1 to trigger signal status check inside PubSub
+    SignalHandlerHelper.onSignal(signalId)
+    os.kill(os.getpid(), signal.SIGUSR1)
+
+    # check thread is stopped
+    time.sleep(2)
+    assert test_thread.is_alive() == False
+    SignalHandlerHelper.resetSignal(signalId)
+
+def test_SignalIntAndSigTerm():
+    check_signal_can_break_pubsub(signal.SIGINT)
+    check_signal_can_break_pubsub(signal.SIGTERM)


### PR DESCRIPTION
#### Why I did it
    Fix hostcfgd can't terminate by SIGTERM and SIGINT issue:
    https://github.com/Azure/sonic-swss-common/issues/603

    PubSub::listen() need exist when receive SIGTERM and SIGINT.

#### How I did it
    Change code to exist when receive SIGTERM and SIGINT.
    Add python signal handler support.

#### How to verify it
   1. manually test.
   2. Pass all test case.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

