### PR TITLE
Update static database_config.json in swsscommon

### DIFF
--- a/common/database_config.json
+++ b/common/database_config.json
@@ -91,6 +91,26 @@
             "id" : 14,
             "separator": ":",
             "instance" : "redis"
+        },
+        "DPU_APPL_DB" : {
+            "id" : 15,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "DPU_APPL_STATE_DB" : {
+            "id" : 16,
+            "separator": "|",
+            "instance" : "redis"
+        },
+        "DPU_STATE_DB" : {
+            "id": 17,
+            "separator": "|",
+            "instance" : "redis"
+        },
+        "DPU_COUNTERS_DB" : {
+            "id": 18,
+            "separator": ":",
+            "instance" : "redis"
         }
     },
     "VERSION" : "1.0"


### PR DESCRIPTION
Update this static file to match https://github.com/sonic-net/sonic-buildimage/blob/master/platform/vs/docker-sonic-vs/database_config.json to prevent the issue below when using DPU DBs on DVS testbeds running on an Ubuntu 22.04 machine

```/usr/local/lib/python3.10/dist-packages/flaky/flaky_pytest_plugin.py:146: _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ conftest.py:1953: in dvs
    return manage_dvs(log_path, dvs_env)
conftest.py:1913: in update_dvs
    dvs = DockerVirtualSwitch(name, imgname, keeptb, new_dvs_env, log_path, max_cpu, forcedvs, buffer_model = buffer_model, enable_coverage=enable_coverage)
conftest.py:435: in __init__
    self.check_ready_status_and_init_db()
conftest.py:524: in check_ready_status_and_init_db
    self.init_dpu_appl_db_validator()
conftest.py:569: in init_dpu_appl_db_validator
    self.dpu_appldb = ApplDbValidator(self.DPU_APPL_DB_ID, self.redis_sock)
conftest.py:183: in __init__
    DVSDatabase.__init__(self, db_id, connector)
dvslib/dvs_database.py:25: in __init__
    self._separator = SonicDBConfig.getSeparator(self.db_connection)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

args = (<swsscommon.swsscommon.DBConnector; proxy of <Swig Object of type 'swss::DBConnector *' at 0x73cb37ddaee0> >,)

    @staticmethod
    def getSeparator(*args):
>       return _swsscommon.SonicDBConfig_getSeparator(*args)
E       IndexError: Failed to find 15 database in : key

/usr/lib/python3/dist-packages/swsscommon/swsscommon.py:1712: IndexError
```