### PR TITLE
[portcounter] Check if counter ID exists before arithmetic operation 

### DIFF
--- a/common/portcounter.lua
+++ b/common/portcounter.lua
@@ -22,10 +22,14 @@ local gb_counter_list= {
 local function get_gbcounter(counter_id)
     local r = 0
     local counter = gb_counter_list[counter_id]
+    local num
     if counter then
         for i,id in ipairs(counter) do
             if #id > 0 then
-                r = r + redis.call('HGET', counters_table .. separator .. KEYS[i+1], id)
+                num = redis.call('HGET', counters_table .. separator .. KEYS[i+1], id)
+                if num then
+                    r = r + num
+                end
             end
         end
     end

--- a/tests/test_countertable.py
+++ b/tests/test_countertable.py
@@ -120,6 +120,18 @@ def test_port():
     assert r
     assert value == "2"
 
+    # Test if the counter is only on asic port
+    counterJabbersID = 'SAI_PORT_STAT_ETHER_STATS_JABBERS'
+    swsscommon.Table(db, "COUNTERS").hset(cache[portName], counterJabbersID, "1")
+    r, value = counterTable.hget(asicPort, portName, counterJabbersID)
+    assert r
+    assert value == "1"
+    r, value = counterTable.hget(PortCounter(), portName, counterJabbersID)
+    assert r
+    assert value == "1"
+    r, value = counterTable.hget(linesidePort, portName, counterJabbersID)
+    assert not r
+
     # Port Ethernet2 is only on asic
     portName = "Ethernet2"
     r, value = counterTable.hget(PortCounter(), portName, counterID)


### PR DESCRIPTION
In local function `get_gbcounter` of portcounter.lua, need to check the return value of redis HGET. We can do addition operation only if counter ID exists and returns its value number.