### PR TITLE
Add --enable-otlp configure flag and 'otlp' debian build profile

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -44,9 +44,39 @@ AC_ARG_ENABLE(yangmodules,
 	no)  yangmodules=false ;;
 	*) AC_MSG_ERROR(bad value ${enableval} for --enable-yangmodules) ;;
 esac],[yangmodules=true])
+AC_ARG_ENABLE(otlp,
+[  --enable-otlp          Build the OTLP sink (requires opentelemetry-cpp)],
+[case "${enableval}" in
+	yes) otlp=true ;;
+	no)  otlp=false ;;
+	*) AC_MSG_ERROR(bad value ${enableval} for --enable-otlp) ;;
+esac],[otlp=false])
 AM_CONDITIONAL(DEBUG, test x$debug = xtrue)
 AM_CONDITIONAL(PYTHON2, test x$python2 = xtrue)
 AM_CONDITIONAL(YANGMODS, test x$yangmodules = xtrue)
+AM_CONDITIONAL(OTLP, test x$otlp = xtrue)
+
+if test x$otlp = xtrue; then
+	PKG_CHECK_MODULES([OPENTELEMETRY],
+		[opentelemetry_api opentelemetry_sdk opentelemetry_exporter_otlp_grpc],
+		[have_otlp_pkgconfig=yes],
+		[have_otlp_pkgconfig=no])
+	if test x$have_otlp_pkgconfig = xno; then
+		# opentelemetry-cpp does not ship pkg-config files in all distributions.
+		# Fall back to header + library probes so the build still succeeds when
+		# the SDK is installed under a standard prefix.
+		AC_LANG_PUSH([C++])
+		AC_CHECK_HEADER([opentelemetry/version.h], [],
+			[AC_MSG_ERROR([--enable-otlp requested but opentelemetry-cpp headers were not found. Install opentelemetry-cpp or pass CPPFLAGS=-I<prefix>/include.])])
+		AC_LANG_POP([C++])
+		OPENTELEMETRY_CFLAGS=""
+		OPENTELEMETRY_LIBS="-lopentelemetry_exporter_otlp_grpc -lopentelemetry_otlp_recordable -lopentelemetry_proto -lopentelemetry_resources -lopentelemetry_trace -lopentelemetry_metrics -lopentelemetry_common -lgrpc++ -lgrpc -lprotobuf"
+	fi
+	AC_DEFINE([HAVE_OTLP], [1], [Define to 1 if the OTLP sink is built])
+fi
+AC_SUBST([OPENTELEMETRY_CFLAGS])
+AC_SUBST([OPENTELEMETRY_LIBS])
+
 if test x$CONFIGURED_ARCH = xarmhf && test x$CROSS_BUILD_ENVIRON = xy; then
 	AM_CONDITIONAL(ARCH64, false)
 else

--- a/debian/rules
+++ b/debian/rules
@@ -35,6 +35,16 @@ else
 CONFIGURE_ARGS += --enable-yangmodules
 endif
 
+# Build the OTLP sink only when the 'otlp' build profile is active. The
+# OTLP sink depends on opentelemetry-cpp, which is not yet packaged in
+# every distribution; the default build keeps OTLP off so behaviour is
+# unchanged.
+ifneq (,$(filter otlp,$(DEB_BUILD_PROFILES)))
+CONFIGURE_ARGS += --enable-otlp
+else
+CONFIGURE_ARGS += --disable-otlp
+endif
+
 # main packaging script
 %:
 	dh $@


### PR DESCRIPTION
### Why

This PR is the build-system half of **Phase 2** in the Component Statistics HLD ([sonic-net/SONiC#2312](https://github.com/sonic-net/SONiC/pull/2312)).

Phase 1 (#1180 here plus [sonic-net/sonic-swss#4516](https://github.com/sonic-net/sonic-swss/pull/4516)) publishes service-level counters to `COUNTERS_DB`. Phase 2 will additionally export the same counters via OTLP/gRPC to a local OpenTelemetry Collector.

The OTLP sink depends on `opentelemetry-cpp`, which is not yet packaged in every SONiC build environment. To unblock the follow-up PRs that introduce the actual sink (`OtlpSink` wrapper + `ComponentStats` fan-out), this PR wires up the configure machinery first, behind an opt-in flag.

### What

* `configure.ac`
  - New `--enable-otlp` option (default: **disabled**).
  - `PKG_CHECK_MODULES` probe for `opentelemetry_api` / `opentelemetry_sdk` / `opentelemetry_exporter_otlp_grpc`.
  - Fallback header check (`opentelemetry/version.h`) + hard-coded `-l<lib>` list for SDKs that do not ship `.pc` files.
  - Defines `HAVE_OTLP`, `AM_CONDITIONAL OTLP`, and substitutes `OPENTELEMETRY_CFLAGS` / `OPENTELEMETRY_LIBS` for use by `Makefile.am` in follow-up PRs.

* `debian/rules`
  - New `otlp` build profile; activates `--enable-otlp` when present, `--disable-otlp` otherwise (mirrors the existing `noyangmod` pattern).

### What this PR does NOT do

- No new source files, no public-API changes, no behaviour change on the default build path.
- Does not require `opentelemetry-cpp` to be installed unless someone passes `--enable-otlp` (or builds with `DEB_BUILD_PROFILES=otlp`).
- Does not introduce any runtime dependency.

### How to verify

```sh
./autogen.sh
./configure                 # default build; opentelemetry-cpp not required
./configure --enable-otlp   # fails fast with a clear message if the SDK is missing
```

### Follow-ups

- **PR B** — introduce an `OtlpSink` wrapper + unit tests (independent of this PR).
- **PR C** — connect `OtlpSink` to the `ComponentStats` writer-thread fan-out (depends on #1180 + this PR + PR B).