### PR TITLE
Add chassis db.

### DIFF
--- a/crates/swss-common-testing/src/lib.rs
+++ b/crates/swss-common-testing/src/lib.rs
@@ -147,6 +147,16 @@ const CONFIG_DB_REDIS_CONFIG_JSON: &str = r#"
                 "separator": ":",
                 "instance": "redis"
             },
+            "CHASSIS_STATE_DB": {
+                "id": 5,
+                "separator": "|",
+                "instance": "redis"
+            },
+            "CHASSIS_APP_DB": {
+                "id": 6,
+                "separator": "|",
+                "instance": "redis"
+            },
             "TEST_DB": {
                 "id": 15,
                 "separator": "|",


### PR DESCRIPTION
Chassis DB were missing in the swss-common-testing crate causing some new UT to fail (https://github.com/sonic-net/sonic-dash-ha/pull/120):
```
Actor failed to handle message: Connecting to db `CHASSIS_STATE_DB`: [SWSSResult SWSSDBConnector_new_keyed(const char*, uint32_t, uint8_t, const char*, const char*, SWSSDBConnectorOpaque**)] Failed to find CHASSIS_STATE_DB database in : key
handle_swbus_message{actor="unknown.unknown.unknown/hamgrd/0/dpu/switch0_dpu0" id=1759761742796580595}: message handled by actor: Fail Connecting to db `CHASSIS_STATE_DB`: [SWSSResult SWSSDBConnector_new_keyed(const char*, uint32_t, uint8_t, const char*, const char*, SWSSDBConnectorOpaque**)] Failed to find CHASSIS_STATE_DB database in : key
```
 Adding these DB to the redis config to fix the above error.