### PR TITLE
Add PR template and align copilot-instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -100,6 +100,11 @@ tests/tests
 - **Testing**: Add tests for new public APIs
 - **ABI compatibility**: Be careful about breaking ABI — this library is linked by many components
 - **SWIG bindings**: If adding new C++ APIs, update SWIG interface files in `pyext/` if Python access is needed
+- **PR description template**: Fill out all sections of the [PR template](pull_request_template.md) when submitting a pull request:
+  - **What I did**: Summarize the change being made
+  - **Why I did it**: Explain motivation and context for the change
+  - **How I verified it**: Provide steps or commands to test the change
+  - **Details if related**: Include any additional context, links, or related information
 
 ## Common Patterns
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+<!--
+Please make sure you have read and understood the contribution guildlines:
+https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md
+
+1. Make sure your commit includes a signature generted with `git commit -s`
+2. Make sure your commit title follows the correct format: [component]: description
+3. Make sure your commit message contains enough details about the change and related tests
+4. Make sure your pull request adds related reviewers, asignees, labels
+
+Please also provide the following information in this pull request:
+-->
+
+**What I did**
+
+**Why I did it**
+
+**How I verified it**
+
+**Details if related**


### PR DESCRIPTION
**What I did**
- Added a new `.github/pull_request_template.md` containing the standard SONiC PR sections (`What I did` / `Why I did it` / `How I verified it` / `Details if related`).
- Aligned the `PR description` guidance in `.github/copilot-instructions.md` to reference the same four sections defined by the new template.


**Why I did it**
The repository did not have a PR template in `.github/`, so contributors were not prompted with the SONiC PR description structure when opening a pull request. Aligned `copilot-instructions.md` so its PR guidance matches the new template.


**How I verified it**
Visual inspection of the updated files.


**Details if related**