### PR TITLE
ZMQ lib change to support one-to-one sync.

### DIFF
--- a/common/zmqclient.cpp
+++ b/common/zmqclient.cpp
@@ -16,7 +16,7 @@ using namespace std;
 namespace swss {
 
 ZmqClient::ZmqClient(const std::string& endpoint)
-:ZmqClient(endpoint, "")
+    : ZmqClient(endpoint, "")
 {
 }
 
@@ -26,7 +26,7 @@ ZmqClient::ZmqClient(const std::string& endpoint, const std::string& vrf)
 }
 
 ZmqClient::ZmqClient(const std::string& endpoint, uint32_t waitTimeMs)
-: m_waitTimeMs(waitTimeMs)
+    : m_waitTimeMs(waitTimeMs), m_oneToOneSync(m_waitTimeMs != 0)
 {
     initialize(endpoint);
 }
@@ -49,7 +49,7 @@ ZmqClient::~ZmqClient()
         zmq_ctx_destroy(m_context);
     }
 }
-    
+
 void ZmqClient::initialize(const std::string& endpoint, const std::string& vrf)
 {
     m_connected = false;
@@ -66,7 +66,7 @@ bool ZmqClient::isConnected()
 {
     return m_connected;
 }
-    
+
 void ZmqClient::connect()
 {
     if (m_connected)
@@ -90,17 +90,26 @@ void ZmqClient::connect()
         zmq_ctx_destroy(m_context);
     }
     
-    // ZMQ Client/Server are n:1 mapping, so need use PUSH/PULL pattern http://api.zeromq.org/master:zmq-socket
     m_context = zmq_ctx_new();
-    m_socket = zmq_socket(m_context, ZMQ_PUSH);
-    
+    if (m_oneToOneSync)
+    {
+        m_socket = zmq_socket(m_context, ZMQ_REQ);
+    }
+    else
+    {
+        m_socket = zmq_socket(m_context, ZMQ_PUSH);
+    }
+
     // timeout all pending send package, so zmq will not block in dtor of this class: http://api.zeromq.org/master:zmq-setsockopt
     int linger = 0;
     zmq_setsockopt(m_socket, ZMQ_LINGER, &linger, sizeof(linger));
 
-    // Increase send buffer for use all bandwidth: http://api.zeromq.org/4-2:zmq-setsockopt
-    int high_watermark = MQ_WATERMARK;
-    zmq_setsockopt(m_socket, ZMQ_SNDHWM, &high_watermark, sizeof(high_watermark));
+    if (!m_oneToOneSync)
+    {
+        // Increase send buffer for use all bandwidth: http://api.zeromq.org/4-2:zmq-setsockopt
+        int high_watermark = MQ_WATERMARK;
+        zmq_setsockopt(m_socket, ZMQ_SNDHWM, &high_watermark, sizeof(high_watermark));
+    }
 
     if (!m_vrf.empty())
     {
@@ -109,6 +118,7 @@ void ZmqClient::connect()
 
     SWSS_LOG_NOTICE("connect to zmq endpoint: %s", m_endpoint.c_str());
     int rc = zmq_connect(m_socket, m_endpoint.c_str());
+
     if (rc != 0)
     {
         m_connected = false;
@@ -150,7 +160,14 @@ void ZmqClient::sendMsg(
             std::lock_guard<std::mutex> lock(m_socketMutex);
 
             // Use none block mode to use all bandwidth: http://api.zeromq.org/2-1%3Azmq-send
-            rc = zmq_send(m_socket, m_sendbuffer.data(), serializedlen, ZMQ_NOBLOCK);
+            if (m_oneToOneSync)
+            {
+                rc = zmq_send(m_socket, m_sendbuffer.data(), serializedlen, 0);
+            }
+            else
+            {
+                rc = zmq_send(m_socket, m_sendbuffer.data(), serializedlen, ZMQ_NOBLOCK);
+            }
         }
         if (rc >= 0)
         {
@@ -202,11 +219,62 @@ void ZmqClient::sendMsg(
     throw system_error(make_error_code(errc::io_error), message);
 }
 
-// TODO: To be implemented later, required for ZMQ_CLIENT & ZMQ_SERVER
-// socket types in response path.
 bool ZmqClient::wait(
-    const std::string &dbName, const std::string &tableName,
-    const std::vector<std::shared_ptr<KeyOpFieldsValuesTuple>> &kcos) {
-  return false;
+    std::string &dbName, std::string &tableName,
+    std::vector<std::shared_ptr<KeyOpFieldsValuesTuple>> &kcos) {
+  SWSS_LOG_ENTER();
+
+  if (!m_oneToOneSync) {
+    return false;
+  }
+
+  zmq_pollitem_t items[1] = {};
+  items[0].socket = m_socket;
+  items[0].events = ZMQ_POLLIN;
+
+  int rc;
+
+  for (int i = 0; true; ++i) {
+    rc = zmq_poll(items, 1, (int)m_waitTimeMs);
+
+    if (rc == 0) {
+      SWSS_LOG_ERROR("zmq_poll timed out");
+      return false;
+    }
+    if (rc > 0) {
+      break;
+    }
+    if (zmq_errno() == EINTR && i <= MQ_MAX_RETRY) {
+      continue;
+    }
+    SWSS_LOG_THROW("zmq_poll failed, zmqerrno: %d", zmq_errno());
+  }
+
+  for (int i = 0; true; ++i) {
+    rc = zmq_recv(m_socket, m_sendbuffer.data(), m_sendbuffer.size(), 0);
+
+    if (rc < 0) {
+      if (zmq_errno() == EINTR && i <= MQ_MAX_RETRY) {
+        continue;
+      }
+      SWSS_LOG_THROW("zmq_recv failed, zmqerrno: %d", zmq_errno());
+    }
+    if (rc >= (int)m_sendbuffer.size()) {
+      SWSS_LOG_THROW(
+          "zmq_recv message was truncated (over %d bytes, received %d), "
+          "increase buffer size, message DROPPED",
+          (int)m_sendbuffer.size(), rc);
+    }
+    break;
+  }
+
+  m_sendbuffer.at(rc) =
+      0;  // make sure that we end string with zero before parse
+  kcos.clear();
+  BinarySerializer::deserializeBuffer(m_sendbuffer.data(), m_sendbuffer.size(),
+                                      dbName, tableName, kcos);
+
+  return true;
 }
+
 }

--- a/common/zmqclient.h
+++ b/common/zmqclient.h
@@ -15,6 +15,9 @@ public:
 
     ZmqClient(const std::string& endpoint);
     ZmqClient(const std::string& endpoint, const std::string& vrf);
+    // If waitTimeMs is set to non-zero, it will enable one-to-one sync with the
+    // server. It will use ZMQ_REQ and ZMQ_REP socket type. There can only be
+    // one client and one server for a ZMQ socket.
     ZmqClient(const std::string& endpoint, uint32_t waitTimeMs);
     ~ZmqClient();
 
@@ -26,9 +29,10 @@ public:
                  const std::string& tableName,
                  const std::vector<KeyOpFieldsValuesTuple>& kcos);
 
-    bool wait(const std::string& dbName,
-              const std::string& tableName,
-              const std::vector<std::shared_ptr<KeyOpFieldsValuesTuple>>& kcos);
+    // This method should only be used in one-to-one sync mode with the server.
+    bool wait(std::string& dbName,
+              std::string& tableName,
+              std::vector<std::shared_ptr<KeyOpFieldsValuesTuple>>& kcos);
 
 private:
     void initialize(const std::string& endpoint, const std::string& vrf = "");
@@ -43,7 +47,10 @@ private:
 
     bool m_connected;
 
-    uint32_t m_waitTimeMs;
+    // If this is set to zero, one-to-one sync is disabled.
+    uint32_t m_waitTimeMs = 0;
+
+    bool m_oneToOneSync = false;
 
     std::mutex m_socketMutex;
 

--- a/common/zmqproducerstatetable.cpp
+++ b/common/zmqproducerstatetable.cpp
@@ -164,9 +164,9 @@ void ZmqProducerStateTable::send(const std::vector<KeyOpFieldsValuesTuple> &kcos
     }
 }
 
-bool ZmqProducerStateTable::wait(const std::string& dbName,
-              const std::string& tableName,
-              const std::vector<std::shared_ptr<KeyOpFieldsValuesTuple>>& kcos)
+bool ZmqProducerStateTable::wait(std::string& dbName,
+                                 std::string& tableName,
+                                 std::vector<std::shared_ptr<KeyOpFieldsValuesTuple>>& kcos)
 {
     return m_zmqClient.wait(dbName, tableName, kcos);
 }

--- a/common/zmqproducerstatetable.h
+++ b/common/zmqproducerstatetable.h
@@ -38,9 +38,9 @@ public:
     virtual void send(const std::vector<KeyOpFieldsValuesTuple> &kcos);
 
     // To wait for the response from the peer.
-    virtual bool wait(const std::string& dbName,
-              const std::string& tableName,
-              const std::vector<std::shared_ptr<KeyOpFieldsValuesTuple>>& kcos);
+    virtual bool wait(std::string& dbName,
+                      std::string& tableName,
+                      std::vector<std::shared_ptr<KeyOpFieldsValuesTuple>>& kcos);
 
     size_t dbUpdaterQueueSize();
 private:

--- a/common/zmqserver.cpp
+++ b/common/zmqserver.cpp
@@ -13,21 +13,28 @@ using namespace std;
 namespace swss {
 
 ZmqServer::ZmqServer(const std::string& endpoint)
-    : ZmqServer(endpoint, "", false)
+    : ZmqServer(endpoint, "", false, false)
 {
 }
 
 ZmqServer::ZmqServer(const std::string& endpoint, const std::string& vrf)
-    : ZmqServer(endpoint, vrf, false)
+    : ZmqServer(endpoint, vrf, false, false)
 {
 }
 
 ZmqServer::ZmqServer(const std::string& endpoint, const std::string& vrf, bool lazyBind)
+    : ZmqServer(endpoint, vrf, lazyBind, false)
+{
+}
+
+ZmqServer::ZmqServer(const std::string& endpoint, const std::string& vrf, bool lazyBind, bool oneToOneSync)
     : m_mqPollThread(nullptr),
     m_endpoint(endpoint),
     m_vrf(vrf),
     m_context(nullptr),
-    m_socket(nullptr)
+    m_socket(nullptr),
+    m_oneToOneSync(oneToOneSync),
+    m_allowZmqPoll(true)
 {
     if (!lazyBind)
     {
@@ -39,6 +46,7 @@ ZmqServer::ZmqServer(const std::string& endpoint, const std::string& vrf, bool l
 
 ZmqServer::~ZmqServer()
 {
+    m_allowZmqPoll = true;
     m_runThread = false;
     if (m_mqPollThread)
     {
@@ -65,11 +73,22 @@ void ZmqServer::bind()
     }
 
     m_context = zmq_ctx_new();
-    m_socket = zmq_socket(m_context, ZMQ_PULL);
 
-    // Increase recv buffer for use all bandwidth:  http://api.zeromq.org/4-2:zmq-setsockopt
-    int high_watermark = MQ_WATERMARK;
-    zmq_setsockopt(m_socket, ZMQ_RCVHWM, &high_watermark, sizeof(high_watermark));
+    if(m_oneToOneSync)
+    {
+        m_socket = zmq_socket(m_context, ZMQ_REP);
+    }
+    else
+    {
+        m_socket = zmq_socket(m_context, ZMQ_PULL);
+    }
+
+    if (!m_oneToOneSync)
+    {
+        // Increase recv buffer for use all bandwidth:  http://api.zeromq.org/4-2:zmq-setsockopt
+        int high_watermark = MQ_WATERMARK;
+        zmq_setsockopt(m_socket, ZMQ_RCVHWM, &high_watermark, sizeof(high_watermark));
+    }
 
     if (!m_vrf.empty())
     {   
@@ -163,6 +182,8 @@ void ZmqServer::mqPollThread()
     SWSS_LOG_NOTICE("bind to zmq endpoint: %s", m_endpoint.c_str());
     while (m_runThread)
     {
+        m_allowZmqPoll = false;
+
         // receive message
         auto rc = zmq_poll(&poll_item, 1, 1000);
         if (rc == 0 || !(poll_item.revents & ZMQ_POLLIN))
@@ -173,7 +194,15 @@ void ZmqServer::mqPollThread()
         }
 
         // receive message
-        rc = zmq_recv(m_socket, m_buffer.data(), MQ_RESPONSE_MAX_COUNT, ZMQ_DONTWAIT);
+        if (m_oneToOneSync)
+        {
+            rc = zmq_recv(m_socket, m_buffer.data(), MQ_RESPONSE_MAX_COUNT, 0);
+        }
+        else
+        {
+            rc = zmq_recv(m_socket, m_buffer.data(), MQ_RESPONSE_MAX_COUNT, ZMQ_DONTWAIT);
+        }
+
         if (rc < 0)
         {
             int zmq_err = zmq_errno();
@@ -200,15 +229,79 @@ void ZmqServer::mqPollThread()
 
         // deserialize and write to redis:
         handleReceivedData(m_buffer.data(), rc);
+        while (m_oneToOneSync && !m_allowZmqPoll) {
+          usleep(10);
+        }
     }
     SWSS_LOG_NOTICE("mqPollThread end");
 }
 
-// TODO: To be implemented later, required for ZMQ_CLIENT & ZMQ_SERVER
-// socket types in response path.
 void ZmqServer::sendMsg(
     const std::string &dbName, const std::string &tableName,
-    const std::vector<swss::KeyOpFieldsValuesTuple> &values) {
-  return;
+    const std::vector<swss::KeyOpFieldsValuesTuple> &values)
+{
+  if (!m_oneToOneSync) {
+    return;
+  }
+
+  int serializedlen = (int)BinarySerializer::serializeBuffer(
+      m_buffer.data(), m_buffer.size(), dbName, tableName, values);
+
+  SWSS_LOG_DEBUG("sending: %d", serializedlen);
+  int zmq_err = 0;
+  int retry_delay = 10;
+  int rc = 0;
+  for (int i = 0; i <= MQ_MAX_RETRY; ++i) {
+    rc = zmq_send(m_socket, m_buffer.data(), serializedlen, 0);
+
+    if (rc >= 0) {
+      m_allowZmqPoll = true;
+      SWSS_LOG_DEBUG("zmq sent %d bytes", serializedlen);
+      return;
+    }
+
+    zmq_err = zmq_errno();
+    // sleep (2 ^ retry time) * 10 ms
+    retry_delay *= 2;
+    if (zmq_err == EINTR || zmq_err == EFSM) {
+      // EINTR: interrupted by signal
+      // EFSM: socket state not ready
+      //       For example when ZMQ socket still not receive reply message from
+      //       last sended package. There was state machine inside ZMQ socket,
+      //       when the socket is not in ready to send state, this error will
+      //       happen.
+      // for more detail, please check: http://api.zeromq.org/2-1:zmq-send
+      SWSS_LOG_DEBUG("zmq send retry, endpoint: %s, error: %d",
+                     m_endpoint.c_str(), zmq_err);
+
+      retry_delay = 0;
+    } else if (zmq_err == EAGAIN) {
+      // EAGAIN: ZMQ is full to need try again
+      SWSS_LOG_WARN("zmq is full, will retry in %d ms, endpoint: %s, error: %d",
+                    retry_delay, m_endpoint.c_str(), zmq_err);
+    } else if (zmq_err == ETERM) {
+      auto message = "zmq connection break, endpoint: " + m_endpoint +
+                     ", error: " + to_string(rc);
+      SWSS_LOG_ERROR("%s", message.c_str());
+      throw system_error(make_error_code(errc::connection_reset), message);
+    } else {
+      // for other error, send failed immediately.
+      auto message = "zmq send failed, endpoint: " + m_endpoint +
+                     ", error: " + to_string(rc);
+      SWSS_LOG_ERROR("%s", message.c_str());
+      throw system_error(make_error_code(errc::io_error), message);
+    }
+
+    usleep(retry_delay * 1000);
+  }
+
+  // failed after retry
+  auto message = "zmq send failed, endpoint: " + m_endpoint +
+                 ", zmqerrno: " + to_string(zmq_err) + ":" +
+                 zmq_strerror(zmq_err) +
+                 ", msg length:" + to_string(serializedlen);
+  SWSS_LOG_ERROR("%s", message.c_str());
+  throw system_error(make_error_code(errc::io_error), message);
 }
+
 }

--- a/common/zmqserver.h
+++ b/common/zmqserver.h
@@ -30,9 +30,13 @@ public:
     /* The default value of pop batch size is 128 */
     static constexpr int DEFAULT_POP_BATCH_SIZE = 128;
 
+    // If oneToOneSync is set to non-zero, it will enable one-to-one sync with
+    // the client. It will use ZMQ_REQ and ZMQ_REP socket type. There can only
+    // be one client and one server for a ZMQ socket.
     ZmqServer(const std::string& endpoint);
     ZmqServer(const std::string& endpoint, const std::string& vrf);
     ZmqServer(const std::string& endpoint, const std::string& vrf, bool lazyBind);
+    ZmqServer(const std::string& endpoint, const std::string& vrf, bool lazyBind, bool oneToOneSync);
     ~ZmqServer();
 
     void registerMessageHandler(
@@ -40,6 +44,7 @@ public:
                                 const std::string tableName,
                                 ZmqMessageHandler* handler);
 
+    // This method should only be used in one-to-one sync mode with the client.
     void sendMsg(const std::string& dbName, const std::string& tableName,
         const std::vector<swss::KeyOpFieldsValuesTuple>& values);
 
@@ -67,6 +72,10 @@ private:
     void* m_context;
 
     void* m_socket;
+
+    bool m_oneToOneSync = false;
+
+    bool m_allowZmqPoll;
 
     std::map<std::string, std::map<std::string, ZmqMessageHandler*>> m_HandlerMap;
 };

--- a/pyext/swsscommon.i
+++ b/pyext/swsscommon.i
@@ -54,7 +54,6 @@
 #include "redis_table_waiter.h"
 #include "restart_waiter.h"
 #include "zmqserver.h"
-#include "zmqclient.h"
 #include "zmqconsumerstatetable.h"
 #include "zmqproducerstatetable.h"
 #include <memory>
@@ -77,6 +76,8 @@
 %template(FieldValuePair) std::pair<std::string, std::string>;
 %template(FieldValuePairs) std::vector<std::pair<std::string, std::string>>;
 %template(FieldValuePairsList) std::vector<std::vector<std::pair<std::string, std::string>>>;
+%template(KeyFieldValuePairs) std::pair<std::string, std::vector<std::pair<std::string, std::string>>>;
+%template(KeyFieldValuePairsList) std::vector<std::pair<std::string, std::vector<std::pair<std::string, std::string>>>>;
 %template(FieldValueMap) std::map<std::string, std::string>;
 %template(VectorString) std::vector<std::string>;
 %template(ScanResult) std::pair<int64_t, std::vector<std::string>>;
@@ -290,6 +291,24 @@ T castSelectableObj(swss::Selectable *temp)
 %extend swss::DBConnector {
     %template(hgetall) hgetall<std::map<std::string, std::string>>;
 }
+
+%ignore swss::ZmqProducerStateTable::wait;
+
+%inline %{
+std::vector<std::pair<std::string, std::vector<swss::FieldValueTuple>>> zmqWait(swss::ZmqProducerStateTable &p)
+{
+    std::vector<std::pair<std::string, std::vector<swss::FieldValueTuple>>>  ret;
+    std::string db_name;
+    std::string table_name;
+    std::vector<std::shared_ptr<swss::KeyOpFieldsValuesTuple>> kcos_ptr;
+    p.wait(db_name, table_name, kcos_ptr);
+    for (const auto kco : kcos_ptr)
+    {
+        ret.push_back(std::pair<std::string, std::vector<swss::FieldValueTuple>>{kfvKey(*kco), kfvFieldsValues(*kco)});
+    }
+    return ret;
+}
+%}
 
 %ignore swss::TableEntryPoppable::pops(std::deque<KeyOpFieldsValuesTuple> &, const std::string &);
 %apply std::vector<std::string>& OUTPUT {std::vector<std::string> &keys};

--- a/tests/zmq_state_ut.cpp
+++ b/tests/zmq_state_ut.cpp
@@ -3,6 +3,8 @@
 #include <thread>
 #include <algorithm>
 #include <deque>
+#include <csignal>
+#include <unistd.h>
 #include <zmq.hpp>
 #include "gtest/gtest.h"
 #include "common/dbconnector.h"
@@ -59,7 +61,7 @@ static bool allDataReceived = false;
 static void producerWorker(string tableName, string endpoint, bool dbPersistence)
 {
     DBConnector db(TEST_DB, 0, true);
-    ZmqClient client(endpoint);
+    ZmqClient client(endpoint, 0);
     ZmqProducerStateTable p(&db, tableName, client, dbPersistence);
     cout << "Producer thread started: " << tableName << endl;
 
@@ -134,7 +136,7 @@ static void producerWorker(string tableName, string endpoint, bool dbPersistence
 static void producerBatchWorker(string tableName, string endpoint, bool dbPersistence)
 {
     DBConnector db(TEST_DB, 0, true);
-    ZmqClient client(endpoint);
+    ZmqClient client(endpoint, 0);
     ZmqProducerStateTable p(&db, tableName, client, dbPersistence);
     cout << "Producer thread started: " << tableName << endl;
     std::vector<KeyOpFieldsValuesTuple> kcos;
@@ -438,7 +440,7 @@ TEST(ZmqConsumerStateTableBatchBufferOverflow, test)
     std::string pushEndpoint = "tcp://localhost:1234";
 
     DBConnector db(TEST_DB, 0, true);
-    ZmqClient client(pushEndpoint);
+    ZmqClient client(pushEndpoint, 0);
     ZmqProducerStateTable p(&db, testTableName, client, true);
 
     // Send a large message and expect exception thrown.
@@ -460,7 +462,7 @@ TEST(ZmqProducerStateTableDeleteAfterSend, test)
     ZmqServer server(pullEndpoint);
 
     DBConnector db(TEST_DB, 0, true);
-    ZmqClient client(pushEndpoint);
+    ZmqClient client(pushEndpoint, 0);
 
     auto *p = new ZmqProducerStateTable(&db, testTableName, client, true);
     std::vector<FieldValueTuple> values;
@@ -479,95 +481,282 @@ TEST(ZmqProducerStateTableDeleteAfterSend, test)
 
 static bool zmq_done = false;
 
-static void zmqConsumerWorker(string tableName, string endpoint,
-                              bool dbPersistence) {
+static void zmqConsumerWorker(string tableName, string endpoint)
+{
   cout << "Consumer thread started: " << tableName << endl;
   DBConnector db(TEST_DB, 0, true);
-  ZmqServer server(endpoint, "");
-  ZmqConsumerStateTable c(&db, tableName, server, 128, 0, dbPersistence);
+  ZmqServer server(endpoint, "", false, true);
+  ZmqConsumerStateTable c(&db, tableName, server, 128, 0, false);
+  Select cs;
+  cs.addSelectable(&c);
+
   // validate received data
+  Selectable* selectcs;
+  std::deque<KeyOpFieldsValuesTuple> vkco;
+  int ret = 0;
+
+  while (!zmq_done) {
+    ret = cs.select(&selectcs, 10, true);
+    if (ret == Select::OBJECT) {
+      c.pops(vkco);
+      std::vector<swss::KeyOpFieldsValuesTuple> values;
+      values.push_back(KeyOpFieldsValuesTuple{
+          "k", SET_COMMAND,
+          std::vector<FieldValueTuple>{FieldValueTuple{"f", "v"}}});
+      server.sendMsg(TEST_DB, tableName, values);
+    }
+  }
+
+  allDataReceived = true;
+  cout << "Consumer thread ended: " << tableName << endl;
+}
+
+TEST(ZmqOneToOneSync, test)
+{
+  std::string testTableName = "ZMQ_PROD_CONS_UT";
+  std::string pushEndpoint = "tcp://localhost:1234";
+  std::string pullEndpoint = "tcp://*:1234";
+  // start consumer first, SHM can only have 1 consumer per table.
+  thread* consumerThread =
+      new thread(zmqConsumerWorker, testTableName, pullEndpoint);
+  // Wait for the consumer to be ready.
+  sleep(1);
+
+  DBConnector db(TEST_DB, 0, true);
+  ZmqClient client(pushEndpoint, 3000);
+  ZmqProducerStateTable p(&db, testTableName, client, false);
+  std::vector<KeyOpFieldsValuesTuple> kcos;
+  kcos.push_back(KeyOpFieldsValuesTuple{
+      "k", SET_COMMAND,
+      std::vector<FieldValueTuple>{FieldValueTuple{"f", "v"}}});
+  std::vector<std::shared_ptr<KeyOpFieldsValuesTuple>> kcos_p;
+
+  std::string dbName, tableName;
+  for (int i = 0; i < 3; ++i) {
+    p.send(kcos);
+    ASSERT_TRUE(p.wait(dbName, tableName, kcos_p));
+    EXPECT_EQ(dbName, TEST_DB);
+    EXPECT_EQ(tableName, testTableName);
+    ASSERT_EQ(kcos_p.size(), 1);
+    EXPECT_EQ(kfvKey(*kcos_p[0]), "k");
+    EXPECT_EQ(kfvOp(*kcos_p[0]), SET_COMMAND);
+    std::vector<FieldValueTuple> cos =
+        std::vector<FieldValueTuple>{FieldValueTuple{"f", "v"}};
+    EXPECT_EQ(kfvFieldsValues(*kcos_p[0]), cos);
+  }
+
+  zmq_done = true;
+  consumerThread->join();
+  delete consumerThread;
+}
+
+TEST(ZmqOneToOneSyncClientError, test)
+{
+  std::string testTableName = "ZMQ_PROD_CONS_UT";
+  std::string pushEndpoint = "tcp://localhost:1234";
+  DBConnector db(TEST_DB, 0, true);
+  ZmqClient client(pushEndpoint, 3000);
+  ZmqProducerStateTable p(&db, testTableName, client, true);
+  std::vector<KeyOpFieldsValuesTuple> kcos;
+  kcos.push_back(
+      KeyOpFieldsValuesTuple{"k", SET_COMMAND, std::vector<FieldValueTuple>{}});
+  std::vector<std::shared_ptr<KeyOpFieldsValuesTuple>> kcos_p;
+  std::string dbName, tableName;
+  p.send(kcos);
+  // Wait will timeout without server reply.
+  EXPECT_FALSE(p.wait(dbName, tableName, kcos_p));
+  // Send will return error without server reply.
+  EXPECT_THROW(p.send(kcos), std::system_error);
+}
+
+TEST(ZmqOneToOneSyncServerError, test)
+{
+  std::string testTableName = "ZMQ_PROD_CONS_UT";
+  std::string pullEndpoint = "tcp://*:1234";
+
+  DBConnector db(TEST_DB, 0, true);
+  ZmqServer server(pullEndpoint, "", false, true);
+  ZmqConsumerStateTable c(&db, testTableName, server);
+
   std::vector<swss::KeyOpFieldsValuesTuple> values;
   values.push_back(KeyOpFieldsValuesTuple{
       "k", SET_COMMAND,
       std::vector<FieldValueTuple>{FieldValueTuple{"f", "v"}}});
+  // Send will return error without client request.
+  EXPECT_THROW(server.sendMsg(TEST_DB, testTableName, values),
+               std::system_error);
+}
 
-  while (!zmq_done) {
-    sleep(2);
-    std::string recDbName, recTableName;
-    std::vector<std::shared_ptr<KeyOpFieldsValuesTuple>> recKcos;
-    std::vector<KeyOpFieldsValuesTuple> deserializedKcos;
+static void zmqConsumerOneToOneSyncWorker(string tableName, string endpoint)
+{
+  cout << "Consumer thread started: " << tableName << endl;
+  DBConnector db(TEST_DB, 0, true);
+  ZmqServer server(endpoint, "", false, true);
+  ZmqConsumerStateTable c(&db, tableName, server, 128, 0, false);
+  Select cs;
+  cs.addSelectable(&c);
 
-    BinarySerializer::deserializeBuffer(server.m_buffer.data(),
-                                        server.m_buffer.size(), recDbName,
-                                        recTableName, recKcos);
+  // validate received data
+  Selectable* selectcs;
+  std::deque<KeyOpFieldsValuesTuple> vkco;
+  int ret = 0;
 
-    for (auto kcoPtr : recKcos)
-    {
-      deserializedKcos.push_back(*kcoPtr);
+  int end_loop = 0;
+
+  while (!end_loop) {
+    ret = cs.select(&selectcs, 10, true);
+    if (ret == Select::OBJECT) {
+      c.pops(vkco);
+      std::vector<swss::KeyOpFieldsValuesTuple> values;
+      values.push_back(KeyOpFieldsValuesTuple{
+          "k", SET_COMMAND,
+          std::vector<FieldValueTuple>{FieldValueTuple{"f", "v"}}});
+
+      for(int i = 0; i <= 200; i++) {
+          try {
+              server.sendMsg(TEST_DB, tableName, values);
+          } catch(...)
+          {
+              break;
+          }
+      }
+      end_loop = 1;
     }
-    EXPECT_EQ(recDbName, TEST_DB);
-    EXPECT_EQ(recTableName, tableName);
-    EXPECT_EQ(deserializedKcos, values);
-    }
+  }
 
-    allDataReceived = true;
-    if (dbPersistence)
+  cout << "Consumer thread ended: " << tableName << endl;
+}
+
+TEST(ZmqClientCleanupDuringSync, test)
+{
+  std::string testTableName = "ZMQ_PROD_CONS_UT";
+  std::string pushEndpoint = "tcp://localhost:1234";
+  std::string pullEndpoint = "tcp://*:1234";
+  // start consumer first, SHM can only have 1 consumer per table.
+  thread* consumerThread =
+      new thread(zmqConsumerOneToOneSyncWorker, testTableName, pullEndpoint);
+  // Wait for the consumer to be ready.
+  sleep(1);
+
+  DBConnector db(TEST_DB, 0, true);
+  ZmqClient *client = new ZmqClient(pushEndpoint, 3000);
+  ZmqProducerStateTable p(&db, testTableName, *client, false);
+  std::vector<KeyOpFieldsValuesTuple> kcos;
+  kcos.push_back(KeyOpFieldsValuesTuple{
+      "k", SET_COMMAND,
+      std::vector<FieldValueTuple>{FieldValueTuple{"f", "v"}}});
+
+  p.send(kcos);
+  delete client;
+  sleep(1);
+
+  consumerThread->join();
+  delete consumerThread;
+}
+
+TEST(ZmqServerTest, DefaultInitializer)
+{
+    std::string endpoint = "tcp://127.0.0.1:5555";
+    std::string vrf = "";
+    bool lazyBind = false;
+
+    ZmqServer server(endpoint, vrf, lazyBind);
+    SUCCEED();
+}
+
+TEST(ZmqOneToOneSyncSendError, test)
+{
+    const std::string endpoint = "tcp://127.0.0.1:5568";
+    const std::string vrf = "";
+    ZmqServer server(endpoint, vrf);
+    std::vector<swss::KeyOpFieldsValuesTuple> values;
+    values.push_back(KeyOpFieldsValuesTuple{"k", "SET", {{"f", "v"}}});
+
+    for (int i = 0; i < 100; ++i)
     {
-        // wait all persist data write to redis
-        while (c.dbUpdaterQueueSize() > 0)
+        try
         {
-            sleep(1);
+            server.sendMsg("DB", "TABLE", values);
+        }
+        catch (const std::system_error& e)
+        {
+            break;
         }
     }
-
-    zmq_done = true;
-    cout << "Consumer thread ended: " << tableName << endl;
 }
 
-static void ZmqWithResponse(bool producerPersistence)
-{
-    std::string testTableName = "ZMQ_PROD_CONS_UT";
-    std::string pushEndpoint = "tcp://localhost:1234";
-    std::string pullEndpoint = "tcp://*:1234";
-    // start consumer first, SHM can only have 1 consumer per table.
-    thread *consumerThread = new thread(zmqConsumerWorker, testTableName, pullEndpoint, !producerPersistence);
+void signal_handler(int sig) {}
 
-    // Wait for the consumer to be ready.
-    sleep(1);
-    DBConnector db(TEST_DB, 0, true);
-    ZmqClient client(pushEndpoint, 3000);
-    ZmqProducerStateTable p(&db, testTableName, client, true);
-    std::vector<KeyOpFieldsValuesTuple> kcos;
-    kcos.push_back(KeyOpFieldsValuesTuple{"k", SET_COMMAND, std::vector<FieldValueTuple>{FieldValueTuple{"f", "v"}}});
-    for (int i = 0; i < 3; ++i) {
-      p.send(kcos);
+TEST(ZmqClientTest, HandlesEINTRInWait)
+{
+    signal(SIGALRM, signal_handler);
+    ZmqClient client("tcp://127.0.0.1:8100", 5000); // 5s timeout
+    // Trigger alarm in 100ms while client is likely polling
+    alarm(1);
+    std::string db, table;
+    std::vector<std::shared_ptr<swss::KeyOpFieldsValuesTuple>> kcos;
+    // Should survive EINTR and eventually return false on true timeout
+    bool result = client.wait(db, table, kcos);
+    EXPECT_FALSE(result);
+}
+
+TEST(ZmqServerTest, TriggerEAGAINOnFullBuffer)
+{
+    // PUSH socket without a PULL client will eventually hit High Water Mark
+    ZmqServer server("tcp://127.0.0.1:8200", "", true, false);
+    server.bind();
+    std::vector<swss::KeyOpFieldsValuesTuple> data = {};
+    // Rapidly send messages to fill the buffer (default HWM is 1000)
+    for (int i = 0; i < 2000; ++i)
+    {
+        try
+        {
+            server.sendMsg("db", "table", data);
+        }
+        catch (...)
+        {
+            // Eventually hits the EAGAIN branch in sendMsg
+            SUCCEED();
+        }
+    }
+}
+
+void my_test_handler(int sig)
+{
+    SWSS_LOG_NOTICE("Signal %d caught, interrupting ZMQ", sig);
+}
+
+TEST(ZmqServerTest, HandlesETERMDuringSend)
+{
+    // Register the handler
+    struct sigaction sa;
+    sa.sa_handler = my_test_handler;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = 0;
+    sigaction(SIGUSR1, &sa, NULL);
+
+    ZmqServer server("tcp://127.0.0.1:8100", "", true, true);
+    server.bind();
+
+    std::thread interruptor([&]() {
+        usleep(50000);
+        raise(SIGUSR1); // This now interrupts zmq_send instead of killing the process
+    });
+
+    std::vector<swss::KeyOpFieldsValuesTuple> data;
+    // This will enter the loop, get interrupted, hit the EINTR branch,
+    // and retry immediately because retry_delay becomes 0.
+    try
+    {
+        server.sendMsg("db", "table", data);
+    }
+    catch (...)
+    {
+        // Expected to eventually throw io_error after MQ_MAX_RETRY
+        SWSS_LOG_INFO("Handling catch()");
     }
 
-    zmq_done = true;
-    consumerThread->join();
-    delete consumerThread;
-}
-
-TEST(ZmqWithResponse, test)
-{
-    // test with persist by consumer
-    ZmqWithResponse(false);
-}
-
-TEST(ZmqWithResponseClientError, test)
-{
-    std::string testTableName = "ZMQ_PROD_CONS_UT";
-    std::string pushEndpoint = "tcp://localhost:1234";
-    DBConnector db(TEST_DB, 0, true);
-    ZmqClient client(pushEndpoint, 3000);
-    ZmqProducerStateTable p(&db, testTableName, client, true);
-    std::vector<KeyOpFieldsValuesTuple> kcos;
-    kcos.push_back(KeyOpFieldsValuesTuple{"k", SET_COMMAND, std::vector<FieldValueTuple>{}});
-    std::vector<std::shared_ptr<KeyOpFieldsValuesTuple>> kcosPtr;
-    std::string dbName, tableName;
-    p.send(kcos);
-    // Wait will timeout without server reply.
-    EXPECT_FALSE(p.wait(dbName, tableName, kcosPtr));
+    interruptor.join();
 }
 
 TEST(ZmqServerLazzyBind, test)
@@ -576,7 +765,7 @@ TEST(ZmqServerLazzyBind, test)
     std::string pushEndpoint = "tcp://localhost:1234";
     std::string pullEndpoint = "tcp://*:1234";
     DBConnector db(TEST_DB, 0, true);
-    ZmqClient client(pushEndpoint, 3000);
+    ZmqClient client(pushEndpoint, 0);
     ZmqProducerStateTable p(&db, testTableName, client, true);
     std::vector<KeyOpFieldsValuesTuple> kcos;
     auto testKey = "testkey";
@@ -586,7 +775,7 @@ TEST(ZmqServerLazzyBind, test)
 
     // initialize ZMQ server with lazzy bind
     DBConnector server_db(TEST_DB, 0, true);
-    ZmqServer server(pullEndpoint, "", true);
+    ZmqServer server(pullEndpoint, "", true, false);
     ZmqConsumerStateTable c(&db, testTableName, server, 128, 0, false);
     server.bind();
 
@@ -638,7 +827,7 @@ TEST_P(ZmqConsumerStateTablePopSize, test)
     thread *consumerThread = new thread([&]() {
         cout << "Consumer thread started" << endl;
         DBConnector db(TEST_DB, 0, true);
-        ZmqServer server(pullEndpoint);
+        ZmqServer server(pullEndpoint, "", false, false);
         Selectable* c = new ZmqConsumerStateTable(&db, testTableName, server, params.batchSize, 0, false);
         Select cs;
         cs.addSelectable(c);
@@ -669,7 +858,7 @@ TEST_P(ZmqConsumerStateTablePopSize, test)
 
     // Producer sends elements
     DBConnector db(TEST_DB, 0, true);
-    ZmqClient client(pushEndpoint, 3000);
+    ZmqClient client(pushEndpoint, 0);
     ZmqProducerStateTable p(&db, testTableName, client, false);
 
     std::vector<KeyOpFieldsValuesTuple> kcos;


### PR DESCRIPTION
### What I did
Introduced one-to-one synchronization option (request/replay) in the ZMQ client and server implementation. This is a new addition to the existing push/pull model.

### Why I did it
To ensure reliable and faster message delivery and synchronization between ZMQ producer and consumer in scenarios where message acknowledgment or ordering is critical. This will be used only by P4RT and P4Orch for now.

### How I verified it
Ran unit tests in zmq_state_ut.cpp and confirmed a successful message exchange using the updated one-to-one sync logic.
Verified zmq_recv and zmq_send retry logic operates correctly using debug logs.

### Details if related
None.