### PR TITLE
[dbconnector]: Fall back to TCP when unix socket path is empty

### DIFF
--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -716,7 +716,8 @@ DBConnector::DBConnector(const string& dbName, unsigned int timeout_ms, bool isT
     }
     else if (SonicDBConfig::getDbSock(dbName, m_key).empty())
     {
-        SWSS_LOG_WARN("Unix socket path for DB %s is empty, falling back to TCP connection", dbName.c_str());
+        SWSS_LOG_WARN("Unix socket path for DB %s in context %s is empty, falling back to TCP connection",
+                      dbName.c_str(), m_key.toString().c_str());
         initContext(SonicDBConfig::getDbHostname(dbName, m_key).c_str(), SonicDBConfig::getDbPort(dbName, m_key), ptv);
     }
     else

--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -714,6 +714,11 @@ DBConnector::DBConnector(const string& dbName, unsigned int timeout_ms, bool isT
     {
         initContext(SonicDBConfig::getDbHostname(dbName, m_key).c_str(), SonicDBConfig::getDbPort(dbName, m_key), ptv);
     }
+    else if (SonicDBConfig::getDbSock(dbName, m_key).empty())
+    {
+        SWSS_LOG_WARN("Unix socket path for DB %s is empty, falling back to TCP connection", dbName.c_str());
+        initContext(SonicDBConfig::getDbHostname(dbName, m_key).c_str(), SonicDBConfig::getDbPort(dbName, m_key), ptv);
+    }
     else
     {
         initContext(SonicDBConfig::getDbSock(dbName, m_key).c_str(), ptv);

--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -714,15 +714,19 @@ DBConnector::DBConnector(const string& dbName, unsigned int timeout_ms, bool isT
     {
         initContext(SonicDBConfig::getDbHostname(dbName, m_key).c_str(), SonicDBConfig::getDbPort(dbName, m_key), ptv);
     }
-    else if (SonicDBConfig::getDbSock(dbName, m_key).empty())
-    {
-        SWSS_LOG_WARN("Unix socket path for DB %s in context %s is empty, falling back to TCP connection",
-                      dbName.c_str(), m_key.toString().c_str());
-        initContext(SonicDBConfig::getDbHostname(dbName, m_key).c_str(), SonicDBConfig::getDbPort(dbName, m_key), ptv);
-    }
     else
     {
-        initContext(SonicDBConfig::getDbSock(dbName, m_key).c_str(), ptv);
+        string sockPath = SonicDBConfig::getDbSock(dbName, m_key);
+        if (sockPath.empty())
+        {
+            SWSS_LOG_WARN("Unix socket path for DB %s in context %s is empty, falling back to TCP connection",
+                          dbName.c_str(), m_key.toString().c_str());
+            initContext(SonicDBConfig::getDbHostname(dbName, m_key).c_str(), SonicDBConfig::getDbPort(dbName, m_key), ptv);
+        }
+        else
+        {
+            initContext(sockPath.c_str(), ptv);
+        }
     }
 
     select(this);

--- a/tests/redis_smartswitch_ut.cpp
+++ b/tests/redis_smartswitch_ut.cpp
@@ -63,3 +63,15 @@ TEST(DBConnector, access_dpu_db_from_dpu)
     DBConnector db("DPU_APPL_DB", 0, true, key);
     TestDPUDatabase(db);
 }
+
+TEST(DBConnector, tcp_fallback_on_empty_unix_socket)
+{
+    // database_config5.json (dpu1) has remote-redis instance with an empty
+    // unix_socket_path. Passing isTcpConn=false should fall back to TCP.
+    SonicDBKey key;
+    key.containerName = "dpu1";
+    EXPECT_TRUE(SonicDBConfig::getDbSock("DPU_APPL_DB", key).empty());
+    DBConnector db("DPU_APPL_DB", 0, false, key);
+    EXPECT_EQ(db.getDbId(), SonicDBConfig::getDbId("DPU_APPL_DB", key));
+    TestDPUDatabase(db);
+}


### PR DESCRIPTION
When `isTcpConn` is `false` but the configured unix socket path for the database is empty, the DBConnector constructor now falls back to using a TCP connection instead of attempting to connect to an empty socket path. A `SWSS_LOG_WARN` is emitted when this fallback occurs.