### PR TITLE
[202511]: Introduce keepalives for ZmqClient and ZmqServer

### DIFF
--- a/common/zmqclient.cpp
+++ b/common/zmqclient.cpp
@@ -102,6 +102,25 @@ void ZmqClient::connect()
     int high_watermark = MQ_WATERMARK;
     zmq_setsockopt(m_socket, ZMQ_SNDHWM, &high_watermark, sizeof(high_watermark));
 
+    /*
+     * Enable TCP keepalive to detect dead connections (e.g. DPU power-off).
+     * Without keepalive, a stale TCP connection persists indefinitely, and the
+     * first message sent after peer restart is silently lost on the dead connection.
+     * Keepalive probes will detect the dead peer within ~10s (5s idle + 5x1s probes),
+     * triggering ZMQ to reconnect before any new data is sent.
+     */
+    int keepalive = 1;
+    zmq_setsockopt(m_socket, ZMQ_TCP_KEEPALIVE, &keepalive, sizeof(keepalive));
+
+    int keepalive_idle = 5;  // seconds before first probe
+    zmq_setsockopt(m_socket, ZMQ_TCP_KEEPALIVE_IDLE, &keepalive_idle, sizeof(keepalive_idle));
+
+    int keepalive_intvl = 1; // seconds between probes
+    zmq_setsockopt(m_socket, ZMQ_TCP_KEEPALIVE_INTVL, &keepalive_intvl, sizeof(keepalive_intvl));
+
+    int keepalive_cnt = 5;   // number of failed probes before connection is considered dead
+    zmq_setsockopt(m_socket, ZMQ_TCP_KEEPALIVE_CNT, &keepalive_cnt, sizeof(keepalive_cnt));
+
     if (!m_vrf.empty())
     {
         zmq_setsockopt(m_socket, ZMQ_BINDTODEVICE, m_vrf.c_str(), m_vrf.length());

--- a/common/zmqserver.cpp
+++ b/common/zmqserver.cpp
@@ -71,6 +71,22 @@ void ZmqServer::bind()
     int high_watermark = MQ_WATERMARK;
     zmq_setsockopt(m_socket, ZMQ_RCVHWM, &high_watermark, sizeof(high_watermark));
 
+    /*
+     * Enable TCP keepalive on the server socket as defense-in-depth.
+     * This allows the server to detect and clean up stale client connections.
+     */
+    int keepalive = 1;
+    zmq_setsockopt(m_socket, ZMQ_TCP_KEEPALIVE, &keepalive, sizeof(keepalive));
+
+    int keepalive_idle = 5;
+    zmq_setsockopt(m_socket, ZMQ_TCP_KEEPALIVE_IDLE, &keepalive_idle, sizeof(keepalive_idle));
+
+    int keepalive_intvl = 1;
+    zmq_setsockopt(m_socket, ZMQ_TCP_KEEPALIVE_INTVL, &keepalive_intvl, sizeof(keepalive_intvl));
+
+    int keepalive_cnt = 5;
+    zmq_setsockopt(m_socket, ZMQ_TCP_KEEPALIVE_CNT, &keepalive_cnt, sizeof(keepalive_cnt));
+
     if (!m_vrf.empty())
     {   
         zmq_setsockopt(m_socket, ZMQ_BINDTODEVICE, m_vrf.c_str(), m_vrf.length());


### PR DESCRIPTION
Fixes issue: sonic-net/sonic-buildimage#23110

Master branch PR: https://github.com/sonic-net/sonic-swss-common/pull/1162/

When a DPU is powered off and back on, the ZMQ client on the switch still holds a stale TCP connection. The first message sent after DPU restart is delivered over the dead connection, gets a TCP RST, and is silently lost. ZMQ then auto-reconnects, so subsequent messages succeed.

This patch enables:

1. TCP keepalive on ZmqClient PUSH sockets to detect dead connections proactively (within ~10 seconds of peer going down).
2. TCP keepalive on ZmqServer PULL sockets as defense-in-depth.

With these changes, after DPU power-off:

 * TCP keepalive probes will fail, causing ZMQ to tear down the stale connection and reconnect