### PR TITLE
[azp] Fix the 'make check' failure at the step 'Compile sonic sairedis'

### DIFF
--- a/.azure-pipelines/build-sairedis-template.yml
+++ b/.azure-pipelines/build-sairedis-template.yml
@@ -104,7 +104,10 @@ jobs:
       set -ex
       rm ../*.deb || true
       ./autogen.sh
-      fakeroot dpkg-buildpackage -b -us -uc -Tbinary-syncd-vs -j$(nproc)
+      DEB_BUILD_OPTIONS=nocheck fakeroot dpkg-buildpackage -b -us -uc -Tbinary-syncd-vs -j$(nproc)
+      # Add SYS_TIME capability for settimeofday ok in syncd test
+      sudo setcap "cap_sys_time=eip" syncd/.libs/tests
+      make check
       mv ../*.deb .
     displayName: "Compile sonic sairedis"
   - script: |


### PR DESCRIPTION
Following https://github.com/Azure/sonic-sairedis/pull/1067 and https://github.com/Azure/sonic-sairedis/pull/1068, it fixes the below failure at `make check` of building syncd in step 'Compile sonic sairedis':

```
Making check in syncd
make[2]: Entering directory '/__w/1/s/syncd'
make check-TESTS
make[3]: Entering directory '/__w/1/s/syncd'
tests: tests.cpp:843: void test_watchdog_timer_clock_rollback(): Assertion `settimeofday(&currentTime, NULL) == 0' failed.
/bin/bash: line 5: 13004 Aborted (core dumped) ${dir}$tst
FAIL: tests
```


