### PR TITLE
swsscommon: expose batched ZmqProducerStateTable APIs to SWIG

### DIFF
--- a/goext/swsscommon_test.go
+++ b/goext/swsscommon_test.go
@@ -1,9 +1,11 @@
 package swsscommon
 
 import (
-	"testing"
+	"fmt"
 	"os"
 	"path/filepath"
+	"testing"
+	"time"
 )
 
 func TestSonicDBConfig(t *testing.T) {
@@ -34,3 +36,159 @@ func TestProducerStateTable(t *testing.T) {
 	}
 }
 
+// waitForKcos polls the consumer until it has popped at least `expected`
+// entries from one or more ZMQ messages, then returns the total drained.
+// Per-entry semantic verification is exercised by the C++ unit tests in
+// tests/zmq_state_ut.cpp; this Go test only proves the SWIG glue works.
+func waitForKcos(t *testing.T, c ZmqConsumerStateTable, expected int) int {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	total := 0
+	for time.Now().Before(deadline) && total < expected {
+		q := NewKeyOpFieldsValuesQueue()
+		c.Pops(q)
+		total += int(q.Size())
+		DeleteKeyOpFieldsValuesQueue(q)
+		if total < expected {
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+	return total
+}
+
+func TestZmqProducerBatchedSet(t *testing.T) {
+	const endpoint = "tcp://127.0.0.1:5710"
+	const tableName = "ZMQ_BATCH_SET"
+	const N = 5
+
+	server := NewZmqServer(endpoint)
+	defer DeleteZmqServer(server)
+	client := NewZmqClient(endpoint)
+	defer DeleteZmqClient(client)
+
+	db := NewDBConnector("APPL_DB", uint(0), true)
+	defer DeleteDBConnector(db)
+	producer := NewZmqProducerStateTable(db, tableName, client, false)
+	defer DeleteZmqProducerStateTable(producer)
+	consumer := NewZmqConsumerStateTable(db, tableName, server)
+	defer DeleteZmqConsumerStateTable(consumer)
+
+	keys := NewVectorString()
+	defer DeleteVectorString(keys)
+	fvss := NewFieldValuePairsList()
+	defer DeleteFieldValuePairsList(fvss)
+	for i := 0; i < N; i++ {
+		keys.Add(fmt.Sprintf("batch_set_key_%d", i))
+		fvs := NewFieldValuePairs()
+		fvs.Add(NewFieldValuePair("field", fmt.Sprintf("value_%d", i)))
+		fvss.Add(fvs)
+	}
+
+	ZmqProducerBatchedSet(producer, keys, fvss)
+
+	if got := waitForKcos(t, consumer, N); got != N {
+		t.Errorf("consumer drained %d kfvs, want %d", got, N)
+	}
+}
+
+func TestZmqProducerBatchedDel(t *testing.T) {
+	const endpoint = "tcp://127.0.0.1:5711"
+	const tableName = "ZMQ_BATCH_DEL"
+	const N = 4
+
+	server := NewZmqServer(endpoint)
+	defer DeleteZmqServer(server)
+	client := NewZmqClient(endpoint)
+	defer DeleteZmqClient(client)
+
+	db := NewDBConnector("APPL_DB", uint(0), true)
+	defer DeleteDBConnector(db)
+	producer := NewZmqProducerStateTable(db, tableName, client, false)
+	defer DeleteZmqProducerStateTable(producer)
+	consumer := NewZmqConsumerStateTable(db, tableName, server)
+	defer DeleteZmqConsumerStateTable(consumer)
+
+	keys := NewVectorString()
+	defer DeleteVectorString(keys)
+	for i := 0; i < N; i++ {
+		keys.Add(fmt.Sprintf("batch_del_key_%d", i))
+	}
+
+	ZmqProducerBatchedDel(producer, keys)
+
+	if got := waitForKcos(t, consumer, N); got != N {
+		t.Errorf("consumer drained %d kfvs, want %d", got, N)
+	}
+}
+
+func TestZmqProducerBatchedSend(t *testing.T) {
+	const endpoint = "tcp://127.0.0.1:5712"
+	const tableName = "ZMQ_BATCH_SEND"
+	const N = 6
+
+	server := NewZmqServer(endpoint)
+	defer DeleteZmqServer(server)
+	client := NewZmqClient(endpoint)
+	defer DeleteZmqClient(client)
+
+	db := NewDBConnector("APPL_DB", uint(0), true)
+	defer DeleteDBConnector(db)
+	producer := NewZmqProducerStateTable(db, tableName, client, false)
+	defer DeleteZmqProducerStateTable(producer)
+	consumer := NewZmqConsumerStateTable(db, tableName, server)
+	defer DeleteZmqConsumerStateTable(consumer)
+
+	keys := NewVectorString()
+	defer DeleteVectorString(keys)
+	ops := NewVectorString()
+	defer DeleteVectorString(ops)
+	fvss := NewFieldValuePairsList()
+	defer DeleteFieldValuePairsList(fvss)
+	for i := 0; i < N; i++ {
+		keys.Add(fmt.Sprintf("send_key_%d", i))
+		fvs := NewFieldValuePairs()
+		if i%2 == 0 {
+			ops.Add("SET")
+			fvs.Add(NewFieldValuePair("k", fmt.Sprintf("v_%d", i)))
+		} else {
+			ops.Add("DEL")
+		}
+		fvss.Add(fvs)
+	}
+
+	ZmqProducerBatchedSend(producer, keys, ops, fvss)
+
+	if got := waitForKcos(t, consumer, N); got != N {
+		t.Errorf("consumer drained %d kfvs, want %d", got, N)
+	}
+}
+
+func TestZmqProducerBatchedSetSizeMismatch(t *testing.T) {
+	const endpoint = "tcp://127.0.0.1:5713"
+	const tableName = "ZMQ_BATCH_MISMATCH"
+
+	server := NewZmqServer(endpoint)
+	defer DeleteZmqServer(server)
+	client := NewZmqClient(endpoint)
+	defer DeleteZmqClient(client)
+
+	db := NewDBConnector("APPL_DB", uint(0), true)
+	defer DeleteDBConnector(db)
+	producer := NewZmqProducerStateTable(db, tableName, client, false)
+	defer DeleteZmqProducerStateTable(producer)
+
+	keys := NewVectorString()
+	defer DeleteVectorString(keys)
+	keys.Add("k0")
+	keys.Add("k1")
+	fvss := NewFieldValuePairsList()
+	defer DeleteFieldValuePairsList(fvss)
+	fvss.Add(NewFieldValuePairs())
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic on size mismatch, got none")
+		}
+	}()
+	ZmqProducerBatchedSet(producer, keys, fvss)
+}

--- a/pyext/swsscommon.i
+++ b/pyext/swsscommon.i
@@ -349,6 +349,58 @@ std::vector<std::pair<std::string, std::vector<swss::FieldValueTuple>>> zmqWait(
 %include "producerstatetable.h"
 %include "zmqproducerstatetable.h"
 
+// Batched helpers for ZmqProducerStateTable. The native C++ overloads
+// (set/del/send taking std::vector<KeyOpFieldsValuesTuple>) are reachable
+// through SWIG only as opaque pointer types because std_vector.i does not
+// synthesize a default constructor for the underlying tuple element. These
+// %inline shims take parallel vectors of already-templated types and build
+// the tuple vector on the C++ side, which lets callers in Go / Python issue
+// a single batched ZMQ message.
+%inline %{
+namespace swss {
+static inline void zmqProducerBatchedSet(swss::ZmqProducerStateTable &p,
+                                         const std::vector<std::string> &keys,
+                                         const std::vector<std::vector<swss::FieldValueTuple>> &fvss)
+{
+    if (keys.size() != fvss.size())
+    {
+        throw std::invalid_argument("zmqProducerBatchedSet: keys.size() != fvss.size()");
+    }
+    std::vector<swss::KeyOpFieldsValuesTuple> kcos;
+    kcos.reserve(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i)
+    {
+        kcos.emplace_back(keys[i], SET_COMMAND, fvss[i]);
+    }
+    p.set(kcos);
+}
+
+static inline void zmqProducerBatchedDel(swss::ZmqProducerStateTable &p,
+                                         const std::vector<std::string> &keys)
+{
+    p.del(keys);
+}
+
+static inline void zmqProducerBatchedSend(swss::ZmqProducerStateTable &p,
+                                          const std::vector<std::string> &keys,
+                                          const std::vector<std::string> &ops,
+                                          const std::vector<std::vector<swss::FieldValueTuple>> &fvss)
+{
+    if (keys.size() != ops.size() || keys.size() != fvss.size())
+    {
+        throw std::invalid_argument("zmqProducerBatchedSend: keys/ops/fvss size mismatch");
+    }
+    std::vector<swss::KeyOpFieldsValuesTuple> kcos;
+    kcos.reserve(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i)
+    {
+        kcos.emplace_back(keys[i], ops[i], fvss[i]);
+    }
+    p.send(kcos);
+}
+} // namespace swss
+%}
+
 %apply std::string& OUTPUT {std::string &key};
 %apply std::string& OUTPUT {std::string &op};
 %apply std::vector<std::pair<std::string, std::string>>& OUTPUT {std::vector<std::pair<std::string, std::string>> &fvs};


### PR DESCRIPTION
## Why

The batched overloads of `ZmqProducerStateTable::set/del/send` that take a `std::vector<KeyOpFieldsValuesTuple>` are unreachable from the Go bindings today (and Python is in the same boat). SWIG happily generates the C trampolines and Go methods (e.g. `SwigcptrZmqProducerStateTable.Set__SWIG_3`), but the parameter type `std::vector<KeyOpFieldsValuesTuple>` is not `%template`'d and SWIG cannot synthesize a default constructor for the opaque underlying tuple element, so callers have no way to build the argument — the type exposes only `Swigcptr()`.

Verified empirically in a clean trixie + SWIG 4.3 + Go 1.24 environment:

| Type | `%template`? | Constructor | `Add/Get/Size` |
|------|---------------|-------------|------------------|
| `FieldValuePairs` (`vector<FieldValueTuple>`)              | yes | ✅ | ✅ |
| `VectorString` (`vector<string>`)                           | yes | ✅ | ✅ |
| `KeyOpFieldsValuesQueue` (`deque<KeyOpFieldsValuesTuple>`)  | yes | ✅ | ✅ |
| `vector<KeyOpFieldsValuesTuple>` (parameter of batched `set`/`send`) | **no** | ❌ | ❌ only `Swigcptr()` |

Adding a single `%template` is not enough: even with the list templated, the element `std::tuple<…>` itself has no usable constructor — `std_vector.i` does not synthesize constructors for opaque tuple elements (`std_deque.i` is more permissive, which is why the existing `KeyOpFieldsValuesQueue` works). So the cleanest fix is a small inline shim layer.

Batched `del(vector<string>)` already works today because `VectorString` is templated.

## What

Add three `%inline` helpers in `pyext/swsscommon.i` (also picked up by the goext build via the symlink):

- `zmqProducerBatchedSet(p, keys, fvss)` — all entries get op=SET
- `zmqProducerBatchedDel(p, keys)` — all entries get op=DEL
- `zmqProducerBatchedSend(p, keys, ops, fvss)` — caller supplies per-entry op for mixed batches

Each helper takes parallel vectors of already-wrapped types (`VectorString` and `FieldValuePairsList`) and assembles the `vector<KeyOpFieldsValuesTuple>` on the C++ side before forwarding to the existing batched API. This mirrors the parallel-vector pattern `Table::pops` already uses. Size mismatches throw `std::invalid_argument`, which the existing SWIG exception bridge surfaces to callers as a recoverable panic.

## Why we want this now

This unblocks bulk gNMI Set in sonic-gnmi (sonic-net/sonic-buildimage#27250 — bulk DASH route programming). Today `MixedDbClient.handleTableData` emits one ZMQ message per key; with these helpers it can ship N keys in a single message. Follow-up PR in sonic-gnmi to land afterwards.

## Tests

- New Go tests in `goext/swsscommon_test.go` (`TestZmqProducerBatchedSet/Del/Send` and a `SetSizeMismatch` negative case) drive each helper through a ZmqConsumerStateTable and verify the entries arrive on the consumer side.
- Per-entry semantic correctness is already covered by the existing C++ tests in `tests/zmq_state_ut.cpp`; the Go tests exist to prove the SWIG glue is reachable from Go.
- Verified locally inside `sonic-slave-trixie`:
  - `./configure --disable-yangmodules && make -j && make install` — clean build, no warnings introduced
  - `./tests/tests --gtest_filter='ZmqConsumerStateTable*'` — all 3 ZMQ unit tests pass
  - `cd goext && go test -v -run TestZmqProducer` — all 4 new tests pass

## Related

- sonic-net/sonic-buildimage#27250