### PR TITLE
SWSS UT: AZ pipelane changes for Single ASIC Fixed System VOQ

### DIFF
--- a/.azure-pipelines/docker-sonic-vs/start.sh
+++ b/.azure-pipelines/docker-sonic-vs/start.sh
@@ -61,10 +61,15 @@ else
         qos_cmd="-j /tmp/qos.json"
     fi
 
+    if [ -f /usr/share/sonic/single_asic_voq_fs/default_config.json ]; then
+        sonic-cfggen -j /usr/share/sonic/single_asic_voq_fs/default_config.json --print-data > /tmp/voq.json
+        voq_cmd="-j /tmp/voq.json"
+    fi
+
     sonic-cfggen -p /usr/share/sonic/device/$PLATFORM/$PLATFORM_CONF -k $HWSKU --print-data > /tmp/ports.json
     # change admin_status from up to down; Test cases dependent
     sed -i "s/up/down/g" /tmp/ports.json
-    sonic-cfggen -j /etc/sonic/init_cfg.json $buffers_cmd $qos_cmd -j /tmp/ports.json --print-data > /etc/sonic/config_db.json
+    sonic-cfggen -j /etc/sonic/init_cfg.json $buffers_cmd $qos_cmd $voq_cmd -j /tmp/ports.json --print-data > /etc/sonic/config_db.json
 fi
 
 sonic-cfggen -t /usr/share/sonic/templates/copp_cfg.j2 > /etc/sonic/copp_cfg.json

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -124,6 +124,8 @@ jobs:
       retry=3
       IMAGE_NAME=docker-sonic-vs:$(Build.DefinitionName).$(Build.BuildNumber)
       echo $all_tests | xargs -n 1 | xargs -P 8 -I TEST_MODULE sudo ./run-tests.sh "$IMAGE_NAME" "--force-recreate-dvs" "TEST_MODULE" 3
+      single_asic_voq_tests="test_portchannel.py test_neighbor.py test_route.py"
+      echo $single_asic_voq_tests | xargs -n 1 | xargs -P 3 -I TEST_MODULE sudo ./run-tests.sh "$IMAGE_NAME" "--force-recreate-dvs --switch-mode=single_asic_fs_voq" "TEST_MODULE" 3
 
       rm -rf $(Build.ArtifactStagingDirectory)/download
     displayName: "Run vs tests"


### PR DESCRIPTION
What I did
- Added test cases currently working for Single ASIC Fixed System VOQ
- running the tests for Single ASIC Fixed System VOQ

Why I did it
- VOQ FS needs functionality to be verified

How I verified it
- ran the tests manually

Also, creating sonic-buildimage PR with this PR and corresponding sonic-swss PR (https://github.com/sonic-net/sonic-swss/pull/3847) to make sure AZ pipeline runs pass.
