### PR TITLE
Add reusable ComponentStats library for per-container statistics.

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -96,6 +96,7 @@ common_libswsscommon_la_SOURCES = \
     common/zmqclient.cpp             \
     common/zmqserver.cpp             \
     common/asyncdbupdater.cpp        \
+    common/componentstats.cpp        \
     common/redis_table_waiter.cpp    \
     common/interface.h               \
     common/c-api/util.cpp                  \

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -95,6 +95,7 @@ common_libswsscommon_la_SOURCES = \
     common/zmqclient.cpp             \
     common/zmqserver.cpp             \
     common/asyncdbupdater.cpp        \
+    common/componentstats.cpp        \
     common/redis_table_waiter.cpp    \
     common/interface.h               \
     common/c-api/util.cpp                  \

--- a/common/componentstats.cpp
+++ b/common/componentstats.cpp
@@ -44,17 +44,30 @@ std::shared_ptr<ComponentStats> ComponentStats::create(
     uint32_t intervalSec)
 {
     const std::string key = toUpper(componentName);
+    const uint32_t effectiveInterval = intervalSec == 0 ? 1 : intervalSec;
 
     std::lock_guard<std::mutex> lock(registryMutex());
     auto& slot = registry()[key];
     if (auto existing = slot.lock())
     {
+        // First call wins. Warn if a later caller passes different params
+        // so the inconsistency is at least visible in syslog.
+        if (existing->m_dbName != dbName ||
+            existing->m_intervalSec != effectiveInterval)
+        {
+            SWSS_LOG_WARN("ComponentStats[%s]: ignoring later create() with "
+                          "db=%s interval=%us; live instance uses db=%s "
+                          "interval=%us",
+                          key.c_str(),
+                          dbName.c_str(), effectiveInterval,
+                          existing->m_dbName.c_str(), existing->m_intervalSec);
+        }
         return existing;
     }
 
     // std::make_shared cannot access the private constructor; use new + wrap.
     std::shared_ptr<ComponentStats> inst(
-        new ComponentStats(key, dbName, intervalSec));
+        new ComponentStats(key, dbName, effectiveInterval));
     slot = inst;
     return inst;
 }
@@ -125,9 +138,12 @@ ComponentStats::getOrCreateCounter(EntityStats& e, const std::string& metric)
     auto it = e.metrics.find(metric);
     if (it == e.metrics.end())
     {
-        it = e.metrics.emplace(metric, std::make_unique<Counter>()).first;
+        // std::map::emplace constructs Counter in place; no move required.
+        it = e.metrics.emplace(std::piecewise_construct,
+                               std::forward_as_tuple(metric),
+                               std::forward_as_tuple()).first;
     }
-    return *it->second;
+    return it->second;
 }
 
 void ComponentStats::increment(const std::string& entity,
@@ -167,7 +183,7 @@ uint64_t ComponentStats::get(const std::string& entity, const std::string& metri
     if (eit == m_entities.end()) return 0;
     auto mit = eit->second.metrics.find(metric);
     if (mit == eit->second.metrics.end()) return 0;
-    return mit->second->value.load(std::memory_order_relaxed);
+    return mit->second.value.load(std::memory_order_relaxed);
 }
 
 ComponentStats::CounterSnapshot
@@ -179,7 +195,7 @@ ComponentStats::getAll(const std::string& entity)
     if (eit == m_entities.end()) return snap;
     for (const auto& kv : eit->second.metrics)
     {
-        snap[kv.first] = kv.second->value.load(std::memory_order_relaxed);
+        snap[kv.first] = kv.second.value.load(std::memory_order_relaxed);
     }
     return snap;
 }
@@ -224,6 +240,10 @@ void ComponentStats::writerThread()
             }
         }
 
+        // Defensive: the connect-retry loop above only exits via `break`
+        // (m_table set) or via m_running becoming false (in which case the
+        // m_running check at the top of this loop already broke out). This
+        // line therefore should not normally be reached.
         if (!m_table) continue;
 
         std::vector<std::string> keys;
@@ -254,7 +274,7 @@ void ComponentStats::writerThread()
                 {
                     row.emplace_back(
                         mkv.first,
-                        std::to_string(mkv.second->value.load(std::memory_order_relaxed)));
+                        std::to_string(mkv.second.value.load(std::memory_order_relaxed)));
                 }
                 keys.push_back(name);
                 values.push_back(std::move(row));

--- a/common/componentstats.cpp
+++ b/common/componentstats.cpp
@@ -1,0 +1,284 @@
+#include "componentstats.h"
+
+#include "dbconnector.h"
+#include "table.h"
+#include "logger.h"
+
+#include <algorithm>
+#include <cctype>
+#include <chrono>
+#include <exception>
+#include <unordered_map>
+#include <utility>
+
+namespace swss {
+
+namespace {
+
+std::string toUpper(std::string s)
+{
+    std::transform(s.begin(), s.end(), s.begin(),
+                   [](unsigned char c){ return std::toupper(c); });
+    return s;
+}
+
+// Registry of created instances keyed by component name, so callers that
+// forget to hold onto the shared_ptr still get the same singleton back.
+std::mutex& registryMutex()
+{
+    static std::mutex m;
+    return m;
+}
+
+std::map<std::string, std::weak_ptr<ComponentStats>>& registry()
+{
+    static std::map<std::string, std::weak_ptr<ComponentStats>> r;
+    return r;
+}
+
+} // namespace
+
+std::shared_ptr<ComponentStats> ComponentStats::create(
+    const std::string& componentName,
+    const std::string& dbName,
+    uint32_t intervalSec)
+{
+    const std::string key = toUpper(componentName);
+
+    std::lock_guard<std::mutex> lock(registryMutex());
+    auto& slot = registry()[key];
+    if (auto existing = slot.lock())
+    {
+        return existing;
+    }
+
+    // std::make_shared cannot access the private constructor; use new + wrap.
+    std::shared_ptr<ComponentStats> inst(
+        new ComponentStats(key, dbName, intervalSec));
+    slot = inst;
+    return inst;
+}
+
+ComponentStats::ComponentStats(const std::string& componentName,
+                               const std::string& dbName,
+                               uint32_t intervalSec)
+    : m_component(componentName)
+    , m_tableName(componentName + "_STATS")
+    , m_dbName(dbName)
+    , m_intervalSec(intervalSec == 0 ? 1 : intervalSec)
+{
+    SWSS_LOG_ENTER();
+    m_thread = std::make_unique<std::thread>(&ComponentStats::writerThread, this);
+    SWSS_LOG_NOTICE("ComponentStats[%s] initialized (db=%s, interval=%us)",
+                    m_component.c_str(), m_dbName.c_str(), m_intervalSec);
+}
+
+ComponentStats::~ComponentStats()
+{
+    stop();
+}
+
+void ComponentStats::stop()
+{
+    if (!m_running.exchange(false))
+    {
+        return; // already stopped
+    }
+    m_cv.notify_all();
+    if (m_thread && m_thread->joinable())
+    {
+        m_thread->join();
+    }
+    SWSS_LOG_NOTICE("ComponentStats[%s] stopped", m_component.c_str());
+}
+
+void ComponentStats::setEnabled(bool on)
+{
+    m_enabled.store(on, std::memory_order_relaxed);
+}
+
+bool ComponentStats::isEnabled() const
+{
+    return m_enabled.load(std::memory_order_relaxed);
+}
+
+ComponentStats::EntityStats&
+ComponentStats::getOrCreateEntity(const std::string& entity)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    auto it = m_entities.find(entity);
+    if (it == m_entities.end())
+    {
+        it = m_entities.emplace(std::piecewise_construct,
+                                std::forward_as_tuple(entity),
+                                std::forward_as_tuple()).first;
+    }
+    // std::map never invalidates references to existing elements on insert,
+    // so returning this reference after the lock is released is safe.
+    return it->second;
+}
+
+ComponentStats::Counter&
+ComponentStats::getOrCreateCounter(EntityStats& e, const std::string& metric)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    auto it = e.metrics.find(metric);
+    if (it == e.metrics.end())
+    {
+        it = e.metrics.emplace(metric, std::make_unique<Counter>()).first;
+    }
+    return *it->second;
+}
+
+void ComponentStats::increment(const std::string& entity,
+                               const std::string& metric,
+                               uint64_t n)
+{
+    if (!isEnabled() || n == 0)
+    {
+        return;
+    }
+    auto& e = getOrCreateEntity(entity);
+    auto& c = getOrCreateCounter(e, metric);
+    c.value.fetch_add(n, std::memory_order_relaxed);
+    // Release ordering pairs with the acquire in writerThread() so that counter
+    // writes become visible before the version bump.
+    e.version.fetch_add(1, std::memory_order_release);
+}
+
+void ComponentStats::setValue(const std::string& entity,
+                              const std::string& metric,
+                              uint64_t value)
+{
+    if (!isEnabled())
+    {
+        return;
+    }
+    auto& e = getOrCreateEntity(entity);
+    auto& c = getOrCreateCounter(e, metric);
+    c.value.store(value, std::memory_order_relaxed);
+    e.version.fetch_add(1, std::memory_order_release);
+}
+
+uint64_t ComponentStats::get(const std::string& entity, const std::string& metric)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    auto eit = m_entities.find(entity);
+    if (eit == m_entities.end()) return 0;
+    auto mit = eit->second.metrics.find(metric);
+    if (mit == eit->second.metrics.end()) return 0;
+    return mit->second->value.load(std::memory_order_relaxed);
+}
+
+ComponentStats::CounterSnapshot
+ComponentStats::getAll(const std::string& entity)
+{
+    CounterSnapshot snap;
+    std::lock_guard<std::mutex> lock(m_mutex);
+    auto eit = m_entities.find(entity);
+    if (eit == m_entities.end()) return snap;
+    for (const auto& kv : eit->second.metrics)
+    {
+        snap[kv.first] = kv.second->value.load(std::memory_order_relaxed);
+    }
+    return snap;
+}
+
+void ComponentStats::writerThread()
+{
+    SWSS_LOG_ENTER();
+    SWSS_LOG_NOTICE("ComponentStats[%s] writer thread started",
+                    m_component.c_str());
+
+    // Defer the DB connection: early-startup containers may call create()
+    // before Redis is reachable. Retry on failure with a bounded back-off.
+    while (m_running.load(std::memory_order_relaxed))
+    {
+        try
+        {
+            m_db = std::make_shared<DBConnector>(m_dbName, 0);
+            m_table = std::make_unique<Table>(m_db.get(), m_tableName);
+            break;
+        }
+        catch (const std::exception& e)
+        {
+            SWSS_LOG_WARN("ComponentStats[%s]: DB connect failed: %s. Retrying…",
+                          m_component.c_str(), e.what());
+            std::unique_lock<std::mutex> lock(m_mutex);
+            m_cv.wait_for(lock, std::chrono::seconds(m_intervalSec),
+                          [this]{ return !m_running.load(std::memory_order_relaxed); });
+        }
+    }
+
+    std::unordered_map<std::string, uint64_t> lastVersions;
+
+    while (true)
+    {
+        {
+            std::unique_lock<std::mutex> lock(m_mutex);
+            m_cv.wait_for(lock, std::chrono::seconds(m_intervalSec),
+                          [this]{ return !m_running.load(std::memory_order_relaxed); });
+            if (!m_running.load(std::memory_order_relaxed))
+            {
+                break;
+            }
+        }
+
+        if (!m_table) continue;
+
+        std::vector<std::string> keys;
+        std::vector<std::vector<FieldValueTuple>> values;
+
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            for (const auto& entry : m_entities)
+            {
+                const std::string& name = entry.first;
+                const EntityStats& stats = entry.second;
+
+                // Acquire pairs with release in increment()/setValue(),
+                // guaranteeing we see all counter updates performed before
+                // the version bump we're about to read.
+                uint64_t curVer = stats.version.load(std::memory_order_acquire);
+
+                auto vit = lastVersions.find(name);
+                if (vit != lastVersions.end() && vit->second == curVer)
+                {
+                    continue; // no change since last flush
+                }
+                lastVersions[name] = curVer;
+
+                std::vector<FieldValueTuple> row;
+                row.reserve(stats.metrics.size());
+                for (const auto& mkv : stats.metrics)
+                {
+                    row.emplace_back(
+                        mkv.first,
+                        std::to_string(mkv.second->value.load(std::memory_order_relaxed)));
+                }
+                keys.push_back(name);
+                values.push_back(std::move(row));
+            }
+        }
+
+        // Write outside the lock so that increment() / setValue() stay
+        // responsive while Redis round-trips are in flight.
+        for (size_t i = 0; i < keys.size(); ++i)
+        {
+            try
+            {
+                m_table->set(keys[i], values[i]);
+            }
+            catch (const std::exception& e)
+            {
+                SWSS_LOG_WARN("ComponentStats[%s]: write failed for %s: %s",
+                              m_component.c_str(), keys[i].c_str(), e.what());
+            }
+        }
+    }
+
+    SWSS_LOG_NOTICE("ComponentStats[%s] writer thread stopped",
+                    m_component.c_str());
+}
+
+} // namespace swss

--- a/common/componentstats.cpp
+++ b/common/componentstats.cpp
@@ -154,7 +154,7 @@ ComponentStats::lookupOrCreate(const std::string& entity,
     // without serializing against each other, which is what makes the hot
     // path effectively lock-free after the first call for (entity, metric).
     {
-        std::shared_lock<std::shared_mutex> rlock(m_structMutex);
+        std::shared_lock<std::shared_timed_mutex> rlock(m_structMutex);
         auto eit = m_entities.find(entity);
         if (eit != m_entities.end())
         {
@@ -171,7 +171,7 @@ ComponentStats::lookupOrCreate(const std::string& entity,
     // Slow path: upgrade to an exclusive lock and insert. A racing thread
     // may have inserted the same key in the meantime; the second find()
     // covers that case so we never construct twice.
-    std::unique_lock<std::shared_mutex> wlock(m_structMutex);
+    std::unique_lock<std::shared_timed_mutex> wlock(m_structMutex);
     auto eit = m_entities.find(entity);
     if (eit == m_entities.end())
     {
@@ -222,14 +222,14 @@ void ComponentStats::setValue(const std::string& entity,
     // fetch_add after setValue's store. Callers that need strict gauge
     // semantics must not mix increment() and setValue() on the same metric
     // (see header doc).
-    std::unique_lock<std::shared_mutex> wlock(m_structMutex);
+    std::unique_lock<std::shared_timed_mutex> wlock(m_structMutex);
     ref.counter.value.store(value, std::memory_order_relaxed);
     ref.entity.version.fetch_add(1, std::memory_order_release);
 }
 
 uint64_t ComponentStats::get(const std::string& entity, const std::string& metric)
 {
-    std::shared_lock<std::shared_mutex> rlock(m_structMutex);
+    std::shared_lock<std::shared_timed_mutex> rlock(m_structMutex);
     auto eit = m_entities.find(entity);
     if (eit == m_entities.end()) return 0;
     auto mit = eit->second.metrics.find(metric);
@@ -241,7 +241,7 @@ ComponentStats::CounterSnapshot
 ComponentStats::getAll(const std::string& entity)
 {
     CounterSnapshot snap;
-    std::shared_lock<std::shared_mutex> rlock(m_structMutex);
+    std::shared_lock<std::shared_timed_mutex> rlock(m_structMutex);
     auto eit = m_entities.find(entity);
     if (eit == m_entities.end()) return snap;
     for (const auto& kv : eit->second.metrics)
@@ -260,7 +260,7 @@ size_t ComponentStats::flushDirty(
     std::vector<std::vector<FieldValueTuple>> values;
 
     {
-        std::shared_lock<std::shared_mutex> rlock(m_structMutex);
+        std::shared_lock<std::shared_timed_mutex> rlock(m_structMutex);
         for (const auto& entry : m_entities)
         {
             const std::string& name = entry.first;

--- a/common/componentstats.cpp
+++ b/common/componentstats.cpp
@@ -276,6 +276,9 @@ size_t ComponentStats::flushDirty(
             {
                 continue; // no change since last flush
             }
+            // Provisionally record the version we're about to write. If
+            // the write below fails we roll this entry back so the next
+            // periodic pass retries it.
             lastVersions[name] = curVer;
 
             std::vector<FieldValueTuple> row;
@@ -292,7 +295,13 @@ size_t ComponentStats::flushDirty(
     }
 
     // Write outside the lock so that increment() / setValue() stay
-    // responsive while Redis round-trips are in flight.
+    // responsive while Redis round-trips are in flight. Per-entity
+    // try/catch: a single failed write must not abort the rest of the
+    // batch — any entity skipped here would have its lastVersions entry
+    // set above and would be silently "unchanged" on the next cycle.
+    // Each failed entity's lastVersions slot is rolled back so the next
+    // periodic pass retries that one entity.
+    size_t failures = 0;
     for (size_t i = 0; i < keys.size(); ++i)
     {
         try
@@ -303,11 +312,17 @@ size_t ComponentStats::flushDirty(
         {
             SWSS_LOG_WARN("ComponentStats[%s]: write failed for %s: %s",
                           m_component.c_str(), keys[i].c_str(), e.what());
-            // Propagate the failure to the caller via lastVersions rollback
-            // so the next periodic pass retries this entity.
             lastVersions.erase(keys[i]);
-            throw;
+            ++failures;
         }
+    }
+    if (failures > 0)
+    {
+        // Signal partial failure to writerThread without losing the
+        // count of how many entities were actually written.
+        throw std::runtime_error("flushDirty: " + std::to_string(failures) +
+                                 " of " + std::to_string(keys.size()) +
+                                 " writes failed");
     }
     return keys.size();
 }

--- a/common/componentstats.cpp
+++ b/common/componentstats.cpp
@@ -36,6 +36,25 @@ std::map<std::string, std::weak_ptr<ComponentStats>>& registry()
     return r;
 }
 
+// Drop entries whose shared_ptr has been released. Called from create()
+// under registryMutex() so long-running processes that cycle through
+// distinct component names don't leak the registry map.
+void pruneExpiredRegistryLocked()
+{
+    auto& r = registry();
+    for (auto it = r.begin(); it != r.end(); )
+    {
+        if (it->second.expired())
+        {
+            it = r.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+}
+
 } // namespace
 
 std::shared_ptr<ComponentStats> ComponentStats::create(
@@ -47,6 +66,11 @@ std::shared_ptr<ComponentStats> ComponentStats::create(
     const uint32_t effectiveInterval = intervalSec == 0 ? 1 : intervalSec;
 
     std::lock_guard<std::mutex> lock(registryMutex());
+
+    // Reclaim any slots whose ComponentStats has already been destroyed
+    // before we (possibly) insert a new one.
+    pruneExpiredRegistryLocked();
+
     auto& slot = registry()[key];
     if (auto existing = slot.lock())
     {
@@ -66,6 +90,8 @@ std::shared_ptr<ComponentStats> ComponentStats::create(
     }
 
     // std::make_shared cannot access the private constructor; use new + wrap.
+    // effectiveInterval is already clamped above, so the constructor receives
+    // a sane value and does not need to clamp again.
     std::shared_ptr<ComponentStats> inst(
         new ComponentStats(key, dbName, effectiveInterval));
     slot = inst;
@@ -78,7 +104,7 @@ ComponentStats::ComponentStats(const std::string& componentName,
     : m_component(componentName)
     , m_tableName(componentName + "_STATS")
     , m_dbName(dbName)
-    , m_intervalSec(intervalSec == 0 ? 1 : intervalSec)
+    , m_intervalSec(intervalSec)
 {
     SWSS_LOG_ENTER();
     m_thread = std::make_unique<std::thread>(&ComponentStats::writerThread, this);
@@ -96,6 +122,11 @@ void ComponentStats::stop()
     if (!m_running.exchange(false))
     {
         return; // already stopped
+    }
+    {
+        std::lock_guard<std::mutex> lock(m_cvMutex);
+        // ensure the writer observes m_running==false even if it just
+        // entered the wait_for above.
     }
     m_cv.notify_all();
     if (m_thread && m_thread->joinable())
@@ -115,35 +146,48 @@ bool ComponentStats::isEnabled() const
     return m_enabled.load(std::memory_order_relaxed);
 }
 
-ComponentStats::EntityStats&
-ComponentStats::getOrCreateEntity(const std::string& entity)
+ComponentStats::CounterRef
+ComponentStats::lookupOrCreate(const std::string& entity,
+                               const std::string& metric)
 {
-    std::lock_guard<std::mutex> lock(m_mutex);
-    auto it = m_entities.find(entity);
-    if (it == m_entities.end())
+    // Fast path: shared lock, lookup only. N concurrent readers proceed
+    // without serializing against each other, which is what makes the hot
+    // path effectively lock-free after the first call for (entity, metric).
     {
-        it = m_entities.emplace(std::piecewise_construct,
-                                std::forward_as_tuple(entity),
-                                std::forward_as_tuple()).first;
+        std::shared_lock<std::shared_mutex> rlock(m_structMutex);
+        auto eit = m_entities.find(entity);
+        if (eit != m_entities.end())
+        {
+            auto mit = eit->second.metrics.find(metric);
+            if (mit != eit->second.metrics.end())
+            {
+                // std::map references stay valid across later inserts,
+                // so returning them after rlock release is safe.
+                return CounterRef{eit->second, mit->second};
+            }
+        }
     }
-    // std::map never invalidates references to existing elements on insert,
-    // so returning this reference after the lock is released is safe.
-    return it->second;
-}
 
-ComponentStats::Counter&
-ComponentStats::getOrCreateCounter(EntityStats& e, const std::string& metric)
-{
-    std::lock_guard<std::mutex> lock(m_mutex);
-    auto it = e.metrics.find(metric);
-    if (it == e.metrics.end())
+    // Slow path: upgrade to an exclusive lock and insert. A racing thread
+    // may have inserted the same key in the meantime; the second find()
+    // covers that case so we never construct twice.
+    std::unique_lock<std::shared_mutex> wlock(m_structMutex);
+    auto eit = m_entities.find(entity);
+    if (eit == m_entities.end())
+    {
+        eit = m_entities.emplace(std::piecewise_construct,
+                                 std::forward_as_tuple(entity),
+                                 std::forward_as_tuple()).first;
+    }
+    auto mit = eit->second.metrics.find(metric);
+    if (mit == eit->second.metrics.end())
     {
         // std::map::emplace constructs Counter in place; no move required.
-        it = e.metrics.emplace(std::piecewise_construct,
-                               std::forward_as_tuple(metric),
-                               std::forward_as_tuple()).first;
+        mit = eit->second.metrics.emplace(std::piecewise_construct,
+                                          std::forward_as_tuple(metric),
+                                          std::forward_as_tuple()).first;
     }
-    return it->second;
+    return CounterRef{eit->second, mit->second};
 }
 
 void ComponentStats::increment(const std::string& entity,
@@ -154,12 +198,11 @@ void ComponentStats::increment(const std::string& entity,
     {
         return;
     }
-    auto& e = getOrCreateEntity(entity);
-    auto& c = getOrCreateCounter(e, metric);
-    c.value.fetch_add(n, std::memory_order_relaxed);
-    // Release ordering pairs with the acquire in writerThread() so that counter
-    // writes become visible before the version bump.
-    e.version.fetch_add(1, std::memory_order_release);
+    auto ref = lookupOrCreate(entity, metric);
+    ref.counter.value.fetch_add(n, std::memory_order_relaxed);
+    // Release ordering pairs with the acquire in writerThread() so that the
+    // counter write becomes visible before the version bump.
+    ref.entity.version.fetch_add(1, std::memory_order_release);
 }
 
 void ComponentStats::setValue(const std::string& entity,
@@ -170,15 +213,23 @@ void ComponentStats::setValue(const std::string& entity,
     {
         return;
     }
-    auto& e = getOrCreateEntity(entity);
-    auto& c = getOrCreateCounter(e, metric);
-    c.value.store(value, std::memory_order_relaxed);
-    e.version.fetch_add(1, std::memory_order_release);
+    auto ref = lookupOrCreate(entity, metric);
+    // Take the structural lock in exclusive mode so that this setValue's
+    // store and version-bump are observed atomically with respect to other
+    // setValue() callers and to writer-thread snapshots. Note this does
+    // NOT fully serialise against concurrent increment(): an increment
+    // whose lookup races ahead of this lock can still land its atomic
+    // fetch_add after setValue's store. Callers that need strict gauge
+    // semantics must not mix increment() and setValue() on the same metric
+    // (see header doc).
+    std::unique_lock<std::shared_mutex> wlock(m_structMutex);
+    ref.counter.value.store(value, std::memory_order_relaxed);
+    ref.entity.version.fetch_add(1, std::memory_order_release);
 }
 
 uint64_t ComponentStats::get(const std::string& entity, const std::string& metric)
 {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::shared_lock<std::shared_mutex> rlock(m_structMutex);
     auto eit = m_entities.find(entity);
     if (eit == m_entities.end()) return 0;
     auto mit = eit->second.metrics.find(metric);
@@ -190,7 +241,7 @@ ComponentStats::CounterSnapshot
 ComponentStats::getAll(const std::string& entity)
 {
     CounterSnapshot snap;
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::shared_lock<std::shared_mutex> rlock(m_structMutex);
     auto eit = m_entities.find(entity);
     if (eit == m_entities.end()) return snap;
     for (const auto& kv : eit->second.metrics)
@@ -200,6 +251,67 @@ ComponentStats::getAll(const std::string& entity)
     return snap;
 }
 
+size_t ComponentStats::flushDirty(
+    std::unordered_map<std::string, uint64_t>& lastVersions)
+{
+    if (!m_table) return 0;
+
+    std::vector<std::string> keys;
+    std::vector<std::vector<FieldValueTuple>> values;
+
+    {
+        std::shared_lock<std::shared_mutex> rlock(m_structMutex);
+        for (const auto& entry : m_entities)
+        {
+            const std::string& name = entry.first;
+            const EntityStats& stats = entry.second;
+
+            // Acquire pairs with release in increment()/setValue(),
+            // guaranteeing we see all counter updates performed before
+            // the version bump we're about to read.
+            uint64_t curVer = stats.version.load(std::memory_order_acquire);
+
+            auto vit = lastVersions.find(name);
+            if (vit != lastVersions.end() && vit->second == curVer)
+            {
+                continue; // no change since last flush
+            }
+            lastVersions[name] = curVer;
+
+            std::vector<FieldValueTuple> row;
+            row.reserve(stats.metrics.size());
+            for (const auto& mkv : stats.metrics)
+            {
+                row.emplace_back(
+                    mkv.first,
+                    std::to_string(mkv.second.value.load(std::memory_order_relaxed)));
+            }
+            keys.push_back(name);
+            values.push_back(std::move(row));
+        }
+    }
+
+    // Write outside the lock so that increment() / setValue() stay
+    // responsive while Redis round-trips are in flight.
+    for (size_t i = 0; i < keys.size(); ++i)
+    {
+        try
+        {
+            m_table->set(keys[i], values[i]);
+        }
+        catch (const std::exception& e)
+        {
+            SWSS_LOG_WARN("ComponentStats[%s]: write failed for %s: %s",
+                          m_component.c_str(), keys[i].c_str(), e.what());
+            // Propagate the failure to the caller via lastVersions rollback
+            // so the next periodic pass retries this entity.
+            lastVersions.erase(keys[i]);
+            throw;
+        }
+    }
+    return keys.size();
+}
+
 void ComponentStats::writerThread()
 {
     SWSS_LOG_ENTER();
@@ -207,7 +319,8 @@ void ComponentStats::writerThread()
                     m_component.c_str());
 
     // Defer the DB connection: early-startup containers may call create()
-    // before Redis is reachable. Retry on failure with a bounded back-off.
+    // before Redis is reachable. Retry on failure until Redis is up or
+    // stop() is requested.
     while (m_running.load(std::memory_order_relaxed))
     {
         try
@@ -220,7 +333,7 @@ void ComponentStats::writerThread()
         {
             SWSS_LOG_WARN("ComponentStats[%s]: DB connect failed: %s. Retrying...",
                           m_component.c_str(), e.what());
-            std::unique_lock<std::mutex> lock(m_mutex);
+            std::unique_lock<std::mutex> lock(m_cvMutex);
             m_cv.wait_for(lock, std::chrono::seconds(m_intervalSec),
                           [this]{ return !m_running.load(std::memory_order_relaxed); });
         }
@@ -228,11 +341,12 @@ void ComponentStats::writerThread()
 
     std::unordered_map<std::string, uint64_t> lastVersions;
     int consecutiveWriteFailures = 0;
+    static constexpr int kMaxConsecutiveWriteFailures = 3;
 
     while (true)
     {
         {
-            std::unique_lock<std::mutex> lock(m_mutex);
+            std::unique_lock<std::mutex> lock(m_cvMutex);
             m_cv.wait_for(lock, std::chrono::seconds(m_intervalSec),
                           [this]{ return !m_running.load(std::memory_order_relaxed); });
             if (!m_running.load(std::memory_order_relaxed))
@@ -241,69 +355,18 @@ void ComponentStats::writerThread()
             }
         }
 
-        // Defensive: the connect-retry loop above only exits via `break`
-        // (m_table set) or via m_running becoming false (in which case the
-        // m_running check at the top of this loop already broke out). This
-        // line therefore should not normally be reached.
         if (!m_table) continue;
 
-        std::vector<std::string> keys;
-        std::vector<std::vector<FieldValueTuple>> values;
-
+        try
         {
-            std::lock_guard<std::mutex> lock(m_mutex);
-            for (const auto& entry : m_entities)
-            {
-                const std::string& name = entry.first;
-                const EntityStats& stats = entry.second;
-
-                // Acquire pairs with release in increment()/setValue(),
-                // guaranteeing we see all counter updates performed before
-                // the version bump we're about to read.
-                uint64_t curVer = stats.version.load(std::memory_order_acquire);
-
-                auto vit = lastVersions.find(name);
-                if (vit != lastVersions.end() && vit->second == curVer)
-                {
-                    continue; // no change since last flush
-                }
-                lastVersions[name] = curVer;
-
-                std::vector<FieldValueTuple> row;
-                row.reserve(stats.metrics.size());
-                for (const auto& mkv : stats.metrics)
-                {
-                    row.emplace_back(
-                        mkv.first,
-                        std::to_string(mkv.second.value.load(std::memory_order_relaxed)));
-                }
-                keys.push_back(name);
-                values.push_back(std::move(row));
-            }
+            flushDirty(lastVersions);
+            consecutiveWriteFailures = 0;
         }
-
-        // Write outside the lock so that increment() / setValue() stay
-        // responsive while Redis round-trips are in flight.
-        //
-        // If Redis goes away (restart, socket reset, ...), every set() will
-        // throw and we'd otherwise log forever without recovering. After a
-        // few consecutive failures we drop m_table/m_db and fall back into
-        // the connect-retry loop above so a healthy Redis is picked back up.
-        static constexpr int kMaxConsecutiveWriteFailures = 3;
-        for (size_t i = 0; i < keys.size(); ++i)
+        catch (const std::exception&)
         {
-            try
-            {
-                m_table->set(keys[i], values[i]);
-                consecutiveWriteFailures = 0;
-            }
-            catch (const std::exception& e)
-            {
-                ++consecutiveWriteFailures;
-                SWSS_LOG_WARN("ComponentStats[%s]: write failed for %s: %s (%d in a row)",
-                              m_component.c_str(), keys[i].c_str(), e.what(),
-                              consecutiveWriteFailures);
-            }
+            ++consecutiveWriteFailures;
+            SWSS_LOG_WARN("ComponentStats[%s]: flush failed (%d in a row)",
+                          m_component.c_str(), consecutiveWriteFailures);
         }
 
         if (consecutiveWriteFailures >= kMaxConsecutiveWriteFailures)
@@ -334,11 +397,33 @@ void ComponentStats::writerThread()
                 {
                     SWSS_LOG_WARN("ComponentStats[%s]: DB reconnect failed: %s. Retrying...",
                                   m_component.c_str(), e.what());
-                    std::unique_lock<std::mutex> lock(m_mutex);
+                    std::unique_lock<std::mutex> lock(m_cvMutex);
                     m_cv.wait_for(lock, std::chrono::seconds(m_intervalSec),
                                   [this]{ return !m_running.load(std::memory_order_relaxed); });
                 }
             }
+        }
+    }
+
+    // Final flush on shutdown. Without this, any counter updates that
+    // happened after the last periodic flush would be silently dropped
+    // when the writer thread exits. Best-effort: if Redis is already
+    // gone, log and move on -- stop() must not block on a dead Redis.
+    if (m_table)
+    {
+        try
+        {
+            size_t n = flushDirty(lastVersions);
+            if (n > 0)
+            {
+                SWSS_LOG_NOTICE("ComponentStats[%s] final flush wrote %zu entities",
+                                m_component.c_str(), n);
+            }
+        }
+        catch (const std::exception& e)
+        {
+            SWSS_LOG_WARN("ComponentStats[%s] final flush failed: %s",
+                          m_component.c_str(), e.what());
         }
     }
 

--- a/common/componentstats.cpp
+++ b/common/componentstats.cpp
@@ -218,7 +218,7 @@ void ComponentStats::writerThread()
         }
         catch (const std::exception& e)
         {
-            SWSS_LOG_WARN("ComponentStats[%s]: DB connect failed: %s. Retrying…",
+            SWSS_LOG_WARN("ComponentStats[%s]: DB connect failed: %s. Retrying...",
                           m_component.c_str(), e.what());
             std::unique_lock<std::mutex> lock(m_mutex);
             m_cv.wait_for(lock, std::chrono::seconds(m_intervalSec),
@@ -227,6 +227,7 @@ void ComponentStats::writerThread()
     }
 
     std::unordered_map<std::string, uint64_t> lastVersions;
+    int consecutiveWriteFailures = 0;
 
     while (true)
     {
@@ -283,16 +284,60 @@ void ComponentStats::writerThread()
 
         // Write outside the lock so that increment() / setValue() stay
         // responsive while Redis round-trips are in flight.
+        //
+        // If Redis goes away (restart, socket reset, ...), every set() will
+        // throw and we'd otherwise log forever without recovering. After a
+        // few consecutive failures we drop m_table/m_db and fall back into
+        // the connect-retry loop above so a healthy Redis is picked back up.
+        static constexpr int kMaxConsecutiveWriteFailures = 3;
         for (size_t i = 0; i < keys.size(); ++i)
         {
             try
             {
                 m_table->set(keys[i], values[i]);
+                consecutiveWriteFailures = 0;
             }
             catch (const std::exception& e)
             {
-                SWSS_LOG_WARN("ComponentStats[%s]: write failed for %s: %s",
-                              m_component.c_str(), keys[i].c_str(), e.what());
+                ++consecutiveWriteFailures;
+                SWSS_LOG_WARN("ComponentStats[%s]: write failed for %s: %s (%d in a row)",
+                              m_component.c_str(), keys[i].c_str(), e.what(),
+                              consecutiveWriteFailures);
+            }
+        }
+
+        if (consecutiveWriteFailures >= kMaxConsecutiveWriteFailures)
+        {
+            SWSS_LOG_WARN("ComponentStats[%s]: %d consecutive write failures; "
+                          "dropping Redis connection and reconnecting",
+                          m_component.c_str(), consecutiveWriteFailures);
+            m_table.reset();
+            m_db.reset();
+            consecutiveWriteFailures = 0;
+            // Force any entities we already had marked clean to be re-flushed
+            // once the new connection comes up, so Redis converges with the
+            // current in-memory state instead of being stale from before the
+            // outage.
+            lastVersions.clear();
+
+            // Re-enter the bounded connect-retry loop.
+            while (m_running.load(std::memory_order_relaxed) && !m_table)
+            {
+                try
+                {
+                    m_db = std::make_shared<DBConnector>(m_dbName, 0);
+                    m_table = std::make_unique<Table>(m_db.get(), m_tableName);
+                    SWSS_LOG_NOTICE("ComponentStats[%s]: reconnected to Redis",
+                                    m_component.c_str());
+                }
+                catch (const std::exception& e)
+                {
+                    SWSS_LOG_WARN("ComponentStats[%s]: DB reconnect failed: %s. Retrying...",
+                                  m_component.c_str(), e.what());
+                    std::unique_lock<std::mutex> lock(m_mutex);
+                    m_cv.wait_for(lock, std::chrono::seconds(m_intervalSec),
+                                  [this]{ return !m_running.load(std::memory_order_relaxed); });
+                }
             }
         }
     }

--- a/common/componentstats.h
+++ b/common/componentstats.h
@@ -1,0 +1,145 @@
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+#include <cstdint>
+
+namespace swss {
+
+class DBConnector;
+class Table;
+
+/**
+ * ComponentStats — a lightweight, container-agnostic counter library.
+ *
+ * Each instance writes counters to a Redis hash of the form:
+ *     <COMPONENT>_STATS:<entity>
+ * where each field is a user-defined metric name (e.g. SET, DEL, GET, ERROR…).
+ *
+ * Design goals:
+ *   - Lock-free hot path: increment() / setValue() use std::atomic operations.
+ *   - Deferred DB connection: the DBConnector is created inside the writer
+ *     thread rather than the constructor, so early-startup callers (singleton
+ *     initialization before Redis is ready) do not crash.
+ *   - Version-based dirty tracking: the writer thread only pushes entities
+ *     whose counters changed since the last flush.
+ *   - Stable references: std::map is used instead of unordered_map so that
+ *     references returned by getOrCreateEntity() remain valid after later
+ *     inserts (unordered_map can rehash and invalidate them).
+ *   - Clean shutdown: the destructor uses condition_variable::notify_all() to
+ *     wake the writer thread immediately instead of waiting up to interval.
+ *
+ * Thread safety: all public methods are safe to call from any thread.
+ */
+class ComponentStats
+{
+public:
+    /// Snapshot of counters for a single entity (used for diagnostics / tests).
+    using CounterSnapshot = std::map<std::string, uint64_t>;
+
+    /**
+     * Create a ComponentStats instance.
+     *
+     * @param componentName  Used as the Redis key prefix, upper-cased.
+     *                       For example, "swss" produces keys like
+     *                       "SWSS_STATS:<entity>".
+     * @param dbName         Redis logical DB name (default: "COUNTERS_DB").
+     * @param intervalSec    Writer thread flush period in seconds.
+     * @return A shared instance. Repeated calls with the same componentName
+     *         return the same underlying singleton.
+     */
+    static std::shared_ptr<ComponentStats> create(
+        const std::string& componentName,
+        const std::string& dbName = "COUNTERS_DB",
+        uint32_t intervalSec = 1);
+
+    ~ComponentStats();
+
+    /// Add n to the named metric on the given entity. Creates the entity on
+    /// first use. Safe to call concurrently from many threads.
+    void increment(const std::string& entity,
+                   const std::string& metric,
+                   uint64_t n = 1);
+
+    /// Overwrite the metric with an absolute value. Useful for gauge-style
+    /// stats (e.g. queue depth) that are not monotonically increasing.
+    void setValue(const std::string& entity,
+                  const std::string& metric,
+                  uint64_t value);
+
+    /// Read a single metric. Returns 0 if either entity or metric are unknown.
+    uint64_t get(const std::string& entity, const std::string& metric);
+
+    /// Snapshot all metrics for an entity. Returns empty map if unknown.
+    CounterSnapshot getAll(const std::string& entity);
+
+    /// Globally enable / disable recording. Hot-path calls become no-ops when
+    /// disabled; the writer thread keeps running but has nothing to flush.
+    /// Intended to be wired to a CONFIG_DB knob if runtime control is desired.
+    void setEnabled(bool on);
+    bool isEnabled() const;
+
+    /// Stop the writer thread. Called automatically by the destructor.
+    void stop();
+
+    // Non-copyable / non-movable (singleton-ish usage)
+    ComponentStats(const ComponentStats&) = delete;
+    ComponentStats& operator=(const ComponentStats&) = delete;
+
+private:
+    struct Counter
+    {
+        std::atomic<uint64_t> value{0};
+        Counter() = default;
+        Counter(const Counter&) = delete;
+        Counter& operator=(const Counter&) = delete;
+    };
+
+    struct EntityStats
+    {
+        // Map of metric name -> counter. std::map keeps references stable.
+        std::map<std::string, std::unique_ptr<Counter>> metrics;
+        // Incremented whenever any counter on this entity changes.
+        std::atomic<uint64_t> version{0};
+
+        EntityStats() = default;
+        EntityStats(const EntityStats&) = delete;
+        EntityStats& operator=(const EntityStats&) = delete;
+    };
+
+    ComponentStats(const std::string& componentName,
+                   const std::string& dbName,
+                   uint32_t intervalSec);
+
+    // Returns a stable reference. Safe to keep after the lock is released
+    // because std::map does not invalidate element references on insert.
+    EntityStats& getOrCreateEntity(const std::string& entity);
+    Counter&     getOrCreateCounter(EntityStats& e, const std::string& metric);
+
+    void writerThread();
+
+    const std::string m_component;   // already upper-cased
+    const std::string m_tableName;   // "<COMPONENT>_STATS"
+    const std::string m_dbName;
+    const uint32_t    m_intervalSec;
+
+    std::atomic<bool> m_enabled{true};
+    std::atomic<bool> m_running{true};
+
+    mutable std::mutex      m_mutex;       // guards m_entities structure
+    std::condition_variable m_cv;          // wakes writer on stop()
+    std::map<std::string, EntityStats> m_entities;
+
+    std::shared_ptr<DBConnector>  m_db;    // created in writerThread
+    std::unique_ptr<Table>        m_table;
+
+    std::unique_ptr<std::thread>  m_thread;
+};
+
+} // namespace swss

--- a/common/componentstats.h
+++ b/common/componentstats.h
@@ -23,7 +23,10 @@ class Table;
  * where each field is a user-defined metric name (e.g. SET, DEL, GET, ERROR…).
  *
  * Design goals:
- *   - Lock-free hot path: increment() / setValue() use std::atomic operations.
+ *   - Lock-free counter update: once an entity/metric pair has been seen,
+ *     increment() / setValue() update the counter with std::atomic ops.
+ *     The first reference to a new entity or metric still takes m_mutex
+ *     to insert into the maps.
  *   - Deferred DB connection: the DBConnector is created inside the writer
  *     thread rather than the constructor, so early-startup callers (singleton
  *     initialization before Redis is ready) do not crash.
@@ -31,11 +34,16 @@ class Table;
  *     whose counters changed since the last flush.
  *   - Stable references: std::map is used instead of unordered_map so that
  *     references returned by getOrCreateEntity() remain valid after later
- *     inserts (unordered_map can rehash and invalidate them).
+ *     inserts (unordered_map can rehash and invalidate them). DO NOT change
+ *     m_entities to a container that can invalidate references on insert,
+ *     and do not add an erase API without revisiting the locking model.
  *   - Clean shutdown: the destructor uses condition_variable::notify_all() to
  *     wake the writer thread immediately instead of waiting up to interval.
  *
  * Thread safety: all public methods are safe to call from any thread.
+ *
+ * Component naming is ASCII-only and case-insensitive; "swss" and "SWSS"
+ * resolve to the same singleton with a Redis prefix of "SWSS_STATS".
  */
 class ComponentStats
 {
@@ -48,11 +56,14 @@ public:
      *
      * @param componentName  Used as the Redis key prefix, upper-cased.
      *                       For example, "swss" produces keys like
-     *                       "SWSS_STATS:<entity>".
+     *                       "SWSS_STATS:<entity>". ASCII only.
      * @param dbName         Redis logical DB name (default: "COUNTERS_DB").
-     * @param intervalSec    Writer thread flush period in seconds.
-     * @return A shared instance. Repeated calls with the same componentName
-     *         return the same underlying singleton.
+     * @param intervalSec    Writer thread flush period in seconds. A value
+     *                       of 0 is clamped to 1.
+     * @return A shared instance. The FIRST call for a given componentName
+     *         (case-insensitive) wins: dbName and intervalSec from later
+     *         calls are ignored, and a warning is logged if they differ
+     *         from the live instance's values.
      */
     static std::shared_ptr<ComponentStats> create(
         const std::string& componentName,
@@ -79,8 +90,10 @@ public:
     /// Snapshot all metrics for an entity. Returns empty map if unknown.
     CounterSnapshot getAll(const std::string& entity);
 
-    /// Globally enable / disable recording. Hot-path calls become no-ops when
-    /// disabled; the writer thread keeps running but has nothing to flush.
+    /// Globally enable / disable recording. While disabled, increment() and
+    /// setValue() become no-ops; existing in-memory counters are preserved
+    /// and the writer thread keeps running (it just has nothing new to
+    /// flush, so previously-flushed values stay in Redis as-is).
     /// Intended to be wired to a CONFIG_DB knob if runtime control is desired.
     void setEnabled(bool on);
     bool isEnabled() const;
@@ -103,8 +116,12 @@ private:
 
     struct EntityStats
     {
-        // Map of metric name -> counter. std::map keeps references stable.
-        std::map<std::string, std::unique_ptr<Counter>> metrics;
+        // Map of metric name -> counter. std::map keeps references and
+        // iterators stable across inserts, which lets the hot path keep a
+        // Counter& after releasing m_mutex. Counter is non-movable
+        // (std::atomic), but std::map::emplace constructs in place so we do
+        // not need an extra unique_ptr indirection.
+        std::map<std::string, Counter> metrics;
         // Incremented whenever any counter on this entity changes.
         std::atomic<uint64_t> version{0};
 
@@ -119,6 +136,9 @@ private:
 
     // Returns a stable reference. Safe to keep after the lock is released
     // because std::map does not invalidate element references on insert.
+    // INVARIANT: no code path may erase from m_entities or from
+    // EntityStats::metrics while a reference returned here might still be
+    // in use on another thread.
     EntityStats& getOrCreateEntity(const std::string& entity);
     Counter&     getOrCreateCounter(EntityStats& e, const std::string& metric);
 

--- a/common/componentstats.h
+++ b/common/componentstats.h
@@ -20,7 +20,7 @@ class Table;
  *
  * Each instance writes counters to a Redis hash of the form:
  *     <COMPONENT>_STATS:<entity>
- * where each field is a user-defined metric name (e.g. SET, DEL, GET, ERROR…).
+ * where each field is a user-defined metric name (e.g. SET, DEL, GET, ERROR...).
  *
  * Design goals:
  *   - Lock-free counter update: once an entity/metric pair has been seen,
@@ -91,9 +91,10 @@ public:
     CounterSnapshot getAll(const std::string& entity);
 
     /// Globally enable / disable recording. While disabled, increment() and
-    /// setValue() become no-ops; existing in-memory counters are preserved
-    /// and the writer thread keeps running (it just has nothing new to
-    /// flush, so previously-flushed values stay in Redis as-is).
+    /// setValue() become no-ops; existing in-memory counters are preserved.
+    /// The writer thread keeps running and may still flush entities that
+    /// were already marked dirty before setEnabled(false) -- disabling does
+    /// not abort in-flight flushes. Re-enabling resumes normal recording.
     /// Intended to be wired to a CONFIG_DB knob if runtime control is desired.
     void setEnabled(bool on);
     bool isEnabled() const;

--- a/common/componentstats.h
+++ b/common/componentstats.h
@@ -197,7 +197,11 @@ private:
     // Reader/writer mutex guarding the *structure* of m_entities and each
     // EntityStats::metrics. Counter *values* are atomics and do not need
     // this lock.
-    mutable std::shared_mutex m_structMutex;
+    //
+    // shared_timed_mutex (rather than shared_mutex) so the code compiles
+    // under -std=c++14, which is what swss-common's build uses today;
+    // shared_mutex is C++17-only. The timed-wait API is not used.
+    mutable std::shared_timed_mutex m_structMutex;
     std::mutex              m_cvMutex;    // pairs with m_cv for waits
     std::condition_variable m_cv;         // wakes writer on stop()
     std::map<std::string, EntityStats> m_entities;

--- a/common/componentstats.h
+++ b/common/componentstats.h
@@ -5,8 +5,10 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <thread>
+#include <unordered_map>
 #include <vector>
 #include <cstdint>
 
@@ -23,24 +25,31 @@ class Table;
  * where each field is a user-defined metric name (e.g. SET, DEL, GET, ERROR...).
  *
  * Design goals:
- *   - Lock-free counter update: once an entity/metric pair has been seen,
- *     increment() / setValue() update the counter with std::atomic ops.
- *     The first reference to a new entity or metric still takes m_mutex
- *     to insert into the maps.
+ *   - Effectively lock-free hot path on cache hit. After the first use of a
+ *     given (entity, metric) pair, increment() / setValue() only takes a
+ *     shared (reader) lock on the structural mutex for lookup, then mutates
+ *     atomics. Concurrent readers do not serialize against each other.
+ *     The first reference to a new entity or metric still takes the
+ *     structural mutex in exclusive mode to insert into the maps.
  *   - Deferred DB connection: the DBConnector is created inside the writer
  *     thread rather than the constructor, so early-startup callers (singleton
  *     initialization before Redis is ready) do not crash.
  *   - Version-based dirty tracking: the writer thread only pushes entities
  *     whose counters changed since the last flush.
  *   - Stable references: std::map is used instead of unordered_map so that
- *     references returned by getOrCreateEntity() remain valid after later
+ *     references returned by the structural lookup remain valid after later
  *     inserts (unordered_map can rehash and invalidate them). DO NOT change
  *     m_entities to a container that can invalidate references on insert,
  *     and do not add an erase API without revisiting the locking model.
  *   - Clean shutdown: the destructor uses condition_variable::notify_all() to
- *     wake the writer thread immediately instead of waiting up to interval.
+ *     wake the writer thread immediately, then the writer performs one final
+ *     dirty-flush pass before exiting so no in-memory updates are lost.
  *
  * Thread safety: all public methods are safe to call from any thread.
+ *
+ * Mixing increment() and setValue() on the same metric from different threads
+ * is supported but the gauge semantics of setValue() take precedence — see
+ * the setValue() doc for the exact ordering guarantee.
  *
  * Component naming is ASCII-only and case-insensitive; "swss" and "SWSS"
  * resolve to the same singleton with a Redis prefix of "SWSS_STATS".
@@ -78,8 +87,19 @@ public:
                    const std::string& metric,
                    uint64_t n = 1);
 
-    /// Overwrite the metric with an absolute value. Useful for gauge-style
-    /// stats (e.g. queue depth) that are not monotonically increasing.
+    /// Overwrite the metric with an absolute value (gauge semantics).
+    ///
+    /// Takes the structural mutex in exclusive mode so that the value-store
+    /// and the per-entity version bump are observed atomically by the
+    /// writer thread, and so concurrent setValue() calls on the same metric
+    /// are serialized.
+    ///
+    /// IMPORTANT: mixing setValue() (gauge) and increment() (counter) on
+    /// the *same* metric from concurrent threads is best-effort only.
+    /// An increment() landing after setValue() releases its lock will be
+    /// observed by the writer as `value + n` rather than `value`, because
+    /// the increment's atomic fetch_add executes outside the lock. Use
+    /// either gauge-style or counter-style on a given metric, not both.
     void setValue(const std::string& entity,
                   const std::string& metric,
                   uint64_t value);
@@ -100,6 +120,9 @@ public:
     bool isEnabled() const;
 
     /// Stop the writer thread. Called automatically by the destructor.
+    /// Before exiting, the writer thread runs one final flush pass so that
+    /// any counters updated after the last periodic flush are persisted to
+    /// Redis (provided the DB connection is still alive).
     void stop();
 
     // Non-copyable / non-movable (singleton-ish usage)
@@ -119,7 +142,7 @@ private:
     {
         // Map of metric name -> counter. std::map keeps references and
         // iterators stable across inserts, which lets the hot path keep a
-        // Counter& after releasing m_mutex. Counter is non-movable
+        // Counter& after releasing m_structMutex. Counter is non-movable
         // (std::atomic), but std::map::emplace constructs in place so we do
         // not need an extra unique_ptr indirection.
         std::map<std::string, Counter> metrics;
@@ -131,19 +154,37 @@ private:
         EntityStats& operator=(const EntityStats&) = delete;
     };
 
+    // Bundle returned by lookupOrCreate(). Both references are stable for
+    // the lifetime of this ComponentStats (std::map never invalidates
+    // references on insert and this class exposes no erase API).
+    struct CounterRef
+    {
+        EntityStats& entity;
+        Counter&     counter;
+    };
+
     ComponentStats(const std::string& componentName,
                    const std::string& dbName,
                    uint32_t intervalSec);
 
-    // Returns a stable reference. Safe to keep after the lock is released
-    // because std::map does not invalidate element references on insert.
+    // Combined lookup-or-create for (entity, metric).
+    //
+    // Fast path: takes a shared lock and returns existing references — N
+    // concurrent callers do not serialize against each other.
+    // Slow path: on cache miss, upgrades to an exclusive lock to insert.
+    //
     // INVARIANT: no code path may erase from m_entities or from
-    // EntityStats::metrics while a reference returned here might still be
-    // in use on another thread.
-    EntityStats& getOrCreateEntity(const std::string& entity);
-    Counter&     getOrCreateCounter(EntityStats& e, const std::string& metric);
+    // EntityStats::metrics while a CounterRef might still be in use on
+    // another thread.
+    CounterRef lookupOrCreate(const std::string& entity,
+                              const std::string& metric);
 
     void writerThread();
+
+    // One snapshot + flush pass over m_entities. Used by both the periodic
+    // writer loop and the final-flush pass on shutdown. Returns the number
+    // of entities written.
+    size_t flushDirty(std::unordered_map<std::string, uint64_t>& lastVersions);
 
     const std::string m_component;   // already upper-cased
     const std::string m_tableName;   // "<COMPONENT>_STATS"
@@ -153,8 +194,12 @@ private:
     std::atomic<bool> m_enabled{true};
     std::atomic<bool> m_running{true};
 
-    mutable std::mutex      m_mutex;       // guards m_entities structure
-    std::condition_variable m_cv;          // wakes writer on stop()
+    // Reader/writer mutex guarding the *structure* of m_entities and each
+    // EntityStats::metrics. Counter *values* are atomics and do not need
+    // this lock.
+    mutable std::shared_mutex m_structMutex;
+    std::mutex              m_cvMutex;    // pairs with m_cv for waits
+    std::condition_variable m_cv;         // wakes writer on stop()
     std::map<std::string, EntityStats> m_entities;
 
     std::shared_ptr<DBConnector>  m_db;    // created in writerThread

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -46,6 +46,7 @@ tests_tests_SOURCES = tests/redis_ut.cpp                \
                       tests/test_sonicv2connector_c_api.cpp \
                       tests/performancetimer_ut.cpp     \
                       tests/timestamp_ut.cpp            \
+                      tests/componentstats_ut.cpp       \
                       tests/main.cpp
 
 tests_tests_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(LIBNL_CFLAGS)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -48,6 +48,7 @@ tests_tests_SOURCES = tests/redis_ut.cpp                \
                       tests/test_sonicv2connector_c_api.cpp \
                       tests/performancetimer_ut.cpp     \
                       tests/timestamp_ut.cpp            \
+                      tests/componentstats_ut.cpp       \
                       tests/main.cpp
 
 tests_tests_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(LIBNL_CFLAGS)

--- a/tests/componentstats_ut.cpp
+++ b/tests/componentstats_ut.cpp
@@ -1,5 +1,7 @@
 #include "gtest/gtest.h"
 #include "common/componentstats.h"
+#include "common/dbconnector.h"
+#include "common/table.h"
 
 #include <atomic>
 #include <chrono>
@@ -8,6 +10,32 @@
 #include <vector>
 
 using namespace swss;
+
+namespace
+{
+
+// Poll Redis up to timeoutMs waiting for the writer thread to flush.
+bool waitForFlush(Table& tbl,
+                  const std::string& key,
+                  const std::string& field,
+                  const std::string& expected,
+                  int timeoutMs = 5000)
+{
+    using namespace std::chrono;
+    auto deadline = steady_clock::now() + milliseconds(timeoutMs);
+    std::string value;
+    while (steady_clock::now() < deadline)
+    {
+        if (tbl.hget(key, field, value) && value == expected)
+        {
+            return true;
+        }
+        std::this_thread::sleep_for(milliseconds(50));
+    }
+    return false;
+}
+
+} // namespace
 
 // These tests focus on the in-process behavior (no Redis required).
 // The writer thread's DB connect attempts will fail and be retried silently;
@@ -119,4 +147,94 @@ TEST(ComponentStats, StopIsIdempotent)
     auto s = ComponentStats::create("UT_STOP");
     s->stop();
     s->stop();  // should not crash or hang
+}
+
+// --- Writer-thread / Redis integration tests ---------------------------------
+// These use the local Redis instance that the swss-common test harness brings
+// up (the same one used by redis_ut.cpp). They cover the writer-thread paths
+// that the in-memory tests above cannot reach.
+
+TEST(ComponentStats, WriterFlushesToRedis)
+{
+    auto s = ComponentStats::create("UT_FLUSH", "TEST_DB", 1);
+    s->increment("e1", "SET", 3);
+    s->increment("e1", "DEL", 1);
+    s->setValue("e1", "GAUGE", 42);
+
+    DBConnector db("TEST_DB", 0, true);
+    Table tbl(&db, "UT_FLUSH_STATS");
+
+    EXPECT_TRUE(waitForFlush(tbl, "e1", "SET", "3"));
+    EXPECT_TRUE(waitForFlush(tbl, "e1", "DEL", "1"));
+    EXPECT_TRUE(waitForFlush(tbl, "e1", "GAUGE", "42"));
+
+    // A second round of changes should be picked up by the dirty-tracking
+    // path on the next flush.
+    s->increment("e1", "SET", 7);
+    EXPECT_TRUE(waitForFlush(tbl, "e1", "SET", "10"));
+
+    s->stop();
+    tbl.del("e1");
+}
+
+TEST(ComponentStats, WriterSkipsUnchangedEntities)
+{
+    // Exercise the "no change since last flush" branch in writerThread.
+    auto s = ComponentStats::create("UT_NOCHANGE", "TEST_DB", 1);
+    s->increment("e", "X", 1);
+
+    DBConnector db("TEST_DB", 0, true);
+    Table tbl(&db, "UT_NOCHANGE_STATS");
+    ASSERT_TRUE(waitForFlush(tbl, "e", "X", "1"));
+
+    // Overwrite Redis directly; if the writer thread re-flushed an unchanged
+    // entity it would clobber our value back to "1".
+    std::vector<FieldValueTuple> sentinel = {{"X", "999"}};
+    tbl.set("e", sentinel);
+
+    // Wait for at least two flush intervals to give the writer thread a
+    // chance to re-flush. With dirty-tracking it must stay at "999".
+    std::this_thread::sleep_for(std::chrono::milliseconds(2500));
+
+    std::string value;
+    ASSERT_TRUE(tbl.hget("e", "X", value));
+    EXPECT_EQ("999", value);
+
+    s->stop();
+    tbl.del("e");
+}
+
+TEST(ComponentStats, DestructorStopsThread)
+{
+    // Let the shared_ptr go out of scope: the destructor must call stop()
+    // and join the writer thread cleanly.
+    {
+        auto s = ComponentStats::create("UT_DTOR", "TEST_DB", 1);
+        s->increment("e", "X", 1);
+    }
+    // If the destructor failed to join, the test process would hang or
+    // crash on later teardown; reaching this line is the assertion.
+    SUCCEED();
+}
+
+TEST(ComponentStats, ConnectRetryOnBadDb)
+{
+    // Use a database name that does not exist in the test config so the
+    // writer thread's DBConnector construction throws, exercising the
+    // catch + retry path.
+    auto s = ComponentStats::create("UT_BADDB", "DOES_NOT_EXIST_DB", 1);
+    s->increment("e", "X", 1);
+
+    // Give the writer thread time to attempt at least one connect.
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    // In-memory state is still readable even though Redis is unreachable.
+    EXPECT_EQ(1U, s->get("e", "X"));
+
+    // stop() must wake the cv_wait inside the retry loop and return
+    // promptly without hanging.
+    auto start = std::chrono::steady_clock::now();
+    s->stop();
+    auto elapsed = std::chrono::steady_clock::now() - start;
+    EXPECT_LT(elapsed, std::chrono::seconds(2));
 }

--- a/tests/componentstats_ut.cpp
+++ b/tests/componentstats_ut.cpp
@@ -1,0 +1,122 @@
+#include "gtest/gtest.h"
+#include "common/componentstats.h"
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <thread>
+#include <vector>
+
+using namespace swss;
+
+// These tests focus on the in-process behavior (no Redis required).
+// The writer thread's DB connect attempts will fail and be retried silently;
+// that does not affect the getters below, which read from the in-memory map.
+
+TEST(ComponentStats, IncrementBasic)
+{
+    auto s = ComponentStats::create("UT1");
+    s->increment("entity_a", "SET");
+    s->increment("entity_a", "SET");
+    s->increment("entity_a", "DEL");
+
+    EXPECT_EQ(2U, s->get("entity_a", "SET"));
+    EXPECT_EQ(1U, s->get("entity_a", "DEL"));
+    EXPECT_EQ(0U, s->get("entity_a", "UNKNOWN"));
+    EXPECT_EQ(0U, s->get("unknown_entity", "SET"));
+}
+
+TEST(ComponentStats, IncrementByN)
+{
+    auto s = ComponentStats::create("UT2");
+    s->increment("e", "COMPLETE", 5);
+    s->increment("e", "COMPLETE", 3);
+    EXPECT_EQ(8U, s->get("e", "COMPLETE"));
+
+    // n=0 is a no-op
+    s->increment("e", "COMPLETE", 0);
+    EXPECT_EQ(8U, s->get("e", "COMPLETE"));
+}
+
+TEST(ComponentStats, SetValueOverwrites)
+{
+    auto s = ComponentStats::create("UT3");
+    s->increment("e", "GAUGE", 10);
+    s->setValue("e", "GAUGE", 3);
+    EXPECT_EQ(3U, s->get("e", "GAUGE"));
+}
+
+TEST(ComponentStats, GetAllReturnsAllMetrics)
+{
+    auto s = ComponentStats::create("UT4");
+    s->increment("e", "A", 1);
+    s->increment("e", "B", 2);
+    s->increment("e", "C", 3);
+
+    auto all = s->getAll("e");
+    EXPECT_EQ(3U, all.size());
+    EXPECT_EQ(1U, all["A"]);
+    EXPECT_EQ(2U, all["B"]);
+    EXPECT_EQ(3U, all["C"]);
+
+    EXPECT_TRUE(s->getAll("missing").empty());
+}
+
+TEST(ComponentStats, MultipleEntitiesIndependent)
+{
+    auto s = ComponentStats::create("UT5");
+    s->increment("e1", "X", 10);
+    s->increment("e2", "X", 20);
+    EXPECT_EQ(10U, s->get("e1", "X"));
+    EXPECT_EQ(20U, s->get("e2", "X"));
+}
+
+TEST(ComponentStats, DisabledIsNoOp)
+{
+    auto s = ComponentStats::create("UT6");
+    s->increment("e", "X", 5);
+    s->setEnabled(false);
+    s->increment("e", "X", 100);      // ignored
+    s->setValue("e", "X", 999);       // ignored
+    EXPECT_EQ(5U, s->get("e", "X"));
+    s->setEnabled(true);
+    s->increment("e", "X", 1);
+    EXPECT_EQ(6U, s->get("e", "X"));
+}
+
+TEST(ComponentStats, SameComponentReturnsSameInstance)
+{
+    auto a = ComponentStats::create("UT_SINGLETON");
+    auto b = ComponentStats::create("ut_singleton");  // case-insensitive
+    EXPECT_EQ(a.get(), b.get());
+    a->increment("e", "X", 7);
+    EXPECT_EQ(7U, b->get("e", "X"));
+}
+
+TEST(ComponentStats, ConcurrentIncrementsAreExact)
+{
+    auto s = ComponentStats::create("UT_CONC");
+    constexpr int kThreads = 8;
+    constexpr int kOps = 1000;
+
+    std::vector<std::thread> ts;
+    for (int i = 0; i < kThreads; ++i)
+    {
+        ts.emplace_back([s]{
+            for (int j = 0; j < kOps; ++j)
+            {
+                s->increment("hot", "SET");
+            }
+        });
+    }
+    for (auto& t : ts) t.join();
+
+    EXPECT_EQ(static_cast<uint64_t>(kThreads) * kOps, s->get("hot", "SET"));
+}
+
+TEST(ComponentStats, StopIsIdempotent)
+{
+    auto s = ComponentStats::create("UT_STOP");
+    s->stop();
+    s->stop();  // should not crash or hang
+}

--- a/tests/componentstats_ut.cpp
+++ b/tests/componentstats_ut.cpp
@@ -295,28 +295,37 @@ TEST(ComponentStats, RegistryPrunesExpiredInstances)
     // the static registry (every entry becomes an expired weak_ptr; the
     // next create() prunes them).
     //
-    // We can't observe registry size directly, but we can verify the
-    // process doesn't trip over the prune logic and that a recreated
-    // component still resolves to a fresh instance after the original is
-    // released.
-    ComponentStats* firstPtr = nullptr;
+    // We can't observe the registry size directly, and we cannot compare
+    // raw pointers across re-creations either: the allocator is free to
+    // recycle the same address for the second instance after the first
+    // one's storage is freed (which is what actually happens in practice
+    // on glibc). Instead, verify the *singleton* property end-to-end:
+    // after the original UT_PRUNE shared_ptr is released and a churn of
+    // unrelated names triggers a prune cycle, re-creating UT_PRUNE must
+    // start over from a zero counter -- if the old in-memory state had
+    // survived (e.g. because the registry never pruned and somehow kept
+    // the instance alive), the counter increment below would observe a
+    // non-zero starting value.
     {
         auto s1 = ComponentStats::create("UT_PRUNE");
-        firstPtr = s1.get();
+        s1->increment("e", "X", 7);
+        EXPECT_EQ(7U, s1->get("e", "X"));
         s1->stop();
-    } // s1 released here, registry slot is expired
+    } // s1 released here; registry slot becomes expired weak_ptr.
 
-    // Create some unrelated instances to trigger pruning.
+    // Create some unrelated instances to drive create() through the prune
+    // path. Each call to pruneExpiredRegistryLocked() inside create()
+    // should reap the now-expired UT_PRUNE slot.
     for (int i = 0; i < 10; ++i)
     {
         auto tmp = ComponentStats::create("UT_PRUNE_TMP_" + std::to_string(i));
         tmp->stop();
     }
 
-    // Re-create the original name: must get a fresh instance (different
-    // pointer) because the previous one was already destroyed.
+    // Re-create UT_PRUNE. Because the old instance was destroyed, the
+    // new one must start with empty in-memory state.
     auto s2 = ComponentStats::create("UT_PRUNE");
-    EXPECT_NE(firstPtr, s2.get());
+    EXPECT_EQ(0U, s2->get("e", "X"));
     s2->stop();
 }
 

--- a/tests/componentstats_ut.cpp
+++ b/tests/componentstats_ut.cpp
@@ -52,6 +52,7 @@ TEST(ComponentStats, IncrementBasic)
     EXPECT_EQ(1U, s->get("entity_a", "DEL"));
     EXPECT_EQ(0U, s->get("entity_a", "UNKNOWN"));
     EXPECT_EQ(0U, s->get("unknown_entity", "SET"));
+    s->stop();
 }
 
 TEST(ComponentStats, IncrementByN)
@@ -64,6 +65,7 @@ TEST(ComponentStats, IncrementByN)
     // n=0 is a no-op
     s->increment("e", "COMPLETE", 0);
     EXPECT_EQ(8U, s->get("e", "COMPLETE"));
+    s->stop();
 }
 
 TEST(ComponentStats, SetValueOverwrites)
@@ -72,6 +74,7 @@ TEST(ComponentStats, SetValueOverwrites)
     s->increment("e", "GAUGE", 10);
     s->setValue("e", "GAUGE", 3);
     EXPECT_EQ(3U, s->get("e", "GAUGE"));
+    s->stop();
 }
 
 TEST(ComponentStats, GetAllReturnsAllMetrics)
@@ -88,6 +91,7 @@ TEST(ComponentStats, GetAllReturnsAllMetrics)
     EXPECT_EQ(3U, all["C"]);
 
     EXPECT_TRUE(s->getAll("missing").empty());
+    s->stop();
 }
 
 TEST(ComponentStats, MultipleEntitiesIndependent)
@@ -97,6 +101,7 @@ TEST(ComponentStats, MultipleEntitiesIndependent)
     s->increment("e2", "X", 20);
     EXPECT_EQ(10U, s->get("e1", "X"));
     EXPECT_EQ(20U, s->get("e2", "X"));
+    s->stop();
 }
 
 TEST(ComponentStats, DisabledIsNoOp)
@@ -110,6 +115,7 @@ TEST(ComponentStats, DisabledIsNoOp)
     s->setEnabled(true);
     s->increment("e", "X", 1);
     EXPECT_EQ(6U, s->get("e", "X"));
+    s->stop();
 }
 
 TEST(ComponentStats, SameComponentReturnsSameInstance)
@@ -119,6 +125,7 @@ TEST(ComponentStats, SameComponentReturnsSameInstance)
     EXPECT_EQ(a.get(), b.get());
     a->increment("e", "X", 7);
     EXPECT_EQ(7U, b->get("e", "X"));
+    a->stop();
 }
 
 TEST(ComponentStats, ConcurrentIncrementsAreExact)
@@ -140,6 +147,35 @@ TEST(ComponentStats, ConcurrentIncrementsAreExact)
     for (auto& t : ts) t.join();
 
     EXPECT_EQ(static_cast<uint64_t>(kThreads) * kOps, s->get("hot", "SET"));
+    s->stop();
+}
+
+TEST(ComponentStats, ConcurrentIncrementAndSetValueDoNotCrash)
+{
+    // Mixing increment() and setValue() on the same metric from multiple
+    // threads must be safe (setValue now takes an exclusive lock so the
+    // store + version bump are observed atomically; increment() keeps its
+    // shared-lock fast path). This test pounds both code paths at once.
+    auto s = ComponentStats::create("UT_MIXED");
+    std::atomic<bool> stop{false};
+
+    std::thread incr([&]{
+        while (!stop.load()) s->increment("e", "M");
+    });
+    std::thread setv([&]{
+        for (int i = 0; i < 1000 && !stop.load(); ++i)
+            s->setValue("e", "M", i);
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    stop = true;
+    incr.join();
+    setv.join();
+
+    // Value is non-deterministic (race between setValue and increment) but
+    // must be readable without UB.
+    (void)s->get("e", "M");
+    s->stop();
 }
 
 TEST(ComponentStats, StopIsIdempotent)
@@ -209,6 +245,37 @@ TEST(ComponentStats, WriterSkipsUnchangedEntities)
     tbl.del("other");
 }
 
+TEST(ComponentStats, FinalFlushOnShutdown)
+{
+    // Updates landing between the last periodic flush and stop() must NOT
+    // be silently dropped: writerThread runs one final flush pass on
+    // shutdown. Use a long interval so a periodic flush cannot race the
+    // stop() call.
+    auto s = ComponentStats::create("UT_FINAL", "TEST_DB", 60);
+
+    DBConnector db("TEST_DB", 0, true);
+    Table tbl(&db, "UT_FINAL_STATS");
+    tbl.del("e");
+
+    s->increment("e", "LATE", 7);
+    s->setValue("e", "GAUGE_LATE", 99);
+
+    // Sanity-check Redis is empty before stop() — we should NOT have seen a
+    // periodic flush land yet given the 60s interval.
+    std::string value;
+    EXPECT_FALSE(tbl.hget("e", "LATE", value));
+
+    // stop() triggers the final flush in writerThread before join.
+    s->stop();
+
+    ASSERT_TRUE(tbl.hget("e", "LATE", value));
+    EXPECT_EQ("7", value);
+    ASSERT_TRUE(tbl.hget("e", "GAUGE_LATE", value));
+    EXPECT_EQ("99", value);
+
+    tbl.del("e");
+}
+
 TEST(ComponentStats, DestructorStopsThread)
 {
     // Let the shared_ptr go out of scope: the destructor must call stop()
@@ -220,6 +287,37 @@ TEST(ComponentStats, DestructorStopsThread)
     // If the destructor failed to join, the test process would hang or
     // crash on later teardown; reaching this line is the assertion.
     SUCCEED();
+}
+
+TEST(ComponentStats, RegistryPrunesExpiredInstances)
+{
+    // Creating and releasing many uniquely-named instances must not leak
+    // the static registry (every entry becomes an expired weak_ptr; the
+    // next create() prunes them).
+    //
+    // We can't observe registry size directly, but we can verify the
+    // process doesn't trip over the prune logic and that a recreated
+    // component still resolves to a fresh instance after the original is
+    // released.
+    ComponentStats* firstPtr = nullptr;
+    {
+        auto s1 = ComponentStats::create("UT_PRUNE");
+        firstPtr = s1.get();
+        s1->stop();
+    } // s1 released here, registry slot is expired
+
+    // Create some unrelated instances to trigger pruning.
+    for (int i = 0; i < 10; ++i)
+    {
+        auto tmp = ComponentStats::create("UT_PRUNE_TMP_" + std::to_string(i));
+        tmp->stop();
+    }
+
+    // Re-create the original name: must get a fresh instance (different
+    // pointer) because the previous one was already destroyed.
+    auto s2 = ComponentStats::create("UT_PRUNE");
+    EXPECT_NE(firstPtr, s2.get());
+    s2->stop();
 }
 
 TEST(ComponentStats, ConnectRetryOnBadDb)

--- a/tests/componentstats_ut.cpp
+++ b/tests/componentstats_ut.cpp
@@ -192,16 +192,21 @@ TEST(ComponentStats, WriterSkipsUnchangedEntities)
     std::vector<FieldValueTuple> sentinel = {{"X", "999"}};
     tbl.set("e", sentinel);
 
-    // Wait for at least two flush intervals to give the writer thread a
-    // chance to re-flush. With dirty-tracking it must stay at "999".
-    std::this_thread::sleep_for(std::chrono::milliseconds(2500));
+    // Dirty a *different* entity and wait for it to land in Redis. This
+    // proves the writer thread is alive and went through at least one flush
+    // cycle after we planted the sentinel -- otherwise a hung writer would
+    // also leave "999" intact and the test would falsely pass.
+    s->increment("other", "Y", 5);
+    ASSERT_TRUE(waitForFlush(tbl, "other", "Y", "5"));
 
+    // The unchanged entity "e" must not have been re-written by the writer.
     std::string value;
     ASSERT_TRUE(tbl.hget("e", "X", value));
     EXPECT_EQ("999", value);
 
     s->stop();
     tbl.del("e");
+    tbl.del("other");
 }
 
 TEST(ComponentStats, DestructorStopsThread)


### PR DESCRIPTION
## What I did

Added a new reusable library `swss::ComponentStats` under `libswsscommon`, together with its unit tests. The library lets any SONiC container publish service-level counters into `COUNTERS_DB` under a uniform `<COMPONENT>_STATS:<entity>` key layout.

This is a purely additive change — no existing API is modified or removed, and no current consumer of `libswsscommon` calls into the new code, so behaviour of every existing SONiC binary is unchanged.

## Why I did it

SONiC already has dataplane counters (Flex-Counter → syncd → `COUNTERS_DB`). What we are missing is **service-level** counters — software-side events such as orchagent task throughput, gNMI request rate, BMP message error counts. Without them we cannot answer questions like *"is orchagent draining tasks?"*, *"is gNMI seeing subscribe failures?"*, *"is one container dropping more events than its peers?"*.

If each container rolled its own plumbing for this, every container would carry its own concurrency review, the bug fixes would drift, and the on-the-wire schemas would diverge. A single shared library is the only way to keep these properties consistent across SONiC.

Full motivation and design are in the HLD: [sonic-net/SONiC#2312](https://github.com/sonic-net/SONiC/pull/2312).

## How I did it

- Implemented the library as a producer with a lock-free hot path, a 1 s background writer thread, version-based dirty tracking (idle entities produce no Redis traffic), lazy DB connection with retry, and a per-component singleton.
- Kept the public API narrow and stable so future containers only need a ~30 LoC facade to adopt it.
- Added a unit-test suite (`tests/componentstats_ut.cpp`, 9 cases) covering basic round-trip, gauge semantics, runtime enable/disable, bulk read, singleton behaviour, and 8-thread × 10 000-increment concurrency.
- Verified the library can be merged independently: the first consumer ([sonic-swss#4516](https://github.com/sonic-net/sonic-swss/pull/4516)) depends on this PR but this PR does not depend on it.

## Related

- HLD: [sonic-net/SONiC#2312](https://github.com/sonic-net/SONiC/pull/2312)
- First consumer (SwssStats facade): [sonic-net/sonic-swss#4516](https://github.com/sonic-net/sonic-swss/pull/4516)
- Build / integration test: [sonic-net/sonic-buildimage#27456](https://github.com/sonic-net/sonic-buildimage/pull/27456)