### PR TITLE
Harden module build script by specifying the source version to get

### DIFF
--- a/.azure-pipelines/build_and_install_module.sh
+++ b/.azure-pipelines/build_and_install_module.sh
@@ -3,15 +3,25 @@
 # build and install team/vrf driver
 #
 
-set -ex
+set -e
 
 source /etc/os-release
 
-function build_and_install_kmodule()
+trim() {
+    local var="$*"
+    # remove leading whitespace characters
+    var="${var#"${var%%[![:space:]]*}"}"
+    # remove trailing whitespace characters
+    var="${var%"${var##*[![:space:]]}"}"
+    printf '%s' "$var"
+}
+
+
+build_and_install_kmodule()
 {
     if sudo modprobe team 2>/dev/null && sudo modprobe vrf 2>/dev/null && sudo modprobe macsec 2>/dev/null; then
         echo "The module team, vrf and macsec exist."
-        return
+        return 0
     fi
 
     [ -z "$WORKDIR" ] && WORKDIR=$(mktemp -d)
@@ -30,31 +40,29 @@ function build_and_install_kmodule()
     apt-get install -y build-essential linux-headers-${KERNEL_RELEASE} autoconf pkg-config fakeroot
     apt-get install -y flex bison libssl-dev libelf-dev dwarves
     apt-get install -y libnl-route-3-200 libnl-route-3-dev libnl-cli-3-200 libnl-cli-3-dev libnl-3-dev
-    # Install libs required by libswsscommon for build
-    apt-get install -y libzmq3-dev libzmq5 libboost-serialization-dev uuid-dev
 
     # Add the apt source mirrors and download the linux image source code
     cp /etc/apt/sources.list /etc/apt/sources.list.bk
     sed -i "s/^# deb-src/deb-src/g" /etc/apt/sources.list
     apt-get update
-    KERNEL_PACKAGE_SOURCE=$(apt-cache show linux-image-unsigned-${KERNEL_RELEASE} | grep ^Source: | cut -d':' -f 2)
-    KERNEL_PACKAGE_VERSION=$(apt-cache show linux-image-unsigned-${KERNEL_RELEASE} | grep ^Version: | cut -d':' -f 2)
-    SOURCE_PACKAGE_VERSION=$(apt-cache showsrc ${KERNEL_PACKAGE_SOURCE} | grep ^Version: | cut -d':' -f 2)
-    if [ ${KERNEL_PACKAGE_VERSION} != ${SOURCE_PACKAGE_VERSION} ]; then
-        echo "WARNING: the running kernel version (${KERNEL_PACKAGE_VERSION}) doesn't match the source package " \
-            "version (${SOURCE_PACKAGE_VERSION}) being downloaded. There's no guarantee the module being downloaded " \
-            "can be loaded into the kernel or function correctly. If possible, please update your kernel and reboot " \
-            "your system so that it's running the matching kernel version." >&2
-        echo "Continuing with the build anyways" >&2
+    KERNEL_PACKAGE_SOURCE=$(trim $(apt-cache show linux-image-unsigned-${KERNEL_RELEASE} | grep ^Source: | cut -d':' -f 2))
+    KERNEL_PACKAGE_VERSION=$(trim $(apt-cache show linux-image-unsigned-${KERNEL_RELEASE} | grep ^Version: | cut -d':' -f 2))
+    SOURCE_PACKAGE_VERSION=$(apt-cache showsrc "${KERNEL_PACKAGE_SOURCE}" | grep ^Version: | cut -d':' -f 2 | tr '\n' ' ')
+    if ! echo "${SOURCE_PACKAGE_VERSION}" | grep "\b${KERNEL_PACKAGE_VERSION}\b"; then
+        echo "ERROR: the running kernel version (${KERNEL_PACKAGE_VERSION}) doesn't match any of the available source " \
+            "package versions (${SOURCE_PACKAGE_VERSION}) being downloaded. There's no guarantee any of the available " \
+            "source packages can be loaded into the kernel or function correctly. Please update your kernel and reboot " \
+            "your system so that it's running a matching kernel version." >&2
+        return 1
     fi
-    apt-get source linux-image-unsigned-${KERNEL_RELEASE} > source.log
+    apt-get source "linux-image-unsigned-${KERNEL_RELEASE}=${KERNEL_PACKAGE_VERSION}"
 
     # Recover the original apt sources list
     cp /etc/apt/sources.list.bk /etc/apt/sources.list
     apt-get update
 
     # Build the Linux kernel module drivers/net/team and vrf
-    cd $(find . -maxdepth 1 -type d | grep -v "^.$")
+    cd ${KERNEL_PACKAGE_SOURCE}-*
     if [ -e debian/debian.env ]; then
         source debian/debian.env
         if [ -n "${DEBIAN}" -a -e ${DEBIAN}/reconstruct ]; then


### PR DESCRIPTION
Harden module build script by specifying the source version to get

#### Why I did it
Fix vstest break because vrf module OOM

#### How I did it
Cherry-pick https://github.com/sonic-net/sonic-swss/pull/3723 to sonic-swss-repo

##### Work item tracking
- Microsoft ADO: 

#### How to verify it
Pass all test cases.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Harden module build script by specifying the source version to get

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

