### PR TITLE
[agent][linkcache] Fix memory leak: free m_link_cache in destructor

### DIFF
--- a/common/linkcache.cpp
+++ b/common/linkcache.cpp
@@ -41,6 +41,10 @@ LinkCache::LinkCache()
 
 LinkCache::~LinkCache()
 {
+    if (m_link_cache != NULL)
+    {
+        nl_cache_free(m_link_cache);
+    }
     if (m_nl_sock != NULL)
     {
         nl_close(m_nl_sock);


### PR DESCRIPTION
#### What I did
Free `m_link_cache` in the `LinkCache` destructor to prevent memory leak.

#### How I did it
Added `nl_cache_free(m_link_cache)` before freeing the socket in `~LinkCache()`.

#### How to verify it
Run under valgrind/ASan — no more leaked netlink cache objects.

#### Which release branch to backport
master

#### Description for the changelog
Fix memory leak in LinkCache destructor — m_link_cache was never freed.

Fixes: #1165