### PR TITLE
Fix PING database command not return bool string issue.

### DIFF
--- a/common/redisreply.cpp
+++ b/common/redisreply.cpp
@@ -340,6 +340,19 @@ string RedisReply::formatReply(string command, const char* str, size_t len)
     {
         return string("True");
     }
+    
+    if (command == "PING")
+    {
+        // In redis-py, result for PING was hard coded: https://github.com/redis/redis-py/blob/bedf3c82a55b4b67eed93f686cb17e82f7ab19cd/redis/client.py#L796
+        if (result == "PONG")
+        {
+            return string("True");
+        }
+        else
+        {
+            return string("False");
+        }
+    }
 
     return result;
 }

--- a/tests/cli_ut.cpp
+++ b/tests/cli_ut.cpp
@@ -249,12 +249,20 @@ TEST(sonic_db_cli, test_cli_help)
 
 TEST(sonic_db_cli, test_cli_ping_cmd)
 {
-    char *args[2];
+    char *args[3];
     args[0] = "sonic-db-cli";
     args[1] = "PING";
 
     auto output = runCli(2, args);
     EXPECT_EQ("PONG\n", output);
+
+    // When ping with DB name, result should be 'True'
+    args[0] = "sonic-db-cli";
+    args[1] = "TEST_DB";
+    args[2] = "PING";
+
+    output = runCli(3, args);
+    EXPECT_EQ("True\n", output);
 }
 
 TEST(sonic_db_cli, test_cli_save_cmd)


### PR DESCRIPTION
#### Why I did it
Fix sonic-db-cli issue on chassis:
[chassis]After sonic-db-cli C++ implementation, database.sh fails to start database-chassis on Supervisor card
https://github.com/Azure/sonic-buildimage/issues/11473

The reason of this issue is because c++ version sonic-db-cli output different with python version:

Here is Python version result:
admin@vlab-01:~$ /usr/local/bin/sonic-db-cli -s PING
PONG
admin@vlab-01:~$ /usr/local/bin/sonic-db-cli STATE_DB PING
True

Here is c++ version result:
admin@vlab-01:~$ /usr/local/sonic-db-cli -s PING
PONG
admin@vlab-01:~$ /usr/local/sonic-db-cli STATE_DB PING
PONG

#### How I did it
Change RedisReply::formatReply() to return bool string for PING command.

#### How to verify it
Pass all test case.
Add new UT cover change.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [x] 202111

#### Description for the changelog
Fix sonic-db-cli issue on chassis:
[chassis]After sonic-db-cli C++ implementation, database.sh fails to start database-chassis on Supervisor card
https://github.com/Azure/sonic-buildimage/issues/11473

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)

