### PR TITLE
Add link event damping support

### DIFF
--- a/common/consumer_table_pops.lua
+++ b/common/consumer_table_pops.lua
@@ -93,7 +93,8 @@ for i = n, 1, -3 do
        op == 'stats_capability_query' or
        op == 'stats_capability_response' or
        op == 'stats_st_capability_query' or
-       op == 'stats_st_capability_response' then
+       op == 'stats_st_capability_response' or
+       op == 'link_event_damping_config_set' then
 
     -- do not modify db entries when spotted those commands, they are used to
     -- trigger actions or get data synchronously from database

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: sonic
 Maintainer: Shuotian Cheng <shuche@microsoft.com>
 Section: net
 Priority: optional
-Build-Depends: dh-exec (>=0.3), debhelper (>= 12), autotools-dev, libboost-dev | libboost1.71-dev | libboost1.83-dev, libhiredis-dev, libgtest-dev, libgmock-dev, swig, nlohmann-json3-dev
+Build-Depends: dh-exec (>=0.3), debhelper (>= 12), autotools-dev, libboost-dev | libboost1.71-dev | libboost1.83-dev, libhiredis-dev, libgtest-dev, libgmock-dev, swig, nlohmann-json3-dev, libyang-dev, python3-libyang
 Standards-Version: 1.0.0
 Rules-Requires-Root: no
 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: sonic
 Maintainer: Shuotian Cheng <shuche@microsoft.com>
 Section: net
 Priority: optional
-Build-Depends: dh-exec (>=0.3), debhelper (>= 12), autotools-dev, libboost-dev | libboost1.71-dev | libboost1.83-dev, libhiredis-dev, libgtest-dev, libgmock-dev, swig, nlohmann-json3-dev, libyang-dev, python3-libyang
+Build-Depends: dh-exec (>=0.3), debhelper (>= 12), autotools-dev, libboost-dev | libboost1.71-dev | libboost1.83-dev, libhiredis-dev, libgtest-dev, libgmock-dev, swig, nlohmann-json3-dev
 Standards-Version: 1.0.0
 Rules-Requires-Root: no
 


### PR DESCRIPTION
Modified the LUA script to include link damping configs CLIs.

Errors were logged without this modification and confirmed that errors are not showing after the fix.