### PR TITLE
[agent][redisreply] Add null check in checkStatus() to prevent segfault

### DIFF
--- a/common/redisreply.cpp
+++ b/common/redisreply.cpp
@@ -153,9 +153,9 @@ redisReply *RedisReply::releaseChild(size_t index)
 
 void RedisReply::checkStatus(const char *status)
 {
-    if (strcmp(m_reply->str, status) != 0)
+    if (!m_reply->str || strcmp(m_reply->str, status) != 0)
     {
-        SWSS_LOG_ERROR("Redis reply %s != %s", m_reply->str, status);
+        SWSS_LOG_ERROR("Redis reply %s != %s", m_reply->str ? m_reply->str : "(null)", status);
 
         throw system_error(make_error_code(errc::io_error),
                            "Invalid return code");

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -6,6 +6,7 @@ LDADD_GTEST = -L/usr/src/gtest -lgtest -lgtest_main -lgmock -lgmock_main
 tests_tests_SOURCES = tests/redis_ut.cpp                \
                       tests/redis_piped_ut.cpp          \
                       tests/redis_command_ut.cpp        \
+                      tests/redisreply_ut.cpp           \
                       tests/redis_state_ut.cpp          \
                       tests/redis_piped_state_ut.cpp    \
                       tests/tokenize_ut.cpp             \

--- a/tests/redisreply_ut.cpp
+++ b/tests/redisreply_ut.cpp
@@ -13,7 +13,7 @@ TEST(RedisReply, check_status_handles_null_status_string)
     reply->type = REDIS_REPLY_STATUS;
     reply->str = nullptr;
 
-    swss::RedisReply redisReply(reply);
+    swss::RedisReply statusReply(reply);
 
-    EXPECT_THROW(redisReply.checkStatusOK(), std::system_error);
+    EXPECT_THROW(statusReply.checkStatusOK(), std::system_error);
 }

--- a/tests/redisreply_ut.cpp
+++ b/tests/redisreply_ut.cpp
@@ -1,0 +1,19 @@
+#include "common/redisreply.h"
+
+#include "gtest/gtest.h"
+
+#include <cstdlib>
+#include <system_error>
+
+TEST(RedisReply, check_status_handles_null_status_string)
+{
+    auto reply = static_cast<redisReply *>(std::calloc(1, sizeof(redisReply)));
+    ASSERT_NE(reply, nullptr);
+
+    reply->type = REDIS_REPLY_STATUS;
+    reply->str = nullptr;
+
+    swss::RedisReply redisReply(reply);
+
+    EXPECT_THROW(redisReply.checkStatusOK(), std::system_error);
+}


### PR DESCRIPTION
#### What I did
Add null check for `m_reply->str` before `strcmp()` in `RedisReply::checkStatus()`.

#### How I did it
Check `!m_reply->str` before calling `strcmp`. Log `"(null)"` when str is NULL for debug clarity.

#### How to verify it
Call `checkStatus()` on a Redis reply with NULL str field — should throw instead of segfault.

#### Which release branch to backport
master

#### Description for the changelog
Fix potential segfault in RedisReply::checkStatus() when m_reply->str is NULL.

Fixes: #1164