### PR TITLE
Purge package sonic-db-cli which depends on libswsscommon

### DIFF
--- a/.azure-pipelines/docker-sonic-vs/Dockerfile
+++ b/.azure-pipelines/docker-sonic-vs/Dockerfile
@@ -4,14 +4,7 @@ ARG docker_container_name
 
 ADD ["debs", "/debs"]
 
-RUN dpkg --purge python-swsscommon
-RUN dpkg --purge python3-swsscommon
-RUN dpkg --purge swss
-RUN dpkg --purge libsairedis
-RUN dpkg --purge libswsscommon
-RUN dpkg --purge libsaimetadata
-RUN dpkg --purge libsaivs
-RUN dpkg --purge syncd-vs
+RUN dpkg --purge python-swsscommon python3-swsscommon swss libsairedis sonic-db-cli libswsscommon libsaimetadata libsaivs syncd-vs
 
 RUN dpkg -i /debs/libswsscommon_1.0.0_amd64.deb
 RUN dpkg -i /debs/python-swsscommon_1.0.0_amd64.deb


### PR DESCRIPTION
**What I did**
Purge package sonic-db-cli which depends on libswsscommon

**Why I did it**
Since sonic-db-cli depends on libswsscommon, we could not simply only purge libswsscommon, so we purge both together.

The build error is as below
```
Step 8/19 : RUN dpkg --purge libswsscommon
 ---> Running in ed8132d457e9
dpkg: dependency problems prevent removal of libswsscommon:
 sonic-db-cli depends on libswsscommon.

dpkg: error processing package libswsscommon (--purge):
 dependency problems - not removing
Errors were encountered while processing:
 libswsscommon
```

**How I verified it**

**Details if related**
