### PR TITLE
Add SonicV2Connector::set method for int value.

### DIFF
--- a/common/sonicv2connector.cpp
+++ b/common/sonicv2connector.cpp
@@ -102,7 +102,7 @@ int64_t SonicV2Connector_Native::set(const std::string& db_name, const std::stri
 
 int64_t SonicV2Connector_Native::set(const std::string& db_name, const std::string& _hash, const std::string& key, const int val, bool blocking)
 {
-    return m_dbintf.set(db_name, _hash, key, to_string(val), blocking);
+    return m_dbintf.set(db_name, _hash, key, std::to_string(val), blocking);
 }
 
 int64_t SonicV2Connector_Native::del(const std::string& db_name, const std::string& key, bool blocking)

--- a/common/sonicv2connector.cpp
+++ b/common/sonicv2connector.cpp
@@ -99,11 +99,6 @@ int64_t SonicV2Connector_Native::set(const std::string& db_name, const std::stri
     return m_dbintf.set(db_name, _hash, key, val, blocking);
 }
 
-int64_t SonicV2Connector_Native::set(const std::string& db_name, const std::string& _hash, const std::string& key, const int val, bool blocking)
-{
-    return m_dbintf.set(db_name, _hash, key, std::to_string(val), blocking);
-}
-
 int64_t SonicV2Connector_Native::del(const std::string& db_name, const std::string& key, bool blocking)
 {
     return m_dbintf.del(db_name, key, blocking);

--- a/common/sonicv2connector.cpp
+++ b/common/sonicv2connector.cpp
@@ -99,6 +99,11 @@ int64_t SonicV2Connector_Native::set(const std::string& db_name, const std::stri
     return m_dbintf.set(db_name, _hash, key, val, blocking);
 }
 
+int64_t SonicV2Connector_Native::set(const std::string& db_name, const std::string& _hash, const std::string& key, const int val, bool blocking)
+{
+    return m_dbintf.set(db_name, _hash, key, to_string(val), blocking);
+}
+
 int64_t SonicV2Connector_Native::del(const std::string& db_name, const std::string& key, bool blocking)
 {
     return m_dbintf.del(db_name, key, blocking);

--- a/common/sonicv2connector.cpp
+++ b/common/sonicv2connector.cpp
@@ -2,6 +2,7 @@
 #include "dbconnector.h"
 #include "logger.h"
 
+
 using namespace swss;
 
 SonicV2Connector_Native::SonicV2Connector_Native(bool use_unix_socket_path, const char *netns)

--- a/common/sonicv2connector.cpp
+++ b/common/sonicv2connector.cpp
@@ -2,7 +2,6 @@
 #include "dbconnector.h"
 #include "logger.h"
 
-
 using namespace swss;
 
 SonicV2Connector_Native::SonicV2Connector_Native(bool use_unix_socket_path, const char *netns)

--- a/common/sonicv2connector.h
+++ b/common/sonicv2connector.h
@@ -2,6 +2,7 @@
 
 #include <stdint.h>
 #include <unistd.h>
+#include <string>
 
 #include "dbinterface.h"
 

--- a/common/sonicv2connector.h
+++ b/common/sonicv2connector.h
@@ -46,8 +46,6 @@ public:
 
     int64_t set(const std::string& db_name, const std::string& _hash, const std::string& key, const std::string& val, bool blocking=false);
 
-    int64_t set(const std::string& db_name, const std::string& _hash, const std::string& key, const int val, bool blocking=false);
-
     int64_t del(const std::string& db_name, const std::string& key, bool blocking=false);
 
     void delete_all_by_pattern(const std::string& db_name, const std::string& pattern);
@@ -94,6 +92,12 @@ private:
 
         def keys(self, *args, **kwargs):
             return list(super(SonicV2Connector, self).keys(*args, **kwargs))
+
+        def set(self, db_name, _hash, key, value, blocking=False):
+			if isinstance(value, str):
+				return super(SonicV2Connector, self).get_all(db_name, _hash, key, value, blocking)
+			else:
+				return super(SonicV2Connector, self).get_all(db_name, _hash, key, str(value), blocking)
 %}
 #endif
 }

--- a/common/sonicv2connector.h
+++ b/common/sonicv2connector.h
@@ -45,6 +45,8 @@ public:
 
     int64_t set(const std::string& db_name, const std::string& _hash, const std::string& key, const std::string& val, bool blocking=false);
 
+    int64_t set(const std::string& db_name, const std::string& _hash, const std::string& key, const int val, bool blocking=false);
+
     int64_t del(const std::string& db_name, const std::string& key, bool blocking=false);
 
     void delete_all_by_pattern(const std::string& db_name, const std::string& pattern);

--- a/common/sonicv2connector.h
+++ b/common/sonicv2connector.h
@@ -94,10 +94,10 @@ private:
             return list(super(SonicV2Connector, self).keys(*args, **kwargs))
 
         def set(self, db_name, _hash, key, value, blocking=False):
-			if isinstance(value, str):
-				return super(SonicV2Connector, self).get_all(db_name, _hash, key, value, blocking)
-			else:
-				return super(SonicV2Connector, self).get_all(db_name, _hash, key, str(value), blocking)
+            if isinstance(value, str):
+                return super(SonicV2Connector, self).set(db_name, _hash, key, value, blocking)
+
+            return super(SonicV2Connector, self).set(db_name, _hash, key, str(value), blocking)
 %}
 #endif
 }

--- a/tests/test_redis_ut.py
+++ b/tests/test_redis_ut.py
@@ -687,3 +687,12 @@ def test_SonicDBConfigGetInstanceList():
     assert instanceList['redis'].unixSocketPath == '/var/run/redis/redis.sock'
     assert instanceList['redis'].hostname == '127.0.0.1'
     assert instanceList['redis'].port == 6379
+
+
+def test_SonicV2Connector():
+    db = SonicV2Connector(use_unix_socket_path=True)
+    db.connect("TEST_DB")
+    
+    db.set("TEST_DB", "test_key", "field1", 1)
+    value = db.get("TEST_DB", "test_key", "field1")
+    assert value == "1"


### PR DESCRIPTION
#### Why I did it
Following config command in sonic-utility using an API does not exist in swss-common:

sudo config rate smoothing-interval 100

https://github.com/Azure/sonic-utilities/blob/e089b964ef0d38d8c691eb3e551e479c0c68dd96/config/main.py#L6548
counters_db.set('COUNTERS_DB', 'RATES:PORT', 'PORT_SMOOTH_INTERVAL', interval) <== interval is an int value.

Currently swss-common only support string value:
int64_t SonicV2Connector_Native::set(const std::string& db_name, const std::string& _hash, const std::string& key, const std::string& val, bool blocking)


#### How I did it
Add SonicV2Connector::set method for int value.

#### How to verify it
Pass all test case.
Add UT to cover new API.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Add SonicV2Connector::set method for int value.

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)

