### PR TITLE
Cherry-pick '[sonic-cli] Fix sonic-db-cli output format not backward compatible with python version issue.' from master branch.

### DIFF
--- a/common/redisreply.cpp
+++ b/common/redisreply.cpp
@@ -1,3 +1,4 @@
+#include <set>
 #include <string.h>
 #include <stdint.h>
 #include <vector>
@@ -5,15 +6,59 @@
 #include <sstream>
 #include <system_error>
 #include <functional>
+#include <boost/algorithm/string.hpp>
 
 #include "common/logger.h"
 #include "common/redisreply.h"
 #include "common/dbconnector.h"
 #include "common/rediscommand.h"
+#include "common/stringutility.h"
 
 using namespace std;
+using namespace boost;
 
 namespace swss {
+
+static set<string> g_intToBoolCommands = {
+                        "COPY",
+                        "EXPIRE",
+                        "EXPIREAT",
+                        "PEXPIRE",
+                        "PEXPIREAT",
+                        "HEXISTS",
+                        "MOVE",
+                        "MSETNX",
+                        "PERSIST",
+                        "RENAMENX",
+                        "SISMEMBER",
+                        "SMOVE",
+                        "SETNX"
+                        };
+
+static set<string> g_strToBoolCommands = {
+                        "AUTH",
+                        "HMSET",
+                        "PSETEX",
+                        "SETEX",
+                        "FLUSHALL",
+                        "FLUSHDB",
+                        "LSET",
+                        "LTRIM",
+                        "MSET",
+                        "PFMERGE",
+                        "ASKING",
+                        "READONLY",
+                        "READWRITE",
+                        "RENAME",
+                        "SAVE",
+                        "SELECT",
+                        "SHUTDOWN",
+                        "SLAVEOF",
+                        "SWAPDB",
+                        "WATCH",
+                        "UNWATCH",
+                        "SET"
+                        };
 
 template <typename FUNC>
 inline void guard(FUNC func, const char* command)
@@ -226,44 +271,193 @@ template<> RedisMessage RedisReply::getReply<RedisMessage>()
     return ret;
 }
 
-
 string RedisReply::to_string()
 {
-    return to_string(getContext());
+    return RedisReply::to_string(this->getContext());
 }
 
-string RedisReply::to_string(redisReply *reply)
+string RedisReply::to_string(redisReply *reply, string command)
 {
+    /*
+        Response format need keep as same as redis-py, redis-py using a command to result type mapping to convert result:
+            https://github.com/redis/redis-py/blob/bedf3c82a55b4b67eed93f686cb17e82f7ab19cd/redis/client.py#L682
+        Redis command result type can be found here:
+            https://redis.io/commands/
+        Only commands used by scripts in sonic repos are supported by these method.
+        For example: 'Info' command not used by any sonic scripts, so the output format will different with redis-py.
+    */
     switch(reply->type)
     {
     case REDIS_REPLY_INTEGER:
-        return std::to_string(reply->integer);
+        return formatReply(command, reply->integer);
 
     case REDIS_REPLY_STRING:
     case REDIS_REPLY_ERROR:
     case REDIS_REPLY_STATUS:
     case REDIS_REPLY_NIL:
-        return string(reply->str, reply->len);
+        return formatReply(command, reply->str, reply->len);
 
     case REDIS_REPLY_ARRAY:
     {
-        stringstream result;
-        for (size_t i = 0; i < reply->elements; i++)
-        {
-            result << to_string(reply->element[i]);
-
-            if (i < reply->elements - 1)
-            {
-                result << endl;
-            }
-        }
-        return result.str();
+        return formatReply(command, reply->element, reply->elements);
     }
 
     default:
         SWSS_LOG_ERROR("invalid type %d for message", reply->type);
         return string();
     }
+}
+
+string RedisReply::formatReply(string command, long long integer)
+{
+    if (g_intToBoolCommands.find(command) != g_intToBoolCommands.end())
+    {
+        if (integer == 1)
+        {
+            return string("True");
+        }
+        else if (integer == 0)
+        {
+            return string("False");
+        }
+    }
+    else if (command == "AUTH")
+    {
+        if (integer != 0)
+        {
+            return string("OK");
+        }
+    }
+
+    return std::to_string(integer);
+}
+
+string RedisReply::formatReply(string command, const char* str, size_t len)
+{
+    string result = string(str, len);
+    if (g_strToBoolCommands.find(command) != g_strToBoolCommands.end()
+        && result == "OK")
+    {
+        return string("True");
+    }
+
+    return result;
+}
+
+string RedisReply::formatReply(string command, struct redisReply **element, size_t elements)
+{
+    if (command == "HGETALL")
+    {
+        return formatDictReply(element, elements);
+    }
+    else if(command == "SCAN"
+            || command == "SSCAN")
+    {
+        return formatSscanReply(element, elements);
+    }
+    else if(command == "HSCAN")
+    {
+        return formatHscanReply(element, elements);
+    }
+    else if(command == "BLPOP"
+            || command == "BRPOP")
+    {
+        return formatTupleReply(element, elements);
+    }
+    else
+    {
+        return formatListReply(element, elements);
+    }
+}
+
+string RedisReply::formatSscanReply(struct redisReply **element, size_t elements)
+{
+    if (elements != 2)
+    {
+        throw system_error(make_error_code(errc::io_error),
+                           "Invalid result");
+    }
+
+    // format HSCAN result, here is a example:
+    //  (0, {'test3': 'test3', 'test2': 'test2'})
+    ostringstream result;
+    result << "(" << element[0]->integer << ", ";
+    // format the field mapping part
+    result << formatArrayReply(element[1]->element, element[1]->elements);
+    result << ")";
+
+    return result.str();
+}
+
+string RedisReply::formatHscanReply(struct redisReply **element, size_t elements)
+{
+    if (elements != 2)
+    {
+        throw system_error(make_error_code(errc::io_error),
+                           "Invalid result");
+    }
+
+    // format HSCAN result, here is a example:
+    //  (0, {'test3': 'test3', 'test2': 'test2'})
+    ostringstream result;
+    result << "(" << element[0]->integer << ", ";
+    // format the field mapping part
+    result << formatDictReply(element[1]->element, element[1]->elements);
+    result << ")";
+
+    return result.str();
+}
+
+string RedisReply::formatDictReply(struct redisReply **element, size_t elements)
+{
+    if (elements%2 != 0)
+    {
+        throw system_error(make_error_code(errc::io_error),
+                           "Invalid result");
+    }
+
+    // format dictionary, not using json.h because the output format are different, here is a example:
+    //      {'test3': 'test3', 'test2': 'test2'}
+    vector<string> elementvector;
+    for (unsigned int i = 0; i < elements; i += 2)
+    {
+        elementvector.push_back("'" + to_string(element[i]) + "': '" + to_string(element[i+1]) + "'");
+    }
+
+    return swss::join(", ", '{', '}', elementvector.begin(), elementvector.end());
+}
+
+string RedisReply::formatArrayReply(struct redisReply **element, size_t elements)
+{
+    vector<string> elementvector;
+    for (unsigned int i = 0; i < elements; i++)
+    {
+        elementvector.push_back("'" + to_string(element[i]) + "'");
+    }
+
+    return swss::join(", ", '[', ']', elementvector.begin(), elementvector.end());
+}
+
+string RedisReply::formatListReply(struct redisReply **element, size_t elements)
+{
+    vector<string> elementvector;
+    for (unsigned int i = 0; i < elements; i++)
+    {
+        elementvector.push_back(to_string(element[i]));
+    }
+
+    return swss::join("\n", elementvector.begin(), elementvector.end());
+}
+
+string RedisReply::formatTupleReply(struct redisReply **element, size_t elements)
+{
+    vector<string> elementvector;
+    for (unsigned int i = 0; i < elements; i++)
+    {
+        elementvector.push_back("'" + to_string(element[i]) + "'");
+    }
+
+    return swss::join(", ", '(', ')', elementvector.begin(), elementvector.end());
 }
 
 }

--- a/common/redisreply.h
+++ b/common/redisreply.h
@@ -94,11 +94,21 @@ public:
 
     std::string to_string();
 
-    static std::string to_string(redisReply *reply);
+    static std::string to_string(redisReply *reply, std::string command = std::string());
 
 private:
     void checkStatus(const char *status);
     void checkReply();
+
+    static std::string formatReply(std::string command, struct redisReply **element, size_t elements);
+    static std::string formatReply(std::string command, long long integer);
+    static std::string formatReply(std::string command, const char* str, size_t len);
+    static std::string formatSscanReply(struct redisReply **element, size_t elements);
+    static std::string formatHscanReply(struct redisReply **element, size_t elements);
+    static std::string formatDictReply(struct redisReply **element, size_t elements);
+    static std::string formatArrayReply(struct redisReply **element, size_t elements);
+    static std::string formatListReply(struct redisReply **element, size_t elements);
+    static std::string formatTupleReply(struct redisReply **element, size_t elements);
 
     redisReply *m_reply;
 };

--- a/common/stringutility.h
+++ b/common/stringutility.h
@@ -70,21 +70,21 @@ void lexical_convert(const std::vector<std::string> &strs, T &t, Args &... args)
 namespace join_detail
 {
 
-    template <typename T>
-    void join(std::ostringstream &ostream, char, const T &t)
+    template <typename D, typename T>
+    void join(std::ostringstream &ostream, D, const T &t)
     {
         ostream << t;
     }
 
-    template <typename T, typename... Args>
-    void join(std::ostringstream &ostream, char delimiter, const T &t, const Args &... args)
+    template <typename D, typename T, typename... Args>
+    void join(std::ostringstream &ostream, const D &delimiter, const T &t, const Args &... args)
     {
         ostream << t << delimiter;
         join(ostream, delimiter, args...);
     }
 
-    template <typename Iterator>
-    void join(std::ostringstream &ostream, char delimiter, Iterator begin, Iterator end)
+    template <typename D, typename Iterator>
+    void join(std::ostringstream &ostream, const D &delimiter, Iterator begin, Iterator end)
     {
         if (begin == end)
         {
@@ -99,21 +99,32 @@ namespace join_detail
     }
 }
 
-template <typename T, typename... Args>
-static inline std::string join(char delimiter, const T &t, const Args &... args)
+template <typename D, typename T, typename... Args>
+static inline std::string join(const D &delimiter, const T &t, const Args &... args)
 {
     std::ostringstream ostream;
     join_detail::join(ostream, delimiter, t, args...);
     return ostream.str();
 }
 
-template <typename Iterator>
-static inline std::string join(char delimiter, Iterator begin, Iterator end)
+template <typename D, typename Iterator>
+static inline std::string join(const D &delimiter, Iterator begin, Iterator end)
 {
     std::ostringstream ostream;
     join_detail::join(ostream, delimiter, begin, end);
     return ostream.str();
 }
+
+template <typename D, typename Iterator>
+static inline std::string join(const D &delimiter, char beginsym, char endsym, Iterator begin, Iterator end)
+{
+    std::ostringstream ostream;
+    ostream << beginsym;
+    join_detail::join(ostream, delimiter, begin, end);
+    ostream << endsym;
+    return ostream.str();
+}
+
 
 static inline bool hex_to_binary(const std::string &hex_str, std::uint8_t *buffer, size_t buffer_length)
 {

--- a/sonic-db-cli/sonic-db-cli.cpp
+++ b/sonic-db-cli/sonic-db-cli.cpp
@@ -2,6 +2,9 @@
 #include <iostream>
 #include <getopt.h>
 #include <list>
+#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/find.hpp>
+#include "common/redisreply.h"
 #include "sonic-db-cli.h"
 
 using namespace swss;
@@ -165,7 +168,8 @@ int executeCommands(
         based on our usage in SONiC, None and list type output from python API needs to be modified
         with these changes, it is enough for us to mimic redis-cli in SONiC so far since no application uses tty mode redis-cli output
         */
-        cout << reply.to_string() << endl;
+        auto commandName = getCommandName(commands);
+        cout << RedisReply::to_string(reply.getContext(), commandName) << endl;
     }
     catch (const std::system_error& e)
     {
@@ -327,4 +331,14 @@ int sonic_db_cli(
     }
 
     return 0;
+}
+
+string getCommandName(vector<string>& commands)
+{
+    if (commands.size() == 0)
+    {
+        return string();
+    }
+
+    return boost::to_upper_copy<string>(commands[0]);
 }

--- a/sonic-db-cli/sonic-db-cli.h
+++ b/sonic-db-cli/sonic-db-cli.h
@@ -53,3 +53,5 @@ int sonic_db_cli(
     char** argv,
     std::function<void()> initializeGlobalConfig,
     std::function<void()> initializeConfig);
+
+std::string getCommandName(std::vector<std::string>& command);


### PR DESCRIPTION
This PR is to cherry-pick #631 to `202111` branch.

[sonic-cli] Fix sonic-db-cli output format not backward compatible with python version issue. #631

Signed-off-by: qiluo-msft <qiluo@microsoft.com>, kcudnik <kcudnik@microsoft.com>