### PR TITLE
Increase ZMQ Response Size to 32MB to support maximum dash configuration size

### DIFF
--- a/common/zmqserver.h
+++ b/common/zmqserver.h
@@ -6,7 +6,7 @@
 #include <vector>
 #include "table.h"
 
-#define MQ_RESPONSE_MAX_COUNT (16*1024*1024)
+#define MQ_RESPONSE_MAX_COUNT (32*1024*1024)
 #define MQ_SIZE 100
 #define MQ_MAX_RETRY 10
 #define MQ_POLL_TIMEOUT (1000)


### PR DESCRIPTION
Why I did it
SONiC Orchagent zmq does not currently support a large enough buffer size to handle the max dash scale config on DPU. 

How I did it
I increased the zmq response size to 32MB.

How to verify it
Send the maximum dash scale config in a test and confirm config is applied.