### PR TITLE
LruDedup queue policy for Notification Consumer

### DIFF
--- a/common/notificationconsumer.cpp
+++ b/common/notificationconsumer.cpp
@@ -8,15 +8,72 @@
 #define REDIS_PUBLISH_MESSAGE_INDEX (2)
 #define REDIS_PUBLISH_MESSAGE_ELEMNTS (3)
 
-swss::NotificationConsumer::NotificationConsumer(swss::DBConnector *db, const std::string &channel, int pri, size_t popBatchSize):
+namespace {
+
+// Periodic stats SWSS_LOG_NOTICE throttle.  At most one log per
+// kStatsLogInterval per consumer/queue, and only when counters have
+// advanced since the previous line.  This is intentionally
+// coarse-grained so a sustained storm produces a steady but small log
+// trail (well under rsyslog's default imuxsock rate limit of
+// 1000 msgs / 5 s).
+constexpr std::chrono::seconds kStatsLogInterval{5};
+
+// Counter-side gate that avoids the cost of steady_clock::now() for every
+// message; the 5 sec wall-clock throttle still determines actual log
+// frequency.
+constexpr uint64_t kStatsCheckEveryN = 1024;
+
+} // namespace
+
+std::string swss::peekOp(const std::string &msg)
+{
+    if (msg.size() < 3 || msg[0] != '[' || msg[1] != '"') return {};
+    auto end = msg.find('"', 2);
+    if (end == std::string::npos) return {};
+    return msg.substr(2, end - 2);
+}
+
+// Original 4-arg constructor. Defaults to Fifo policy; behavior identical to
+// legacy.
+swss::NotificationConsumer::NotificationConsumer(swss::DBConnector *db,
+                                                 const std::string &channel,
+                                                 int pri,
+                                                 size_t popBatchSize):
     Selectable(pri),
     POP_BATCH_SIZE(popBatchSize),
     m_db(db),
     m_subscribe(NULL),
-    m_channel(channel)
+    m_channel(channel),
+    m_queue(std::make_unique<FifoNotificationQueue>())
 {
     SWSS_LOG_ENTER();
+    subscribeWithRetry();
+}
 
+// New 5-arg constructor with explicit policy.
+swss::NotificationConsumer::NotificationConsumer(swss::DBConnector *db,
+                                                 const std::string &channel,
+                                                 int pri,
+                                                 size_t popBatchSize,
+                                                 swss::NotificationQueuePolicy policy):
+    Selectable(pri),
+    POP_BATCH_SIZE(popBatchSize),
+    m_db(db),
+    m_subscribe(NULL),
+    m_channel(channel),
+    m_queue(policy == NotificationQueuePolicy::LruDedup
+            ? std::unique_ptr<NotificationQueueBase>(std::make_unique<LruDedupNotificationQueue>(channel))
+            : std::unique_ptr<NotificationQueueBase>(std::make_unique<FifoNotificationQueue>()))
+{
+    SWSS_LOG_ENTER();
+    subscribeWithRetry();
+}
+
+// Both constructors share the same subscribe-and-retry loop.  Any
+// future change (backoff, retry limit, error reporting) lives here
+// in one place.
+void swss::NotificationConsumer::subscribeWithRetry()
+{
     while (true)
     {
         try
@@ -27,7 +84,6 @@ swss::NotificationConsumer::NotificationConsumer(swss::DBConnector *db, const st
         catch(...)
         {
             delete m_subscribe;
-
             SWSS_LOG_ERROR("failed to subscribe on %s", m_channel.c_str());
         }
     }
@@ -105,12 +161,12 @@ uint64_t swss::NotificationConsumer::readData()
 
 bool swss::NotificationConsumer::hasData()
 {
-    return m_queue.size() > 0;
+    return m_queue->size() > 0;
 }
 
 bool swss::NotificationConsumer::hasCachedData()
 {
-    return m_queue.size() > 1;
+    return m_queue->size() > 1;
 }
 
 void swss::NotificationConsumer::processReply(redisReply *reply)
@@ -138,21 +194,89 @@ void swss::NotificationConsumer::processReply(redisReply *reply)
 
     SWSS_LOG_DEBUG("got message: %s", msg.c_str());
 
-    m_queue.push(msg);
+    m_received.fetch_add(1, std::memory_order_relaxed);
+
+    if (!m_op_allowlist.empty())
+    {
+        auto op = peekOp(msg);
+        // Drop messages whose op is not in the allowlist before they
+        // consume queue memory.  This is the cross-fanout defense for
+        // shared channels like "NOTIFICATIONS": each subscriber
+        // declares exactly which ops its doTask cares about and
+        // silently drops the rest at admission instead of after pop.
+        if (op.empty() || m_op_allowlist.find(op) == m_op_allowlist.end())
+        {
+            m_dropped_allowlist.fetch_add(1, std::memory_order_relaxed);
+            maybeLogStats();
+            return;
+        }
+    }
+
+    m_queue->push(msg);
+    maybeLogStats();
+}
+
+void swss::NotificationConsumer::setStatsLabel(const std::string &label)
+{
+    m_stats_label = label;
+    // If the underlying queue is LruDedup, propagate the label so the
+    // queue-side stats / HWM lines use the same identifier.
+    if (auto *lru = getLruDedupQueue())
+    {
+        lru->setLabel(label);
+    }
+    SWSS_LOG_NOTICE("NotificationConsumer[%s]: stats label set (channel=%s)",
+                    label.c_str(), m_channel.c_str());
+}
+
+void swss::NotificationConsumer::setOpAllowList(std::unordered_set<std::string> ops)
+{
+    m_op_allowlist = std::move(ops);
+    SWSS_LOG_NOTICE("NotificationConsumer[%s]: op allowlist set to %zu entries",
+                    (m_stats_label.empty() ? m_channel : m_stats_label).c_str(),
+                    m_op_allowlist.size());
+}
+
+swss::LruDedupNotificationQueue* swss::NotificationConsumer::getLruDedupQueue() const
+{
+    return dynamic_cast<LruDedupNotificationQueue*>(m_queue.get());
+}
+
+void swss::NotificationConsumer::maybeLogStats()
+{
+    uint64_t r = m_received.load(std::memory_order_relaxed);
+    if ((r & (kStatsCheckEveryN - 1)) != 0) return;
+
+    auto now = std::chrono::steady_clock::now();
+    if (now - m_last_stats_log < kStatsLogInterval) return;
+
+    if (r == m_last_logged_received) return;     // idle, nothing new since last log
+
+    uint64_t d = m_dropped_allowlist.load(std::memory_order_relaxed);
+    SWSS_LOG_NOTICE("NotificationConsumer[%s]: stats received=%llu "
+                    "dropped_allowlist=%llu admit_ratio=%.2f%% allowlist_entries=%zu",
+                    (m_stats_label.empty() ? m_channel : m_stats_label).c_str(),
+                    static_cast<unsigned long long>(r),
+                    static_cast<unsigned long long>(d),
+                    r ? 100.0 * static_cast<double>(r - d) / static_cast<double>(r) : 0.0,
+                    m_op_allowlist.size());
+
+    m_last_logged_received = r;
+    m_last_stats_log = now;
 }
 
 void swss::NotificationConsumer::pop(std::string &op, std::string &data, std::vector<FieldValueTuple> &values)
 {
     SWSS_LOG_ENTER();
 
-    if (m_queue.empty())
+    if (m_queue->empty())
     {
         SWSS_LOG_ERROR("notification queue is empty, can't pop");
         throw std::runtime_error("notification queue is empty, can't pop");
     }
 
-    std::string msg = m_queue.front();
-    m_queue.pop();
+    std::string msg = m_queue->front();
+    m_queue->pop();
 
     values.clear();
     JSon::readJson(msg, values);
@@ -170,9 +294,9 @@ void swss::NotificationConsumer::pops(std::deque<KeyOpFieldsValuesTuple> &vkco)
     SWSS_LOG_ENTER();
 
     vkco.clear();
-    while(!m_queue.empty())
+    while(!m_queue->empty())
     {
-        while(!m_queue.empty())
+        while(!m_queue->empty())
         {
             std::string op;
             std::string data;
@@ -198,7 +322,7 @@ void swss::NotificationConsumer::pops(std::deque<KeyOpFieldsValuesTuple> &vkco)
 int swss::NotificationConsumer::peek()
 {
     SWSS_LOG_ENTER();
-    if (m_queue.empty())
+    if (m_queue->empty())
     {
         // Peek for more data in redis socket
         int rc = swss::peekRedisContext(m_subscribe->getContext());
@@ -209,5 +333,73 @@ int swss::NotificationConsumer::peek()
         readData();
     }
 
-    return m_queue.empty() ? 0 : 1;
+    return m_queue->empty() ? 0 : 1;
+}
+
+void swss::LruDedupNotificationQueue::push(const std::string& msg)
+{
+    bool was_dedup_hit = false;
+    auto it = m_idx.find(msg);
+    if (it != m_idx.end()) {
+        m_dq.erase(it->second);
+        m_idx.erase(it);
+        was_dedup_hit = true;
+    }
+    m_dq.push_back(msg);
+    m_idx[msg] = std::prev(m_dq.end());
+
+    // Counters.  Relaxed atomics throughout: every member that
+    // getStats() reads may be observed from a different thread
+    // (orchagent's telemetry publisher).  push()/pop() are still
+    // single-threaded; the atomics are only for cross-thread reads.
+    m_pushed.fetch_add(1, std::memory_order_relaxed);
+    if (was_dedup_hit) {
+        m_dedup_hits.fetch_add(1, std::memory_order_relaxed);
+    } else {
+        // Net queue growth happens only on novel payloads.  Dedup
+        // hits keep depth constant.
+        m_current_depth.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    // Track the high watermark.  Don't emit a per-update syslog --
+    // under a workload with many distinct payloads, every novel push
+    // raises HWM and would flood syslog.  HWM is visible via the
+    // throttled stats line and getStats() / COUNTERS_DB.
+    size_t cur = m_current_depth.load(std::memory_order_relaxed);
+    size_t prev_hwm = m_high_watermark.load(std::memory_order_relaxed);
+    if (cur > prev_hwm) {
+        m_high_watermark.store(cur, std::memory_order_relaxed);
+    }
+
+    maybeLogStats();
+}
+
+// ---------------------------------------------------------------------------
+// LruDedupNotificationQueue::maybeLogStats -- defined out-of-line so the
+// steady_clock dependency stays in the .cpp.
+// ---------------------------------------------------------------------------
+void swss::LruDedupNotificationQueue::maybeLogStats()
+{
+    uint64_t p = m_pushed.load(std::memory_order_relaxed);
+    if ((p & (kStatsCheckEveryN - 1)) != 0) return;
+
+    auto now = std::chrono::steady_clock::now();
+    if (now - m_last_stats_log < kStatsLogInterval) return;
+
+    if (p == m_last_logged_pushed) return;       // idle, no progress
+
+    uint64_t h = m_dedup_hits.load(std::memory_order_relaxed);
+    size_t   d = m_current_depth.load(std::memory_order_relaxed);
+    size_t   hwm = m_high_watermark.load(std::memory_order_relaxed);
+    SWSS_LOG_NOTICE(
+        "LruDedupNotificationQueue[%s]: stats pushed=%llu dedup_hits=%llu "
+        "dedup_ratio=%.2f%% depth=%zu hwm=%zu",
+        m_label.c_str(),
+        static_cast<unsigned long long>(p),
+        static_cast<unsigned long long>(h),
+        p ? 100.0 * static_cast<double>(h) / static_cast<double>(p) : 0.0,
+        d, hwm);
+
+    m_last_logged_pushed = p;
+    m_last_stats_log = now;
 }

--- a/common/notificationconsumer.h
+++ b/common/notificationconsumer.h
@@ -1,9 +1,15 @@
 #ifndef __NOTIFICATIONCONSUMER__
 #define __NOTIFICATIONCONSUMER__
 
+#include <atomic>
+#include <chrono>
 #include <string>
 #include <vector>
 #include <queue>
+#include <list>
+#include <unordered_map>
+#include <unordered_set>
+#include <memory>
 
 #include <hiredis/hiredis.h>
 
@@ -18,10 +24,216 @@ namespace swss {
 
 static constexpr size_t DEFAULT_NC_POP_BATCH_SIZE = 2048;
 
+// Extract the leading op string from a NotificationProducer JSON-array
+// message of the form: ["op","data","f1","v1",...].  Returns an empty
+// string if the message does not start with the expected
+// array-of-strings prefix.  Bounded scan, no JSON parse.  See
+// NotificationProducer::send + JSon::buildJson for the wire format
+// this matches.
+std::string peekOp(const std::string &msg);
+
+// ---------------------------------------------------------------------------
+// Abstract queue strategy.  Single-threaded; no internal locking required.
+// getStats() is safe to call from any thread, other APIs are single-threaded.
+// ---------------------------------------------------------------------------
+class NotificationQueueBase {
+public:
+    virtual ~NotificationQueueBase() = default;
+    virtual void               push(const std::string& msg) = 0;
+    virtual const std::string& front() const                = 0;
+    virtual void               pop()                        = 0;
+    virtual bool               empty() const                = 0;
+    virtual size_t             size()  const                = 0;
+};
+
+// ---------------------------------------------------------------------------
+// Existing FIFO behavior -- preserves strict arrival order, no dedup.
+// This is the default and is bit-for-bit identical to the pre-strategy code.
+// ---------------------------------------------------------------------------
+class FifoNotificationQueue : public NotificationQueueBase {
+public:
+    void push(const std::string& msg) override
+    {
+        m_q.push(msg);
+    }
+
+    const std::string& front() const override
+    {
+        return m_q.front();
+    }
+
+    void pop() override
+    {
+        m_q.pop();
+    }
+
+    bool empty() const override
+    {
+        return m_q.empty();
+    }
+
+    size_t size() const override
+    {
+        return m_q.size();
+    }
+
+private:
+    std::queue<std::string> m_q;
+};
+
+// ---------------------------------------------------------------------------
+// LRU-dedup queue.
+//
+// On push(msg): if msg is already present (byte-identical), the old list
+// position is erased and the entry is re-inserted at the tail.  On push
+// of a novel msg, the msg is appended at the tail unconditionally.
+// pop() removes from the head.
+//
+// Drain order: "last-seen time per unique payload."  Memory is bounded by
+// count(distinct payloads ever present), not by event rate.
+//
+// Max queue-depth: queue depth is bound to count(distinct_payloads). If the
+// consumer has very high cardinality of distinct payloads, the max queue
+// depth could still be high under storm.
+//
+// Instrumentation:
+//   - m_high_watermark : monotonic max of m_dq.size() seen.
+//                        A SWSS_LOG_NOTICE fires whenever a new max is
+//                        reached, including a per-instance label
+//                        (typically the channel name).
+//
+// Only opt in for consumers that have been audited as end-state-idempotent.
+// ---------------------------------------------------------------------------
+class LruDedupNotificationQueue : public NotificationQueueBase {
+public:
+    // Snapshot returned by getStats().  Cheap to copy; can be published to
+    // COUNTERS_DB or logged.
+    //
+    // Plain aggregate; no default member initializers because some
+    // gcc/-std=c++14 combinations reject brace-init of an aggregate that
+    // mixes DMIs with a returned aggregate.  All callers supply every
+    // member.
+    struct Stats {
+        uint64_t pushed;          // total push() calls
+        uint64_t dedup_hits;      // pushes that collapsed onto existing entry
+        size_t   high_watermark;  // max queue depth ever
+        size_t   current_depth;   // depth right now
+    };
+
+    explicit LruDedupNotificationQueue(const std::string& label = "")
+        : m_label(label) {}
+
+    void push(const std::string& msg) override;
+
+    const std::string& front() const override
+    {
+        return m_dq.front();
+    }
+
+    void pop() override
+    {
+        if (m_dq.empty()) return;   // defensive; caller should check empty()
+        auto it = m_idx.find(m_dq.front());
+        if (it != m_idx.end()) m_idx.erase(it);
+        m_dq.pop_front();
+        m_current_depth.fetch_sub(1, std::memory_order_relaxed);
+    }
+
+    bool empty() const override
+    {
+        return m_dq.empty();
+    }
+
+    size_t size() const override
+    {
+        return m_dq.size();
+    }
+
+    // Snapshot of all counters.  Lock-free; safe to call from a thread
+    // other than the one driving push()/pop().
+    Stats getStats() const {
+        Stats s;
+        s.pushed         = m_pushed.load(std::memory_order_relaxed);
+        s.dedup_hits     = m_dedup_hits.load(std::memory_order_relaxed);
+        s.high_watermark = m_high_watermark.load(std::memory_order_relaxed);
+        s.current_depth  = m_current_depth.load(std::memory_order_relaxed);
+        return s;
+    }
+
+    // Mutable from gdb for inspection; the setter form keeps the
+    // NotificationConsumer-driven label-propagation path safe under
+    // a future API audit (see setLabel below).
+    void setLabel(const std::string& label) { m_label = label; }
+
+private:
+    void maybeLogStats();
+
+    std::list<std::string> m_dq;
+    std::unordered_map<std::string, std::list<std::string>::iterator> m_idx;
+    std::string m_label;
+
+    // Telemetry.  All atomic so getStats() is safe to call cross-thread.
+    // m_pushed / m_dedup_hits are monotonic counters incremented in
+    // push().  m_high_watermark is monotonic-increasing.  m_current_depth
+    // tracks net queue growth (incremented on novel push, decremented
+    // on pop, unchanged on dedup-hit).
+    std::atomic<uint64_t> m_pushed{0};
+    std::atomic<uint64_t> m_dedup_hits{0};
+    std::atomic<size_t>   m_high_watermark{0};
+    std::atomic<size_t>   m_current_depth{0};
+
+    // Throttling for the periodic stats SWSS_LOG_NOTICE.  At most one log
+    // per kStatsLogInterval, and only when the counters have advanced
+    // since the previous log line.  No timer thread is needed -- the
+    // throttle gate runs inline from push().
+    std::chrono::steady_clock::time_point m_last_stats_log{};
+    uint64_t m_last_logged_pushed{0};
+};
+
+// ---------------------------------------------------------------------------
+// Policy tag passed to NotificationConsumer at construction time.
+// Existing call sites compile unchanged (Fifo is the default).
+// ---------------------------------------------------------------------------
+enum class NotificationQueuePolicy {
+    // Default. Strict FIFO; every push is preserved in arrival order.
+    Fifo,
+
+    // Opt-in dedup with re-ordering. Collapses duplicated by moving the
+    // duplicate to the tail of the queue, so drain order becomes "last-seen
+    // time per unique payload" instead of arrival order. Bounds the size of
+    // the queue under storms.
+    // Pick this policy if the consumer's outcome is idempotent and determined
+    // by the final state per unique payload. If the consumers needs every
+    // event observed in arrival order, pick Fifo.
+    LruDedup
+};
+
 class NotificationConsumer : public Selectable
 {
 public:
-    NotificationConsumer(swss::DBConnector *db, const std::string &channel, int pri = 100, size_t popBatchSize = DEFAULT_NC_POP_BATCH_SIZE);
+    // Snapshot returned by getStats().  Cheap to copy.
+    struct Stats {
+        uint64_t received;           // total processReply admissions attempted
+        uint64_t dropped_allowlist;  // dropped at admission by op-allowlist
+    };
+
+    // Original 4-arg constructor.  Preserved verbatim so the mangled symbol
+    // matches every binary that linked against pre-strategy libswsscommon
+    // (e.g. python3-swsscommon's _swsscommon.so).  Defaults to Fifo policy.
+    NotificationConsumer(swss::DBConnector *db,
+                         const std::string &channel,
+                         int pri = 100,
+                         size_t popBatchSize = DEFAULT_NC_POP_BATCH_SIZE);
+
+    // New 5-arg constructor that takes an explicit queue policy.  Callers
+    // that want LruDedup pass NotificationQueuePolicy::LruDedup here.
+    // Distinct mangled symbol from the 4-arg form, so old binaries keep
+    // resolving the 4-arg version unchanged.
+    NotificationConsumer(swss::DBConnector *db,
+                         const std::string &channel,
+                         int pri,
+                         size_t popBatchSize,
+                         NotificationQueuePolicy policy);
 
     // Pop one or multiple data from the internal queue which fed from redis socket
     // Note:
@@ -44,6 +256,50 @@ public:
     bool hasCachedData() override;
     const size_t POP_BATCH_SIZE;
 
+    // Set an orch-qualified label (e.g. "FdbOrch:fdb_event") for syslog
+    // identification.  Without this, every consumer on the same Redis
+    // channel logs as "NotificationConsumer[<channel>]" -- indistinguish-
+    // able when several orchs subscribe to the same channel.  When set,
+    // both the consumer's periodic stats line and the internal LruDedup
+    // queue's HWM / stats lines use this label instead of the bare
+    // channel name.  Empty (default) preserves legacy channel-only
+    // logging.
+    void setStatsLabel(const std::string &label);
+
+    // Restrict which messages are admitted into the internal queue.
+    //
+    // When the set is non-empty, processReply extracts the leading "op"
+    // token from the JSON-array message and drops the message unless op
+    // is in the set.  An empty set (default) preserves legacy behavior:
+    // every received message is enqueued.
+    //
+    // Intended use: every orch's doTask(NotificationConsumer&) handles a
+    // small fixed set of op strings and discards the rest.  Setting the
+    // same set here prevents the discarded messages from ever consuming
+    // queue memory.  This is the consumer-side defense against pub/sub
+    // fanout on the "NOTIFICATIONS" channel, where every subscriber
+    // receives a copy of every message even if it only cares about one op.
+    void setOpAllowList(std::unordered_set<std::string> ops);
+
+    // Snapshot of admission counters.  Lock-free.
+    Stats getStats() const {
+        Stats s;
+        s.received          = m_received.load(std::memory_order_relaxed);
+        s.dropped_allowlist = m_dropped_allowlist.load(std::memory_order_relaxed);
+        return s;
+    }
+
+    // Returns a pointer to the internal LruDedup queue if this consumer
+    // was constructed with NotificationQueuePolicy::LruDedup, otherwise
+    // nullptr.  Telemetry uses this to fetch the queue-side counters
+    // (dedup hits, HWM) via LruDedupNotificationQueue::getStats().
+    //
+    // Lifetime: pointer is valid as long as the NotificationConsumer is
+    // alive.  Do not delete.
+    LruDedupNotificationQueue* getLruDedupQueue() const;
+
+    const std::string& getChannel() const { return m_channel; }
+
 private:
 
     NotificationConsumer(const NotificationConsumer &other);
@@ -51,14 +307,26 @@ private:
 
     void processReply(redisReply *reply);
     void subscribe();
+    void subscribeWithRetry();
+    void maybeLogStats();
 
     swss::DBConnector *m_db;
     swss::DBConnector *m_subscribe;
     std::string m_channel;
-    std::queue<std::string> m_queue;
+    std::string m_stats_label;     // orch-qualified label for syslog; empty -> use m_channel
+    std::unique_ptr<NotificationQueueBase> m_queue;
+    std::unordered_set<std::string> m_op_allowlist;
+
+    // Telemetry.
+    std::atomic<uint64_t> m_received{0};
+    std::atomic<uint64_t> m_dropped_allowlist{0};
+
+    // Throttling for the periodic stats SWSS_LOG_NOTICE.  Same pattern as
+    // LruDedupNotificationQueue::maybeLogStats.
+    std::chrono::steady_clock::time_point m_last_stats_log{};
+    uint64_t m_last_logged_received{0};
 };
 
 }
 
 #endif // __NOTIFICATIONCONSUMER__
-

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -21,3 +21,14 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+cc_test(
+    name = "notification_queue_ut",
+    srcs = ["notification_queue_ut.cpp"],
+    deps = [
+        "//:libswsscommon",
+        "@com_github_google_glog//:glog",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -32,6 +32,7 @@ tests_tests_SOURCES = tests/redis_ut.cpp                \
                       tests/boolean_ut.cpp              \
                       tests/status_code_util_test.cpp   \
                       tests/saiaclschema_ut.cpp         \
+                      tests/notification_queue_ut.cpp   \
                       tests/countertable_ut.cpp         \
                       tests/timer_ut.cpp                \
                       tests/cli_ut.cpp                  \

--- a/tests/notification_queue_ut.cpp
+++ b/tests/notification_queue_ut.cpp
@@ -1,0 +1,265 @@
+// Unit tests for the NotificationQueueBase strategy classes:
+//   FifoNotificationQueue     -- verifies strict arrival-order preservation
+//   LruDedupNotificationQueue -- verifies LRU dedup semantics
+//   peekOp                    -- verifies the op-extraction helper
+//                                that drives setOpAllowList admission
+//
+// These tests are pure in-memory; they do NOT require a running redis-server.
+// End-to-end coverage of setOpAllowList filtering (which needs a real
+// NotificationProducer + DBConnector wired through redis) lives in
+// ntf_ut.cpp; see TEST(Notifications, AllowList).
+
+#include <gtest/gtest.h>
+
+#include "common/notificationconsumer.h"
+
+using swss::FifoNotificationQueue;
+using swss::LruDedupNotificationQueue;
+using swss::peekOp;
+
+// ---------------------------------------------------------------------------
+// FifoNotificationQueue tests
+// ---------------------------------------------------------------------------
+
+TEST(FifoNotificationQueue, PreservesArrivalOrder)
+{
+    FifoNotificationQueue q;
+    EXPECT_TRUE(q.empty());
+    EXPECT_EQ(q.size(), 0u);
+
+    q.push("a");
+    q.push("b");
+    q.push("c");
+
+    EXPECT_EQ(q.size(), 3u);
+
+    EXPECT_EQ(q.front(), "a"); q.pop();
+    EXPECT_EQ(q.front(), "b"); q.pop();
+    EXPECT_EQ(q.front(), "c"); q.pop();
+    EXPECT_TRUE(q.empty());
+}
+
+TEST(FifoNotificationQueue, AllowsDuplicates)
+{
+    FifoNotificationQueue q;
+    q.push("dup");
+    q.push("dup");
+    q.push("dup");
+    EXPECT_EQ(q.size(), 3u);
+    EXPECT_EQ(q.front(), "dup"); q.pop();
+    EXPECT_EQ(q.front(), "dup"); q.pop();
+    EXPECT_EQ(q.front(), "dup"); q.pop();
+    EXPECT_TRUE(q.empty());
+}
+
+// ---------------------------------------------------------------------------
+// LruDedupNotificationQueue tests
+// ---------------------------------------------------------------------------
+
+TEST(LruDedupNotificationQueue, CollapsesByteIdenticalDuplicate)
+{
+    LruDedupNotificationQueue q("test");
+    q.push("a");
+    q.push("a");
+    q.push("a");
+
+    EXPECT_EQ(q.size(), 1u);
+    EXPECT_EQ(q.front(), "a");
+    q.pop();
+    EXPECT_TRUE(q.empty());
+
+    auto s = q.getStats();
+    EXPECT_EQ(s.pushed, 3u);
+    EXPECT_EQ(s.dedup_hits, 2u);
+    EXPECT_EQ(s.high_watermark, 1u);
+}
+
+TEST(LruDedupNotificationQueue, DrainOrderIsLastSeenPerUniquePayload)
+{
+    LruDedupNotificationQueue q("test");
+
+    // Arrival: a, b, a, c, b
+    q.push("a");          // [a]
+    q.push("b");          // [a, b]
+    q.push("a");          // [b, a]      (a re-inserted at tail)
+    q.push("c");          // [b, a, c]
+    q.push("b");          // [a, c, b]   (b re-inserted at tail)
+
+    EXPECT_EQ(q.size(), 3u);
+    EXPECT_EQ(q.front(), "a"); q.pop();
+    EXPECT_EQ(q.front(), "c"); q.pop();
+    EXPECT_EQ(q.front(), "b"); q.pop();
+    EXPECT_TRUE(q.empty());
+}
+
+TEST(LruDedupNotificationQueue, HighWatermarkIsMonotonic)
+{
+    LruDedupNotificationQueue q("test");
+
+    q.push("a");
+    q.push("b");
+    q.push("c");
+    EXPECT_EQ(q.getStats().high_watermark, 3u);
+
+    q.pop();
+    q.pop();
+    EXPECT_EQ(q.getStats().high_watermark, 3u);  // HWM does not decrease
+
+    q.push("d");
+    EXPECT_EQ(q.getStats().high_watermark, 3u);  // still 3, didn't exceed it
+
+    q.push("e");
+    q.push("f");
+    EXPECT_EQ(q.getStats().high_watermark, 4u);  // new max reached
+}
+
+TEST(LruDedupNotificationQueue, MemoryBoundedByDistinctPayloads)
+{
+    LruDedupNotificationQueue q("test");
+
+    // Push the same 4 distinct payloads many times, in arbitrary interleaving.
+    const char *payloads[] = {"A", "B", "C", "D"};
+    for (int i = 0; i < 1000; ++i) {
+        q.push(payloads[i % 4]);
+    }
+
+    EXPECT_EQ(q.size(), 4u);
+    auto s = q.getStats();
+    EXPECT_EQ(s.pushed, 1000u);
+    EXPECT_EQ(s.dedup_hits, 996u);
+    EXPECT_EQ(s.high_watermark, 4u);
+}
+
+TEST(LruDedupNotificationQueue, EmptyPopIsSafe)
+{
+    LruDedupNotificationQueue q;
+    EXPECT_TRUE(q.empty());
+    q.pop();   // must not crash
+    EXPECT_TRUE(q.empty());
+}
+
+TEST(LruDedupNotificationQueue, SetLabelTakesEffectForFutureStatsLines)
+{
+    // setLabel is used by NotificationConsumer::setStatsLabel to keep the
+    // queue-side periodic log identifier aligned with the consumer-side
+    // identifier.  Exercise it directly so the path is covered without
+    // requiring a redis-backed NotificationConsumer.
+    LruDedupNotificationQueue q("initial");
+    q.setLabel("renamed");
+
+    // No public getter for the label -- the only observable side effect is
+    // the periodic SWSS_LOG_NOTICE.  Drive a push() so the maybeLogStats()
+    // path actually executes with the renamed label; the test asserts on
+    // structural invariants (no crash, counters advance) and trusts the
+    // log inspection during coverage runs to confirm the rename took.
+    q.push("payload-a");
+    EXPECT_EQ(q.getStats().pushed, 1u);
+    EXPECT_EQ(q.size(), 1u);
+}
+
+TEST(LruDedupNotificationQueue, MaybeLogStatsCounterGateAndEmission)
+{
+    // LruDedupNotificationQueue::maybeLogStats() is the throttled stats
+    // logger called from every push().  It has three gates:
+    //
+    //   1. counter gate: returns unless `m_pushed % kStatsCheckEveryN == 0`
+    //      (1024 in the .cpp).  Skipped pushes never even read the clock.
+    //   2. time gate:    returns if less than 5s since the previous log.
+    //   3. idle gate:    returns if no new pushes since the previous log.
+    //
+    // This test exercises (1) and (2) plus the actual emission path by
+    // pushing two batches of 1024 distinct payloads back-to-back: the
+    // first 1024th push opens all three gates and emits, the second
+    // 1024th push (cumulative 2048) opens the counter gate but is closed
+    // by the time gate because the two batches land within ~milliseconds
+    // of each other.  Coverage tooling sees both branches at each gate.
+    //
+    // The idle gate is defense-in-depth -- it can only fire if push() is
+    // bypassed and maybeLogStats is invoked directly, which never happens
+    // in production -- so it's intentionally left uncovered here.
+    LruDedupNotificationQueue q("counter-gate-test");
+
+    // First batch: 1024 distinct payloads.  Push 1024 reaches the gate,
+    // counters advance, log emits.
+    for (size_t i = 0; i < 1024; ++i) {
+        q.push("first-" + std::to_string(i));
+    }
+    auto s1 = q.getStats();
+    EXPECT_EQ(s1.pushed, 1024u);
+    EXPECT_EQ(s1.dedup_hits, 0u);
+
+    // Second batch: another 1024 distinct payloads.  At cumulative 2048
+    // the counter gate fires again, but the time gate returns (we're
+    // well under 5s).  Counters still advance through push().
+    for (size_t i = 0; i < 1024; ++i) {
+        q.push("second-" + std::to_string(i));
+    }
+    auto s2 = q.getStats();
+    EXPECT_EQ(s2.pushed, 2048u);
+    EXPECT_EQ(s2.dedup_hits, 0u);
+}
+
+// ---------------------------------------------------------------------------
+// peekOp tests
+//
+// peekOp drives setOpAllowList admission, so any payload that confuses it
+// would either over-admit (defeating the allowlist) or under-admit
+// (dropping good traffic).  Cover the shapes that can actually appear on
+// the NotificationProducer wire plus the malformed shapes the public
+// API has to tolerate.
+// ---------------------------------------------------------------------------
+
+TEST(PeekOp, ExtractsWellFormedOp)
+{
+    EXPECT_EQ(peekOp("[\"SET\",\"key\",\"f\",\"v\"]"), "SET");
+    EXPECT_EQ(peekOp("[\"DEL\",\"\"]"),                "DEL");
+    EXPECT_EQ(peekOp("[\"fdb_event\",\"\"]"),          "fdb_event");
+    EXPECT_EQ(peekOp("[\"flush\",\"\"]"),              "flush");
+}
+
+TEST(PeekOp, EmptyAndShortInputs)
+{
+    EXPECT_EQ(peekOp(""),     "");
+    EXPECT_EQ(peekOp("["),    "");
+    EXPECT_EQ(peekOp("[\""),  "");    // exactly 2 chars, fails the size >= 3 gate
+    EXPECT_EQ(peekOp("\"\""), "");    // no leading [
+}
+
+TEST(PeekOp, MissingClosingQuoteReturnsEmpty)
+{
+    // No second quote at all -- find(...) returns npos and we abort
+    // rather than scan past the buffer.
+    EXPECT_EQ(peekOp("[\"unterminated"),           "");
+    EXPECT_EQ(peekOp("[\"unterminated_with_data"), "");
+}
+
+TEST(PeekOp, EmptyOpStringReturnsEmpty)
+{
+    // [""] has a closing quote at index 2; substr(2, 0) -> "".
+    // Treated the same as malformed for allowlist purposes (it can't be
+    // in the set, so the message is dropped).
+    EXPECT_EQ(peekOp("[\"\"]"),         "");
+    EXPECT_EQ(peekOp("[\"\",\"data\"]"), "");
+}
+
+TEST(PeekOp, NonArrayInputsReturnEmpty)
+{
+    // Anything that doesn't start with the array-of-strings prefix
+    // ["..." gets rejected.  These are not valid NotificationProducer
+    // wire-format payloads.
+    EXPECT_EQ(peekOp("not_json"),            "");
+    EXPECT_EQ(peekOp("[]"),                  "");   // size 2, fails the gate
+    EXPECT_EQ(peekOp("[1,2]"),               "");   // [1 -- second char is '1', not '"'
+    EXPECT_EQ(peekOp("{\"op\":\"SET\"}"),    "");   // object form, not the array form
+    EXPECT_EQ(peekOp(" [\"SET\",\"x\"]"),    "");   // leading space breaks the prefix
+}
+
+TEST(PeekOp, DoesNotUnescape)
+{
+    // Documented limitation: peekOp stops at the first '"', so a
+    // backslash-escaped quote inside the op string is not interpreted.
+    // This matches the producer side (NotificationProducer never emits
+    // ops containing quotes), but pin the behavior down so a change is
+    // caught.
+    EXPECT_EQ(peekOp("[\"\\\"OP\",\"x\"]"), "\\");   // sees the literal backslash, stops at the next "
+}

--- a/tests/ntf_ut.cpp
+++ b/tests/ntf_ut.cpp
@@ -215,3 +215,206 @@ TEST(Notifications, pipelineProducer)
     EXPECT_EQ(rc, 0);
 }
 
+// ---------------------------------------------------------------------------
+// End-to-end coverage of NotificationConsumer::setOpAllowList.  Publishes
+// a mix of in-allowlist and out-of-allowlist ops over a real redis pub/sub
+// channel and verifies that:
+//   - only in-allowlist ops are admitted to the queue (observed via pop())
+//   - getStats().received counts every message that hit processReply
+//   - getStats().dropped_allowlist counts the filtered ones
+//
+// Uses the same real-redis fixture as the tests above so the wire-format
+// path matches production.
+// ---------------------------------------------------------------------------
+TEST(Notifications, AllowListFilter)
+{
+    SWSS_LOG_ENTER();
+
+    const std::string kChannel = "ALLOWLIST_TEST_NOTIFICATIONS";
+    swss::DBConnector dbNtf("ASIC_DB", 0, true);
+    swss::NotificationConsumer nc(&dbNtf, kChannel, 100, (size_t)64);
+
+    // Allow only fdb_event + flush; drop everything else.
+    nc.setOpAllowList({"fdb_event", "flush"});
+
+    swss::NotificationProducer producer(&dbNtf, kChannel);
+
+    swss::Select s;
+    s.addSelectable(&nc);
+
+    auto send = [&](const std::string& op) {
+        std::vector<swss::FieldValueTuple> entry;
+        // Retry briefly for the initial subscribe handshake -- send()
+        // returns 0 sentClients if nobody is subscribed yet.
+        for (int i = 0; i < 50; ++i) {
+            auto n = producer.send(op, op + "_data", entry);
+            if (n >= 1) return;
+            usleep(20 * 1000);
+        }
+        FAIL() << "no subscriber attached for op=" << op;
+    };
+
+    // 3 admitted, 3 dropped at admission.
+    send("fdb_event");          // admit
+    send("bgp_event");          // drop
+    send("flush");              // admit
+    send("port_state_change");  // drop
+    send("fdb_event");          // admit
+    send("ignored");            // drop
+
+    // Drain whatever is available; the publish path is async, so poll
+    // with a bounded timeout.
+    std::vector<std::string> admitted_ops;
+    for (int i = 0; i < 100 && admitted_ops.size() < 3; ++i) {
+        swss::Selectable *sel = nullptr;
+        int result = s.select(&sel, 100 /* ms */);
+        if (result == swss::Select::TIMEOUT) continue;
+        std::deque<swss::KeyOpFieldsValuesTuple> vkco;
+        nc.pops(vkco);
+        for (auto& kco : vkco) admitted_ops.push_back(kfvOp(kco));
+    }
+
+    ASSERT_EQ(admitted_ops.size(), 3u);
+    EXPECT_EQ(admitted_ops[0], "fdb_event");
+    EXPECT_EQ(admitted_ops[1], "flush");
+    EXPECT_EQ(admitted_ops[2], "fdb_event");
+
+    auto stats = nc.getStats();
+    EXPECT_EQ(stats.received, 6u);
+    EXPECT_EQ(stats.dropped_allowlist, 3u);
+}
+
+// ---------------------------------------------------------------------------
+// Covers the 5-arg constructor branch (NotificationQueuePolicy::LruDedup),
+// the LruDedup-side of getLruDedupQueue() (non-null), and setStatsLabel()'s
+// label-propagation path that calls into the underlying LruDedup queue.
+// Mirrors AllowListFilter's real-redis fixture so the constructor's
+// subscribeWithRetry() actually subscribes.
+// ---------------------------------------------------------------------------
+TEST(Notifications, LruDedupPolicyConstructorAndLabelPropagation)
+{
+    SWSS_LOG_ENTER();
+
+    const std::string kChannel = "LRUDEDUP_TEST_NOTIFICATIONS";
+    swss::DBConnector dbNtf("ASIC_DB", 0, true);
+    swss::NotificationConsumer nc(&dbNtf, kChannel, 100, (size_t)64,
+                                  swss::NotificationQueuePolicy::LruDedup);
+
+    // 5-arg constructor must wire an LruDedup queue underneath -- visible
+    // through the public accessor that NotificationConsumerStatsOrch uses.
+    auto *lru = nc.getLruDedupQueue();
+    ASSERT_NE(lru, nullptr) << "LruDedup policy must expose getLruDedupQueue()";
+
+    // setStatsLabel propagates the label into the underlying queue.  No
+    // public getter for the queue's label, so we exercise the path for
+    // coverage and verify the call doesn't crash; the log line carries
+    // the renamed identifier on the next periodic emission.
+    nc.setStatsLabel("UnitTest:LruDedup");
+
+    // Send a couple of messages so processReply runs and the stats
+    // counters advance (covers the m_received accounting in the
+    // post-allowlist-empty branch).
+    swss::NotificationProducer producer(&dbNtf, kChannel);
+    swss::Select s;
+    s.addSelectable(&nc);
+
+    auto send = [&](const std::string& op) {
+        std::vector<swss::FieldValueTuple> entry;
+        for (int i = 0; i < 50; ++i) {
+            auto n = producer.send(op, op + "_data", entry);
+            if (n >= 1) return;
+            usleep(20 * 1000);
+        }
+        FAIL() << "no subscriber attached for op=" << op;
+    };
+    send("fdb_event");
+    send("fdb_event");    // byte-identical to first -- LruDedup should collapse
+
+    // Drain so processReply is invoked.
+    size_t pops = 0;
+    for (int i = 0; i < 50 && pops == 0; ++i) {
+        swss::Selectable *sel = nullptr;
+        if (s.select(&sel, 100 /* ms */) == swss::Select::TIMEOUT) continue;
+        std::deque<swss::KeyOpFieldsValuesTuple> vkco;
+        nc.pops(vkco);
+        pops += vkco.size();
+    }
+    EXPECT_GE(pops, 1u);
+
+    auto stats = nc.getStats();
+    EXPECT_EQ(stats.received, 2u);
+    EXPECT_EQ(stats.dropped_allowlist, 0u);   // no allowlist set, no drops
+}
+
+// ---------------------------------------------------------------------------
+// Covers the FIFO branch of getLruDedupQueue() (returns null because the
+// underlying queue is FifoNotificationQueue).  This is the default-policy
+// path used by every legacy 4-arg call site.
+// ---------------------------------------------------------------------------
+TEST(Notifications, FifoConsumerReturnsNullFromGetLruDedupQueue)
+{
+    SWSS_LOG_ENTER();
+
+    swss::DBConnector dbNtf("ASIC_DB", 0, true);
+    swss::NotificationConsumer nc(&dbNtf, "FIFO_TEST_NOTIFICATIONS", 100,
+                                  (size_t)64);
+    // 4-arg default-Fifo path: getLruDedupQueue() must return null so that
+    // NotificationConsumerStatsOrch knows to publish only the admit-side
+    // counters and skip the lru_* fields.
+    EXPECT_EQ(nc.getLruDedupQueue(), nullptr);
+
+    // setStatsLabel on a Fifo consumer takes the early-return branch
+    // (no inner LruDedup to forward to).
+    nc.setStatsLabel("UnitTest:Fifo");
+}
+
+// ---------------------------------------------------------------------------
+// Covers NotificationConsumer::maybeLogStats' counter-gate + time-gate +
+// emission paths.  The gate is `(m_received & (kStatsCheckEveryN - 1)) == 0`
+// where kStatsCheckEveryN = 1024 in the .cpp, so we need to drive 1024+
+// messages through processReply.
+//
+// Slow-ish (a few hundred ms with the producer batching used here), but the
+// alternative is exposing kStatsCheckEveryN as a configurable for tests
+// only, which complicates the public API.
+// ---------------------------------------------------------------------------
+TEST(Notifications, ConsumerMaybeLogStatsCounterGate)
+{
+    SWSS_LOG_ENTER();
+
+    const std::string kChannel = "STATSLOG_TEST_NOTIFICATIONS";
+    swss::DBConnector dbNtf("ASIC_DB", 0, true);
+    swss::RedisPipeline pipeline{&dbNtf};
+    swss::NotificationConsumer nc(&dbNtf, kChannel, 100, (size_t)4096);
+    const bool buffered = true;
+    swss::NotificationProducer producer(&pipeline, kChannel, buffered);
+
+    swss::Select s;
+    s.addSelectable(&nc);
+
+    // Buffered/pipelined producer: send 1100 ops so we cross the
+    // kStatsCheckEveryN = 1024 boundary, ensuring the counter gate
+    // releases at least once and the emission code path executes.
+    const int kCount = 1100;
+    std::vector<swss::FieldValueTuple> entry;
+    for (int i = 0; i < kCount; ++i) {
+        producer.send("ntf", std::to_string(i), entry);
+    }
+    pipeline.flush();
+
+    // Drain.  pops() inside the consumer runs processReply for each
+    // message, which is the function we care about exercising.
+    size_t drained = 0;
+    for (int i = 0; i < 200 && drained < (size_t)kCount; ++i) {
+        swss::Selectable *sel = nullptr;
+        if (s.select(&sel, 100 /* ms */) == swss::Select::TIMEOUT) continue;
+        std::deque<swss::KeyOpFieldsValuesTuple> vkco;
+        nc.pops(vkco);
+        drained += vkco.size();
+    }
+    EXPECT_EQ(drained, (size_t)kCount);
+
+    auto stats = nc.getStats();
+    EXPECT_EQ(stats.received, (uint64_t)kCount);
+    EXPECT_EQ(stats.dropped_allowlist, 0u);
+}


### PR DESCRIPTION
## What I did

Adds opt-in primitives to `swss::NotificationConsumer` for bounding queue growth and reducing cross-fanout cost on shared Redis pubsub channels.

## How I did it
- **LRU-dedup queue policy** (`NotificationQueuePolicy::LruDedup`) — collapses byte-identical payloads on enqueue (`std::list` + `std::unordered_map<string, iter>`). Drain order: "last-seen time per unique payload." Memory bounded by `count(distinct in-flight payloads)`.
- **5-arg `NotificationConsumer` constructor** takes the policy. The 4-arg constructor's mangled symbol is preserved verbatim (no ABI break for `python3-swsscommon`, etc.).
- **`setOpAllowList(ops)`** — admission filter that drops messages whose JSON-array leading `op` is not in the set, before they consume queue memory. Defends against cross-fanout on shared channels like `"NOTIFICATIONS"`. Empty set (default) preserves legacy behavior.
- **`setStatsLabel(label)`** — orch-qualified label so syslog can distinguish multiple consumers SUBSCRIBE'd to the same channel.
- **Atomic stats counters** (`received`, `dropped_allowlist`, `pushed`, `dedup_hits`, `high_watermark`, `current_depth`) + `getStats()` + a self-throttled 5 s `SWSS_LOG_NOTICE` summary inline from `processReply` / `push`.

## How to verify

Unit tests

## Related work
HLD: https://github.com/sonic-net/SONiC/pull/2334
sonic-sairedis PR: https://github.com/sonic-net/sonic-sairedis/pull/1899
sonic-swss PR: https://github.com/sonic-net/sonic-swss/pull/4586