### PR TITLE
Read tables in insertion order in ConfigDBConnector.mod_config()

### DIFF
--- a/common/configdb.h
+++ b/common/configdb.h
@@ -24,6 +24,8 @@ public:
     std::map<std::string, std::map<std::string, std::string>> get_table(std::string table);
     void delete_table(std::string table);
     virtual void mod_config(const std::map<std::string, std::map<std::string, std::map<std::string, std::string>>>& data);
+    virtual void mod_config(const std::unordered_map<std::string, std::map<std::string, std::map<std::string, std::string>>>& data,
+                            const std::vector<std::string>& order);
     virtual std::map<std::string, std::map<std::string, std::map<std::string, std::string>>> get_config();
 
     std::string getKeySeparator() const;
@@ -235,7 +237,7 @@ func NewConfigDBConnector(a ...interface{}) *ConfigDBConnector {
                     raw_key = self.serialize_key(key)
                     raw_data = self.typed_to_raw(data)
                     raw_config[table_name][raw_key] = raw_data
-            super(ConfigDBConnector, self).mod_config(raw_config)
+            super(ConfigDBConnector, self).mod_config(raw_config, list(raw_config))
 
         def mod_entry(self, table, key, data):
             key = self.serialize_key(key)
@@ -331,6 +333,8 @@ public:
 
     void set_entry(std::string table, std::string key, const std::map<std::string, std::string>& data) override;
     void mod_config(const std::map<std::string, std::map<std::string, std::map<std::string, std::string>>>& data) override;
+    void mod_config(const std::unordered_map<std::string, std::map<std::string, std::map<std::string, std::string>>>& data,
+                    const std::vector<std::string>& order) override;
     std::map<std::string, std::map<std::string, std::map<std::string, std::string>>> get_config() override;
 
 private:

--- a/pyext/swsscommon.i
+++ b/pyext/swsscommon.i
@@ -67,6 +67,7 @@
 %include <std_map.i>
 %include <std_deque.i>
 #ifdef SWIGPYTHON
+%include <std_unordered_map.i>
 %include <std_shared_ptr.i>
 #endif
 %include <typemaps.i>
@@ -81,6 +82,9 @@
 %template(ScanResult) std::pair<int64_t, std::vector<std::string>>;
 %template(GetTableResult) std::map<std::string, std::map<std::string, std::string>>;
 %template(GetConfigResult) std::map<std::string, std::map<std::string, std::map<std::string, std::string>>>;
+#ifdef SWIGPYTHON
+%template(GetUnorderedConfigResult) std::unordered_map<std::string, std::map<std::string, std::map<std::string, std::string>>>;
+#endif
 %template(GetInstanceListResult) std::map<std::string, swss::RedisInstInfo>;
 %template(KeyOpFieldsValuesQueue) std::deque<std::tuple<std::string, std::string, std::vector<std::pair<std::string, std::string>>>>;
 %template(VectorSonicDbKey) std::vector<swss::SonicDBKey>;


### PR DESCRIPTION
When the SWSS SDK was ported to C++, one of the effects is that the map of tables passed in to mod_config() is now converted to a std::map by SWIG. Iteration over std::map always happens in lexical order of the table names, which causes issues for frrcfgd when one table depend on the contents of the another (e.g. PREFIX depends on PREFIX_SET, but PREFIX sorts before PREFIX_SET.)

This adds an overload to mod_config() that takes in an unsorted_map of the config data, along with a vector specifying the order in which to read the tables. The Python implementation is adjusted to always use the new function, to preserve the dictionary insertion order.

Fixes https://github.com/sonic-net/sonic-buildimage/issues/22974