### PR TITLE
Fix epoll and socket resource leak issue.

### DIFF
--- a/pyext/swsscommon.i
+++ b/pyext/swsscommon.i
@@ -142,6 +142,12 @@ T castSelectableObj(swss::Selectable *temp)
 %template(CastSelectableToRedisSelectObj) castSelectableObj<swss::RedisSelect *>;
 %template(CastSelectableToSubscriberTableObj) castSelectableObj<swss::SubscriberStateTable *>;
 
+// Handle object ownership issue with %newobject:
+//        https://www.swig.org/Doc4.0/SWIGDocumentation.html#Customization_ownership
+// %newobject must declared before %include header files
+%newobject swss::DBConnector::pubsub;
+%newobject swss::DBConnector::newConnector;
+
 %include "schema.h"
 %include "dbconnector.h"
 %include "sonicv2connector.h"
@@ -156,14 +162,6 @@ T castSelectableObj(swss::Selectable *temp)
 
 %extend swss::DBConnector {
     %template(hgetall) hgetall<std::map<std::string, std::string>>;
-}
-
-%extend swss::PubSub {
-%pythoncode {
-    def __del__(self):
-        self.__swig_destroy__(self.this)
-        del self.this
-}
 }
 
 %ignore swss::TableEntryPoppable::pops(std::deque<KeyOpFieldsValuesTuple> &, const std::string &);
@@ -218,7 +216,3 @@ T castSelectableObj(swss::Selectable *temp)
 %include "dbinterface.h"
 %include "logger.h"
 %include "status_code_util.h"
-
-// Handle object ownership issue with %newobject https://www.swig.org/Doc4.0/SWIGDocumentation.html#Customization_ownership
-%newobject DBConnector::pubsub();
-%newobject DBConnector::newConnector(unsigned int timeout);

--- a/pyext/swsscommon.i
+++ b/pyext/swsscommon.i
@@ -158,6 +158,14 @@ T castSelectableObj(swss::Selectable *temp)
     %template(hgetall) hgetall<std::map<std::string, std::string>>;
 }
 
+%extend swss::PubSub {
+%pythoncode {
+    def __del__(self):
+        self.__swig_destroy__(self.this)
+        del self.this
+}
+}
+
 %ignore swss::TableEntryPoppable::pops(std::deque<KeyOpFieldsValuesTuple> &, const std::string &);
 %apply std::vector<std::string>& OUTPUT {std::vector<std::string> &keys};
 %apply std::vector<std::string>& OUTPUT {std::vector<std::string> &ops};
@@ -210,3 +218,7 @@ T castSelectableObj(swss::Selectable *temp)
 %include "dbinterface.h"
 %include "logger.h"
 %include "status_code_util.h"
+
+// Handle object ownership issue with %newobject https://www.swig.org/Doc4.0/SWIGDocumentation.html#Customization_ownership
+%newobject DBConnector::pubsub();
+%newobject DBConnector::newConnector(unsigned int timeout);


### PR DESCRIPTION
#### Why I did it
Fix epoll and socket resurce leak issue:
[chassis] Too many open files error and unable to connect to redis socket error
https://github.com/Azure/sonic-buildimage/issues/10870

The reason of this issue is in SWIG any method return a new object need decorate with %newobject, so SWIG will generate code to release C++ object when python wrapper object released:
https://www.swig.org/Doc4.0/SWIGDocumentation.html#Customization_ownership


#### How I did it
Update swsscommon.i to decorate return new object methods with %newobject

#### How to verify it
Pass all test case.

Run following code in python and validate there is no epoll and socket leak:

from swsscommon.swsscommon import SonicDBConfig
from swsscommon.swsscommon import SonicV2Connector
import gc

SonicDBConfig.load_sonic_global_db_config()
SonicDBConfig.get_ns_list()
db = SonicV2Connector(use_unix_socket_path=True, namespace='')
db.connect("CONFIG_DB")
db.get_redis_client("CONFIG_DB")
client = db.get_redis_client("CONFIG_DB")
client.pubsub()
client.pubsub()
client.pubsub()
client.newConnector(0)
client.newConnector(0)
client.newConnector(0)

gc.collect()

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [x] 202111

#### Description for the changelog
Fix epoll and socket resurce leak issue:
[chassis] Too many open files error and unable to connect to redis socket error
https://github.com/Azure/sonic-buildimage/issues/10870

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)

