### PR TITLE
Add lock to RedisContext to fix race condition

### DIFF
--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -498,6 +498,11 @@ string RedisContext::getClientName()
     }
 }
 
+recursive_mutex& RedisContext::getMutex()
+{
+    return m_mutex;
+}
+
 void DBConnector::select(DBConnector *db)
 {
     string select("SELECT ");

--- a/common/dbconnector.h
+++ b/common/dbconnector.h
@@ -127,6 +127,8 @@ public:
 
     std::string getClientName();
 
+    std::recursive_mutex& getMutex();
+
 protected:
     RedisContext();
     void initContext(const char *host, int port, const timeval *tv);
@@ -135,6 +137,7 @@ protected:
 
 private:
     redisContext *m_conn;
+    std::recursive_mutex m_mutex;
 };
 
 class DBConnector : public RedisContext

--- a/common/redisreply.cpp
+++ b/common/redisreply.cpp
@@ -33,6 +33,7 @@ inline void guard(FUNC func, const char* command)
 
 RedisReply::RedisReply(RedisContext *ctx, const RedisCommand& command)
 {
+    lock_guard<recursive_mutex> lockguard(ctx->getMutex());
     int rc = redisAppendFormattedCommand(ctx->getContext(), command.c_str(), command.length());
     if (rc != REDIS_OK)
     {
@@ -51,6 +52,7 @@ RedisReply::RedisReply(RedisContext *ctx, const RedisCommand& command)
 
 RedisReply::RedisReply(RedisContext *ctx, const string& command)
 {
+    lock_guard<recursive_mutex> lockguard(ctx->getMutex());
     int rc = redisAppendCommand(ctx->getContext(), command.c_str());
     if (rc != REDIS_OK)
     {


### PR DESCRIPTION
#### Why I did it
Fix race condition issue when parallel threads share same DBConnector and run concurrent redis commands.
Concurrent redis commands will read & write to same redis connection, and the command text and result data will fix together, which will cause unpredictable result:
1. Memory overflow.
2. Send invalid commands to command server side, and server will report error then break application.
2. Get unexpected command result from server side.

Following log is an example show how this happen:

```
// Thread A get ACL_RULE keys here:
Jun 17 06:01:48.093947 str-e1031-acs-3 ERR caclmgrd[900022]: :- get_table: [ACL TEST] ConfigDBConnector_Native::get_table ACL_RULE
Jun 17 06:01:48.094686 str-e1031-acs-3 ERR caclmgrd[900022]: :- keys: [ACL TEST] 862220847 DBConnector::keys ACL_RULE|*
Jun 17 06:01:48.095345 str-e1031-acs-3 ERR caclmgrd[900022]: :- format: [ACL TEST] 862220847 RedisCommand::format *2#015#012$4#015#012KEYS#015#012$10#015#012ACL_RULE|*#015#012, len: 31

// Thread B get policy_desc here:
Jun 17 06:01:48.111314 str-e1031-acs-3 ERR caclmgrd[900022]: :- hgetall: [ACL TEST] 862220847 DBConnector::hgetall start 
Jun 17 06:01:48.111556 str-e1031-acs-3 ERR caclmgrd[900022]: :- hgetall: [ACL TEST] 862220847 DBConnector::hgetall key: policy_desc
Jun 17 06:01:48.111815 str-e1031-acs-3 ERR caclmgrd[900022]: :- format: [ACL TEST] 862220847 RedisCommand::format *2#015#012$7#015#012HGETALL#015#012$11#015#012policy_desc#015#012, len: 35

// How the result is ACL_RULE, and there are 153 elements, which will break code, because current code make an assumption that result count always be even number.
Jun 17 06:01:48.112057 str-e1031-acs-3 ERR caclmgrd[900022]: :- hgetall: [ACL TEST] 862220847 DBConnector::hgetall result type: 2, count: 153
Jun 17 06:01:48.112296 str-e1031-acs-3 ERR caclmgrd[900022]: :- hgetall: [ACL TEST] 862220847 DBConnector::hgetall element: 0 : ACL_RULE|SSH_ONLY|RULE_1
Jun 17 06:01:48.112541 str-e1031-acs-3 ERR caclmgrd[900022]: :- hgetall: [ACL TEST] 862220847 DBConnector::hgetall element: 1 : ACL_RULE|SNMP_ACL|RULE_21
```

#### How I did it
Add lock to RedisContext, and lock context when run Redis command in RedisReply.

#### How to verify it
Pass all E2E test scenario.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111

#### Description for the changelog
Add lock to RedisContext.
Lock RedisContext when run Redis command in RedisReply.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

