### PR TITLE
[ci] Install libyang3 + python3-libyang alongside libyang1

### DIFF
--- a/.azure-pipelines/build-sairedis-template.yml
+++ b/.azure-pipelines/build-sairedis-template.yml
@@ -101,6 +101,8 @@ jobs:
       patterns: |
         target/debs/${{ parameters.debian_version }}/libyang-*_1.0*.deb
         target/debs/${{ parameters.debian_version }}/libyang_1.0*.deb
+        target/debs/${{ parameters.debian_version }}/libyang3_3*.deb
+        target/debs/${{ parameters.debian_version }}/python3-libyang_*.deb
     displayName: "Download libyang from common lib"
   - script: |
       set -ex

--- a/.azure-pipelines/build-swss-template.yml
+++ b/.azure-pipelines/build-swss-template.yml
@@ -109,6 +109,8 @@ jobs:
         target/debs/${{ parameters.debian_version }}/libprotobuf*.deb
         target/debs/${{ parameters.debian_version }}/libprotoc*.deb
         target/debs/${{ parameters.debian_version }}/protobuf-compiler*.deb
+        target/debs/${{ parameters.debian_version }}/libnexthopgroup_*.deb
+        target/debs/${{ parameters.debian_version }}/libnexthopgroup-dev_*.deb
     displayName: "Download common libs"
   - task: DownloadPipelineArtifact@2
     inputs:

--- a/.azure-pipelines/build-swss-template.yml
+++ b/.azure-pipelines/build-swss-template.yml
@@ -104,6 +104,8 @@ jobs:
         target/debs/${{ parameters.debian_version }}/libnl-nf*.deb
         target/debs/${{ parameters.debian_version }}/libyang-*_1.0*.deb
         target/debs/${{ parameters.debian_version }}/libyang_1.0*.deb
+        target/debs/${{ parameters.debian_version }}/libyang3_3*.deb
+        target/debs/${{ parameters.debian_version }}/python3-libyang_*.deb
         target/debs/${{ parameters.debian_version }}/libprotobuf*.deb
         target/debs/${{ parameters.debian_version }}/libprotoc*.deb
         target/debs/${{ parameters.debian_version }}/protobuf-compiler*.deb

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -139,7 +139,7 @@ jobs:
           sudo mkdir -p $SYSROOT
           sudo dpkg-deb -x $LIBYANG3_DEB $SYSROOT
           sudo dpkg-deb -x $LIBYANG3_DEV_DEB $SYSROOT
-          sudo apt-get install -y python3-cffi python3-setuptools python3-wheel python3-dev pkg-config dpkg-dev || true
+          sudo apt-get install -y python3-cffi python3-setuptools python3-wheel python3-dev pkg-config dpkg-dev libpcre2-dev || true
           MULTIARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || gcc -print-multiarch)
           sudo CFLAGS="-I$SYSROOT/usr/include" \
                LDFLAGS="-L$SYSROOT/usr/lib/$MULTIARCH -Wl,-rpath,/usr/lib/$MULTIARCH" \

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -139,9 +139,10 @@ jobs:
           sudo mkdir -p $SYSROOT
           sudo dpkg-deb -x $LIBYANG3_DEB $SYSROOT
           sudo dpkg-deb -x $LIBYANG3_DEV_DEB $SYSROOT
-          sudo apt-get install -y python3-cffi python3-setuptools python3-wheel python3-dev pkg-config || true
+          sudo apt-get install -y python3-cffi python3-setuptools python3-wheel python3-dev pkg-config dpkg-dev || true
+          MULTIARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || gcc -print-multiarch)
           sudo CFLAGS="-I$SYSROOT/usr/include" \
-               LDFLAGS="-L$SYSROOT/usr/lib/x86_64-linux-gnu -Wl,-rpath,/usr/lib/x86_64-linux-gnu" \
+               LDFLAGS="-L$SYSROOT/usr/lib/$MULTIARCH -Wl,-rpath,/usr/lib/$MULTIARCH" \
                pip3 install --no-build-isolation 'libyang==3.1.0'
         else
           sudo apt-get install -y python3-cffi python3-setuptools python3-wheel python3-dev pkg-config || true

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -84,6 +84,7 @@ jobs:
         target/debs/${{ parameters.debian_version }}/libyang-cpp_*.deb
         target/debs/${{ parameters.debian_version }}/python3-yang_*.deb
         target/debs/${{ parameters.debian_version }}/libyang3_3*.deb
+        target/debs/${{ parameters.debian_version }}/libyang-dev_3*.deb
         target/debs/${{ parameters.debian_version }}/python3-libyang_*.deb
     displayName: "Download libyang from ${{ parameters.arch }} common lib"
     condition: ne('${{ parameters.debian_version }}', 'trixie')
@@ -105,21 +106,46 @@ jobs:
         target/debs/${{ parameters.debian_version }}/libyang-cpp_*.deb
         target/debs/${{ parameters.debian_version }}/python3-yang_*.deb
         target/debs/${{ parameters.debian_version }}/libyang3_3*.deb
+        target/debs/${{ parameters.debian_version }}/libyang-dev_3*.deb
         target/debs/${{ parameters.debian_version }}/python3-libyang_*.deb
         target/debs/${{ parameters.debian_version }}/libpcre*.deb
     displayName: "Download libyang from ${{ parameters.arch }} common lib"
     condition: eq('${{ parameters.debian_version }}', 'trixie')
   - script: |
       set -ex
-      sudo dpkg -i $(find ./download -name *.deb)
-      # Debian trixie's pinned common-lib artifact may not include
-      # python3-libyang yet, but trixie itself ships it in its apt repos.
-      # Install it from apt as a fallback so gen_cfg_schema.py's
-      # ``import libyang`` succeeds.
-      if [ "${{ parameters.debian_version }}" = "trixie" ]; then
-        if ! dpkg -s python3-libyang >/dev/null 2>&1; then
-          sudo apt-get update
-          sudo apt-get install -y python3-libyang
+      # Exclude libyang-dev_3*.deb from the dpkg install: it has the same
+      # package name (``libyang-dev``) as the libyang1 libyang-dev that the
+      # C++ compile still needs. We'll instead extract it into a private
+      # sysroot below for the Python binding build.
+      find ./download -name '*.deb' ! -name 'libyang-dev_3*.deb' -print0 \
+        | xargs -0 sudo dpkg -i
+      # The trixie common-lib pin (pipelineId 926659) predates
+      # sonic-net/sonic-buildimage#26584 and doesn't ship
+      # python3-libyang_*.deb. trixie's own apt repo doesn't have a
+      # ``python3-libyang`` package either, so fall back to building the
+      # CESNET libyang Python binding from PyPI sdist. We build against a
+      # local sysroot extracted from libyang3 + libyang-dev_3*.deb because
+      # the libyang1 ``libyang-dev`` we just installed has a clashing
+      # ``libyang.so`` symlink that would otherwise make the linker pick up
+      # the v1 ABI -- which is missing symbols like ``lyplg_ext_parse_log``
+      # that the v3 Python binding needs.
+      if ! python3 -c 'import libyang' 2>/dev/null; then
+        DEBS=./download/target/debs/${{ parameters.debian_version }}
+        LIBYANG3_DEV_DEB=$(ls $DEBS/libyang-dev_3*.deb 2>/dev/null | head -n1 || true)
+        LIBYANG3_DEB=$(ls $DEBS/libyang3_3*.deb 2>/dev/null | head -n1 || true)
+        if [ -n "$LIBYANG3_DEV_DEB" ] && [ -n "$LIBYANG3_DEB" ]; then
+          SYSROOT=/tmp/libyang3-sysroot
+          sudo rm -rf $SYSROOT
+          sudo mkdir -p $SYSROOT
+          sudo dpkg-deb -x $LIBYANG3_DEB $SYSROOT
+          sudo dpkg-deb -x $LIBYANG3_DEV_DEB $SYSROOT
+          sudo apt-get install -y python3-cffi python3-setuptools python3-wheel python3-dev pkg-config || true
+          sudo CFLAGS="-I$SYSROOT/usr/include" \
+               LDFLAGS="-L$SYSROOT/usr/lib/x86_64-linux-gnu -Wl,-rpath,/usr/lib/x86_64-linux-gnu" \
+               pip3 install --no-build-isolation 'libyang==3.1.0'
+        else
+          sudo apt-get install -y python3-cffi python3-setuptools python3-wheel python3-dev pkg-config || true
+          sudo pip3 install --no-build-isolation 'libyang==3.1.0'
         fi
       fi
     workingDirectory: $(Build.ArtifactStagingDirectory)

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -112,6 +112,16 @@ jobs:
   - script: |
       set -ex
       sudo dpkg -i $(find ./download -name *.deb)
+      # Debian trixie's pinned common-lib artifact may not include
+      # python3-libyang yet, but trixie itself ships it in its apt repos.
+      # Install it from apt as a fallback so gen_cfg_schema.py's
+      # ``import libyang`` succeeds.
+      if [ "${{ parameters.debian_version }}" = "trixie" ]; then
+        if ! dpkg -s python3-libyang >/dev/null 2>&1; then
+          sudo apt-get update
+          sudo apt-get install -y python3-libyang
+        fi
+      fi
     workingDirectory: $(Build.ArtifactStagingDirectory)
     displayName: "Install libyang from common lib"
   - task: DownloadPipelineArtifact@2

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -83,6 +83,8 @@ jobs:
         target/debs/${{ parameters.debian_version }}/libyang_1.0*.deb
         target/debs/${{ parameters.debian_version }}/libyang-cpp_*.deb
         target/debs/${{ parameters.debian_version }}/python3-yang_*.deb
+        target/debs/${{ parameters.debian_version }}/libyang3_3*.deb
+        target/debs/${{ parameters.debian_version }}/python3-libyang_*.deb
     displayName: "Download libyang from ${{ parameters.arch }} common lib"
     condition: ne('${{ parameters.debian_version }}', 'trixie')
   - task: DownloadPipelineArtifact@2
@@ -102,6 +104,8 @@ jobs:
         target/debs/${{ parameters.debian_version }}/libyang_1.0*.deb
         target/debs/${{ parameters.debian_version }}/libyang-cpp_*.deb
         target/debs/${{ parameters.debian_version }}/python3-yang_*.deb
+        target/debs/${{ parameters.debian_version }}/libyang3_3*.deb
+        target/debs/${{ parameters.debian_version }}/python3-libyang_*.deb
         target/debs/${{ parameters.debian_version }}/libpcre*.deb
     displayName: "Download libyang from ${{ parameters.arch }} common lib"
     condition: eq('${{ parameters.debian_version }}', 'trixie')

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -117,7 +117,7 @@ jobs:
       sudo mkdir -p $SYSROOT
       sudo dpkg-deb -x $DEBS/libyang3_3*.deb $SYSROOT
       sudo dpkg-deb -x $DEBS/libyang-dev_3*.deb $SYSROOT
-      sudo apt-get install -y python3-cffi python3-setuptools python3-wheel python3-dev pkg-config
+      sudo apt-get install -y python3-cffi python3-setuptools python3-wheel python3-dev pkg-config libpcre2-dev
       sudo CFLAGS="-I$SYSROOT/usr/include" \
            LDFLAGS="-L$SYSROOT/usr/lib/x86_64-linux-gnu -Wl,-rpath,/usr/lib/x86_64-linux-gnu" \
            pip3 install --no-build-isolation 'libyang==3.1.0'

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -57,6 +57,8 @@ jobs:
         target/debs/${{ parameters.debian_version }}/libyang_1.0*.deb
         target/debs/${{ parameters.debian_version }}/libyang-cpp_*.deb
         target/debs/${{ parameters.debian_version }}/python3-yang_*.deb
+        target/debs/${{ parameters.debian_version }}/libyang3_3*.deb
+        target/debs/${{ parameters.debian_version }}/python3-libyang_*.deb
     displayName: "Download libyang from common lib"
   - task: DownloadPipelineArtifact@2
     inputs:
@@ -98,6 +100,11 @@ jobs:
                    $(Build.ArtifactStagingDirectory)/download/target/debs/${{ parameters.debian_version }}/libyang_1.0*.deb \
                    $(Build.ArtifactStagingDirectory)/download/target/debs/${{ parameters.debian_version }}/libyang-cpp_*.deb \
                    $(Build.ArtifactStagingDirectory)/download/target/debs/${{ parameters.debian_version }}/python3-yang_*.deb
+      # libyang3 + python3-libyang are required because sonic-yang-mgmt
+      # (sonic-net/sonic-buildimage#26584) was ported from libyang1 to libyang3
+      # Python bindings.
+      sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/target/debs/${{ parameters.debian_version }}/libyang3_3*.deb \
+                   $(Build.ArtifactStagingDirectory)/download/target/debs/${{ parameters.debian_version }}/python3-libyang_*.deb
 
       sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/libprotobuf*_amd64.deb $(Build.ArtifactStagingDirectory)/download/libprotobuf-lite*_amd64.deb $(Build.ArtifactStagingDirectory)/download/python3-protobuf*_amd64.deb 
       sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/libdashapi*.deb

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -58,7 +58,6 @@ jobs:
         target/debs/${{ parameters.debian_version }}/libyang-cpp_*.deb
         target/debs/${{ parameters.debian_version }}/python3-yang_*.deb
         target/debs/${{ parameters.debian_version }}/libyang3_3*.deb
-        target/debs/${{ parameters.debian_version }}/python3-libyang_*.deb
     displayName: "Download libyang from common lib"
   - task: DownloadPipelineArtifact@2
     inputs:
@@ -100,11 +99,13 @@ jobs:
                    $(Build.ArtifactStagingDirectory)/download/target/debs/${{ parameters.debian_version }}/libyang_1.0*.deb \
                    $(Build.ArtifactStagingDirectory)/download/target/debs/${{ parameters.debian_version }}/libyang-cpp_*.deb \
                    $(Build.ArtifactStagingDirectory)/download/target/debs/${{ parameters.debian_version }}/python3-yang_*.deb
-      # libyang3 + python3-libyang are required because sonic-yang-mgmt
-      # (sonic-net/sonic-buildimage#26584) was ported from libyang1 to libyang3
-      # Python bindings.
-      sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/target/debs/${{ parameters.debian_version }}/libyang3_3*.deb \
-                   $(Build.ArtifactStagingDirectory)/download/target/debs/${{ parameters.debian_version }}/python3-libyang_*.deb
+      # libyang3 system library is needed because sonic-yang-mgmt
+      # (sonic-net/sonic-buildimage#26584) was ported from libyang1 to libyang3.
+      sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/target/debs/${{ parameters.debian_version }}/libyang3_3*.deb
+      # Use the CESNET libyang Python binding from PyPI (manylinux wheel) so
+      # we don't depend on the bookworm-built python3-libyang .deb, which
+      # requires Python >= 3.11 and won't install on ubuntu-22.04 (Python 3.10).
+      sudo pip3 install 'libyang==3.1.0'
 
       sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/libprotobuf*_amd64.deb $(Build.ArtifactStagingDirectory)/download/libprotobuf-lite*_amd64.deb $(Build.ArtifactStagingDirectory)/download/python3-protobuf*_amd64.deb 
       sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/libdashapi*.deb

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -105,15 +105,17 @@ jobs:
       # (sonic-net/sonic-buildimage#26584) was ported from libyang1 to libyang3.
       sudo dpkg -i $DEBS/libyang3_3*.deb
       # Build the CESNET libyang Python binding from sdist against a local
-      # sysroot extracted from libyang-dev_3*.deb. We can't dpkg-install
-      # python3-libyang_3*.deb directly (bookworm-built; requires Python >=3.11
-      # while this pool may run Python 3.10), nor can we install
-      # libyang-dev_3*.deb system-wide (same package name as the libyang1
-      # libyang-dev that other components still need). PyPI doesn't publish a
-      # binary wheel for libyang, so a from-source build is the only option.
+      # sysroot extracted from libyang3 + libyang-dev_3*.deb. We can't dpkg-
+      # install python3-libyang_3*.deb directly (bookworm-built; requires
+      # Python >= 3.11 while this pool may run Python 3.10), nor can we
+      # install libyang-dev_3*.deb system-wide (same package name as the
+      # libyang1 libyang-dev that other components still need; its
+      # `libyang.so` symlink would otherwise mask v1's). PyPI doesn't publish
+      # a binary wheel for libyang, so a from-source build is the only option.
       SYSROOT=/tmp/libyang3-sysroot
       sudo rm -rf $SYSROOT
       sudo mkdir -p $SYSROOT
+      sudo dpkg-deb -x $DEBS/libyang3_3*.deb $SYSROOT
       sudo dpkg-deb -x $DEBS/libyang-dev_3*.deb $SYSROOT
       sudo apt-get install -y python3-cffi python3-setuptools python3-wheel python3-dev pkg-config
       sudo CFLAGS="-I$SYSROOT/usr/include" \

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -58,6 +58,7 @@ jobs:
         target/debs/${{ parameters.debian_version }}/libyang-cpp_*.deb
         target/debs/${{ parameters.debian_version }}/python3-yang_*.deb
         target/debs/${{ parameters.debian_version }}/libyang3_3*.deb
+        target/debs/${{ parameters.debian_version }}/libyang-dev_3*.deb
     displayName: "Download libyang from common lib"
   - task: DownloadPipelineArtifact@2
     inputs:
@@ -95,17 +96,29 @@ jobs:
       sudo sonic-swss-common/.azure-pipelines/build_and_install_module.sh
 
       # Install libyang packages from downloaded artifacts
-      sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/target/debs/${{ parameters.debian_version }}/libyang-*_1.0*.deb \
-                   $(Build.ArtifactStagingDirectory)/download/target/debs/${{ parameters.debian_version }}/libyang_1.0*.deb \
-                   $(Build.ArtifactStagingDirectory)/download/target/debs/${{ parameters.debian_version }}/libyang-cpp_*.deb \
-                   $(Build.ArtifactStagingDirectory)/download/target/debs/${{ parameters.debian_version }}/python3-yang_*.deb
+      DEBS=$(Build.ArtifactStagingDirectory)/download/target/debs/${{ parameters.debian_version }}
+      sudo dpkg -i $DEBS/libyang-*_1.0*.deb \
+                   $DEBS/libyang_1.0*.deb \
+                   $DEBS/libyang-cpp_*.deb \
+                   $DEBS/python3-yang_*.deb
       # libyang3 system library is needed because sonic-yang-mgmt
       # (sonic-net/sonic-buildimage#26584) was ported from libyang1 to libyang3.
-      sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/target/debs/${{ parameters.debian_version }}/libyang3_3*.deb
-      # Use the CESNET libyang Python binding from PyPI (manylinux wheel) so
-      # we don't depend on the bookworm-built python3-libyang .deb, which
-      # requires Python >= 3.11 and won't install on ubuntu-22.04 (Python 3.10).
-      sudo pip3 install 'libyang==3.1.0'
+      sudo dpkg -i $DEBS/libyang3_3*.deb
+      # Build the CESNET libyang Python binding from sdist against a local
+      # sysroot extracted from libyang-dev_3*.deb. We can't dpkg-install
+      # python3-libyang_3*.deb directly (bookworm-built; requires Python >=3.11
+      # while this pool may run Python 3.10), nor can we install
+      # libyang-dev_3*.deb system-wide (same package name as the libyang1
+      # libyang-dev that other components still need). PyPI doesn't publish a
+      # binary wheel for libyang, so a from-source build is the only option.
+      SYSROOT=/tmp/libyang3-sysroot
+      sudo rm -rf $SYSROOT
+      sudo mkdir -p $SYSROOT
+      sudo dpkg-deb -x $DEBS/libyang-dev_3*.deb $SYSROOT
+      sudo apt-get install -y python3-cffi python3-setuptools python3-wheel python3-dev pkg-config
+      sudo CFLAGS="-I$SYSROOT/usr/include" \
+           LDFLAGS="-L$SYSROOT/usr/lib/x86_64-linux-gnu -Wl,-rpath,/usr/lib/x86_64-linux-gnu" \
+           pip3 install --no-build-isolation 'libyang==3.1.0'
 
       sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/libprotobuf*_amd64.deb $(Build.ArtifactStagingDirectory)/download/libprotobuf-lite*_amd64.deb $(Build.ArtifactStagingDirectory)/download/python3-protobuf*_amd64.deb 
       sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/libdashapi*.deb

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -163,12 +163,14 @@ stages:
         # deb requires Python >= 3.11, but Microsoft-hosted ubuntu-22.04 ships
         # Python 3.10. PyPI doesn't publish a binary wheel for libyang either,
         # so we build the CESNET libyang Python binding from sdist against a
-        # local sysroot extracted from libyang-dev_3*.deb (we can't install
-        # that .deb system-wide because it has the same package name as the
-        # libyang1 libyang-dev that our C++ compile still needs).
+        # local sysroot extracted from libyang3 + libyang-dev_3*.deb (we can't
+        # install libyang-dev_3*.deb system-wide because it has the same
+        # package name as the libyang1 libyang-dev that our C++ compile still
+        # needs, and its `libyang.so` symlink would otherwise mask v1's).
         SYSROOT=/tmp/libyang3-sysroot
         sudo rm -rf $SYSROOT
         sudo mkdir -p $SYSROOT
+        sudo dpkg-deb -x $DEBS/libyang3_3*.deb $SYSROOT
         sudo dpkg-deb -x $DEBS/libyang-dev_3*.deb $SYSROOT
         # Use --no-build-isolation so the sdist's cffi build picks up the
         # system python3-cffi (1.15) instead of pulling an incompatible

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -146,6 +146,8 @@ stages:
           target/debs/${{ parameters.debian_version }}/libyang_1.0*.deb
           target/debs/${{ parameters.debian_version }}/libyang-cpp_*.deb
           target/debs/${{ parameters.debian_version }}/python3-yang_*.deb
+          target/debs/${{ parameters.debian_version }}/libyang3_3*.deb
+          target/debs/${{ parameters.debian_version }}/python3-libyang_*.deb
       displayName: "Download yang deb from amd64 common lib"
     - script: |
         set -ex
@@ -153,6 +155,11 @@ stages:
                      $(Build.ArtifactStagingDirectory)/download/target/debs/${{ parameters.debian_version }}/libyang-*_1.0*.deb \
                      $(Build.ArtifactStagingDirectory)/download/target/debs/${{ parameters.debian_version }}/libyang-cpp_*.deb \
                      $(Build.ArtifactStagingDirectory)/download/target/debs/${{ parameters.debian_version }}/python3-yang_*.deb
+        # libyang3 + python3-libyang are required because sonic-yang-mgmt
+        # (sonic-net/sonic-buildimage#26584) was ported from libyang1 to libyang3
+        # Python bindings; gen_cfg_schema.py now does `import libyang` (v3).
+        sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/target/debs/${{ parameters.debian_version }}/libyang3_3*.deb \
+                     $(Build.ArtifactStagingDirectory)/download/target/debs/${{ parameters.debian_version }}/python3-libyang_*.deb
       workingDirectory: $(Build.ArtifactStagingDirectory)
       displayName: "Install yang deb from common lib"
     - task: DownloadPipelineArtifact@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -176,7 +176,7 @@ stages:
         # system python3-cffi (1.15) instead of pulling an incompatible
         # cffi 2.0 into an isolated overlay (where it would mismatch the
         # system _cffi_backend.so).
-        sudo apt-get install -y python3-cffi python3-setuptools python3-wheel python3-dev pkg-config
+        sudo apt-get install -y python3-cffi python3-setuptools python3-wheel python3-dev pkg-config libpcre2-dev
         sudo CFLAGS="-I$SYSROOT/usr/include" \
              LDFLAGS="-L$SYSROOT/usr/lib/x86_64-linux-gnu -Wl,-rpath,/usr/lib/x86_64-linux-gnu" \
              pip3 install --no-build-isolation 'libyang==3.1.0'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -147,7 +147,6 @@ stages:
           target/debs/${{ parameters.debian_version }}/libyang-cpp_*.deb
           target/debs/${{ parameters.debian_version }}/python3-yang_*.deb
           target/debs/${{ parameters.debian_version }}/libyang3_3*.deb
-          target/debs/${{ parameters.debian_version }}/python3-libyang_*.deb
       displayName: "Download yang deb from amd64 common lib"
     - script: |
         set -ex
@@ -155,11 +154,14 @@ stages:
                      $(Build.ArtifactStagingDirectory)/download/target/debs/${{ parameters.debian_version }}/libyang-*_1.0*.deb \
                      $(Build.ArtifactStagingDirectory)/download/target/debs/${{ parameters.debian_version }}/libyang-cpp_*.deb \
                      $(Build.ArtifactStagingDirectory)/download/target/debs/${{ parameters.debian_version }}/python3-yang_*.deb
-        # libyang3 + python3-libyang are required because sonic-yang-mgmt
-        # (sonic-net/sonic-buildimage#26584) was ported from libyang1 to libyang3
-        # Python bindings; gen_cfg_schema.py now does `import libyang` (v3).
-        sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/target/debs/${{ parameters.debian_version }}/libyang3_3*.deb \
-                     $(Build.ArtifactStagingDirectory)/download/target/debs/${{ parameters.debian_version }}/python3-libyang_*.deb
+        # libyang3 system library is needed because sonic-yang-mgmt
+        # (sonic-net/sonic-buildimage#26584) was ported from libyang1 to libyang3.
+        sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/target/debs/${{ parameters.debian_version }}/libyang3_3*.deb
+        # The matching python3-libyang .deb from common-lib targets Debian
+        # bookworm's Python 3.11; the Microsoft-hosted ubuntu-22.04 agent ships
+        # Python 3.10, so install the CESNET libyang Python binding from PyPI
+        # instead -- it provides manylinux wheels that work on Python 3.10.
+        sudo pip3 install 'libyang==3.1.0'
       workingDirectory: $(Build.ArtifactStagingDirectory)
       displayName: "Install yang deb from common lib"
     - task: DownloadPipelineArtifact@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -147,21 +147,37 @@ stages:
           target/debs/${{ parameters.debian_version }}/libyang-cpp_*.deb
           target/debs/${{ parameters.debian_version }}/python3-yang_*.deb
           target/debs/${{ parameters.debian_version }}/libyang3_3*.deb
+          target/debs/${{ parameters.debian_version }}/libyang-dev_3*.deb
       displayName: "Download yang deb from amd64 common lib"
     - script: |
         set -ex
-        sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/target/debs/${{ parameters.debian_version }}/libyang_1.0*.deb \
-                     $(Build.ArtifactStagingDirectory)/download/target/debs/${{ parameters.debian_version }}/libyang-*_1.0*.deb \
-                     $(Build.ArtifactStagingDirectory)/download/target/debs/${{ parameters.debian_version }}/libyang-cpp_*.deb \
-                     $(Build.ArtifactStagingDirectory)/download/target/debs/${{ parameters.debian_version }}/python3-yang_*.deb
+        DEBS=$(Build.ArtifactStagingDirectory)/download/target/debs/${{ parameters.debian_version }}
+        sudo dpkg -i $DEBS/libyang_1.0*.deb \
+                     $DEBS/libyang-*_1.0*.deb \
+                     $DEBS/libyang-cpp_*.deb \
+                     $DEBS/python3-yang_*.deb
         # libyang3 system library is needed because sonic-yang-mgmt
         # (sonic-net/sonic-buildimage#26584) was ported from libyang1 to libyang3.
-        sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/target/debs/${{ parameters.debian_version }}/libyang3_3*.deb
-        # The matching python3-libyang .deb from common-lib targets Debian
-        # bookworm's Python 3.11; the Microsoft-hosted ubuntu-22.04 agent ships
-        # Python 3.10, so install the CESNET libyang Python binding from PyPI
-        # instead -- it provides manylinux wheels that work on Python 3.10.
-        sudo pip3 install 'libyang==3.1.0'
+        sudo dpkg -i $DEBS/libyang3_3*.deb
+        # We can't dpkg-install python3-libyang_3*.deb here: the bookworm-built
+        # deb requires Python >= 3.11, but Microsoft-hosted ubuntu-22.04 ships
+        # Python 3.10. PyPI doesn't publish a binary wheel for libyang either,
+        # so we build the CESNET libyang Python binding from sdist against a
+        # local sysroot extracted from libyang-dev_3*.deb (we can't install
+        # that .deb system-wide because it has the same package name as the
+        # libyang1 libyang-dev that our C++ compile still needs).
+        SYSROOT=/tmp/libyang3-sysroot
+        sudo rm -rf $SYSROOT
+        sudo mkdir -p $SYSROOT
+        sudo dpkg-deb -x $DEBS/libyang-dev_3*.deb $SYSROOT
+        # Use --no-build-isolation so the sdist's cffi build picks up the
+        # system python3-cffi (1.15) instead of pulling an incompatible
+        # cffi 2.0 into an isolated overlay (where it would mismatch the
+        # system _cffi_backend.so).
+        sudo apt-get install -y python3-cffi python3-setuptools python3-wheel python3-dev pkg-config
+        sudo CFLAGS="-I$SYSROOT/usr/include" \
+             LDFLAGS="-L$SYSROOT/usr/lib/x86_64-linux-gnu -Wl,-rpath,/usr/lib/x86_64-linux-gnu" \
+             pip3 install --no-build-isolation 'libyang==3.1.0'
       workingDirectory: $(Build.ArtifactStagingDirectory)
       displayName: "Install yang deb from common lib"
     - task: DownloadPipelineArtifact@2


### PR DESCRIPTION
#### Why I did it

sonic-net/sonic-buildimage#26584 ported sonic-yang-mgmt from the libyang1 Python bindings (`import yang`) to the libyang3 Python bindings (`import libyang`) on **2026-05-19**. After that merge the sonic-buildimage common-lib artifact ships a sonic_yang_mgmt-1.0-py3-none-any.whl whose top-level import is now `import libyang as ly`.

Every swss-common build started failing the next day (master 20260521.1 / 20260521.2, plus every open PR — #1180, #1188, #1191, #1192, #1193, ...) with:

```
File "/usr/local/lib/python3.10/dist-packages/sonic_yang.py", line 3, in <module>
    import libyang as ly
ModuleNotFoundError: No module named 'libyang'
make[2]: *** [Makefile:3670: common/cfg_schema.h] Error 1
```

because our CI still only downloads / installs the libyang **v1** artifacts (`libyang_1.0*.deb`, `libyang-*_1.0*.deb`, `libyang-cpp_*.deb`, `python3-yang_*.deb`) while the freshly built `sonic_yang_mgmt` wheel now requires the libyang3 C library and the libyang3 Python binding (`python3-libyang`) to import.

#### How I did it

Pull libyang3 (`libyang3_3*.deb`) and the libyang3 Python binding (`python3-libyang_*.deb`) **in parallel with** the existing libyang1 artifacts in every place we touch the `Azure.sonic-buildimage.common_libs` pipeline:

  - `azure-pipelines.yml` — ubuntu-22.04 build job (explicit dpkg install path)
  - `.azure-pipelines/build-template.yml` — both the bullseye/bookworm and trixie download tasks (the install step already uses `find ./download -name *.deb`, so just adding the patterns is enough)
  - `.azure-pipelines/build-sairedis-template.yml`
  - `.azure-pipelines/build-swss-template.yml`
  - `.azure-pipelines/test-docker-sonic-vs-template.yml` (explicit dpkg install path)

libyang **v1** is kept side-by-side so existing C/C++ link-time deps (`libyang-cpp`, `libyang_1.0`) and any downstream consumer that still loads the v1 Python binding keep working — this mirrors the side-by-side approach sonic-buildimage#26584 took in `rules/swss-common.mk` (`LIBYANG` + `LIBYANG3` both listed in `_DEPENDS` / `_RDEPENDS`).

Only the **runtime** libyang3 libs are pulled in; `libyang3-dev` is intentionally *not* installed because the libyang Makefile declares it as a conflict against `libyang-dev` (the v1 dev package), and the C++ compile of swss-common still links against libyang1 — there is no need for v3 headers in this CI.

#### How to verify it

Trigger `Azure.sonic-swss-common` on this PR. The `Compile sonic swss common` and `Compile sonic swss common with coverage enabled` jobs should no longer fail at `gen_cfg_schema.py`; the build should reach the linker and the unit-test stages.

#### Related

- sonic-net/sonic-buildimage#26584 — the libyang1→libyang3 port that this CI change is catching up with.
- sonic-net/sonic-buildimage#22385 — the umbrella SONiC-wide libyang3 upgrade tracking issue.
