### PR TITLE
Fix mocktests for buster builds

### DIFF
--- a/tests/zmq_state_ut.cpp
+++ b/tests/zmq_state_ut.cpp
@@ -695,7 +695,7 @@ TEST_P(ZmqConsumerStateTablePopSize, test)
     }
 }
 
-INSTANTIATE_TEST_SUITE_P(
+INSTANTIATE_TEST_CASE_P(
     BatchSizeTests,
     ZmqConsumerStateTablePopSize,
     ::testing::Values(


### PR DESCRIPTION
 * PTF build still uses buster which does not support INSTANTIATE_TEST_SUITE_P. This change fixes the error below related to #1084 

```
   tests/zmq_state_ut.cpp:698:25: error: expected constructor, destructor, or type conversion before '(' token INSTANTIATE_TEST_SUITE_P( ^ tests/zmq_state_ut.cpp:702:56: error: expected unqualified-id before ',' token
         PopSizeTestParams{40, 150, 4, {40, 40, 40, 30}},
                                                        ^
tests/zmq_state_ut.cpp:703:26: error: expected constructor, destructor, or type conversion before '{' token
         PopSizeTestParams{-1, 384, 3, {128, 128, 128}}
                          ^
tests/zmq_state_ut.cpp:704:5: error: expected unqualified-id before ')' token
     )
     ^
make[4]: *** [Makefile:2683: tests/tests-zmq_state_ut.o] Error 1
```