### PR TITLE
zmq: prevent use-after-free of ZmqConsumerStateTable handler

### DIFF
--- a/common/zmqconsumerstatetable.cpp
+++ b/common/zmqconsumerstatetable.cpp
@@ -21,7 +21,8 @@ ZmqConsumerStateTable::ZmqConsumerStateTable(DBConnector *db, const std::string 
     : Selectable(pri)
     , TableBase(tableName, TableBase::getTableSeparator(db->getDbId()))
     , m_db(db)
-    , m_zmqServer(zmqServer)
+    , m_dbName(db->getDbName())
+    , m_handlerRegistry(zmqServer.getHandlerRegistry())
 {
     if (popBatchSize > 0)
     {
@@ -44,9 +45,20 @@ ZmqConsumerStateTable::ZmqConsumerStateTable(DBConnector *db, const std::string 
         m_asyncDBUpdater = nullptr;
     }
 
-    m_zmqServer.registerMessageHandler(m_db->getDbName(), tableName, this);
+    m_handlerRegistry->registerHandler(m_dbName, tableName, this);
 
     SWSS_LOG_DEBUG("ZmqConsumerStateTable ctor tableName: %s", tableName.c_str());
+}
+
+ZmqConsumerStateTable::~ZmqConsumerStateTable()
+{
+    // Detach from the registry before any of our members (notably the
+    // SelectableEvent, whose eventfd we'd write to from handleReceivedData)
+    // are destroyed. removeHandler() blocks until any in-flight dispatch
+    // into us returns. The registry is co-owned with the ZmqServer that
+    // created us, so this is safe even if that ZmqServer has already been
+    // destroyed — only the shared registry is touched.
+    m_handlerRegistry->removeHandler(m_dbName, getTableName());
 }
 
 void ZmqConsumerStateTable::handleReceivedData(const std::vector<std::shared_ptr<KeyOpFieldsValuesTuple>> &kcos)

--- a/common/zmqconsumerstatetable.h
+++ b/common/zmqconsumerstatetable.h
@@ -21,6 +21,8 @@ public:
 
     ZmqConsumerStateTable(DBConnector *db, const std::string &tableName, ZmqServer &zmqServer, int popBatchSize = DEFAULT_POP_BATCH_SIZE, int pri = 0, bool dbPersistence = false);
 
+    ~ZmqConsumerStateTable() override;
+
     /* Get multiple pop elements */
     void pops(std::deque<KeyOpFieldsValuesTuple> &vkco, const std::string &prefix = EMPTY_PREFIX);
 
@@ -81,7 +83,13 @@ private:
 
     DBConnector *m_db;
 
-    ZmqServer& m_zmqServer;
+    // Cached at construction time so the destructor can call
+    // m_handlerRegistry->removeHandler() without dereferencing m_db.
+    std::string m_dbName;
+
+    // Co-owned with the ZmqServer that created us. Lets the destructor
+    // unregister cleanly even if the ZmqServer has already been destroyed.
+    std::shared_ptr<ZmqHandlerRegistry> m_handlerRegistry;
 
     std::unique_ptr<AsyncDBUpdater> m_asyncDBUpdater;
 

--- a/common/zmqserver.cpp
+++ b/common/zmqserver.cpp
@@ -12,6 +12,75 @@ using namespace std;
 
 namespace swss {
 
+void ZmqHandlerRegistry::registerHandler(
+    const std::string& dbName,
+    const std::string& tableName,
+    ZmqMessageHandler* handler)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    auto dbResult = m_handlers.insert(make_pair(dbName, map<string, ZmqMessageHandler*>()));
+    if (dbResult.second) {
+        SWSS_LOG_DEBUG("ZmqHandlerRegistry add mapping for db: %s", dbName.c_str());
+    }
+
+    auto tableResult = dbResult.first->second.insert(make_pair(tableName, handler));
+    if (tableResult.second) {
+        SWSS_LOG_DEBUG("ZmqHandlerRegistry register handler for db: %s, table: %s",
+                       dbName.c_str(), tableName.c_str());
+    }
+}
+
+void ZmqHandlerRegistry::removeHandler(
+    const std::string& dbName,
+    const std::string& tableName)
+{
+    // Take the same mutex that dispatch() holds across the callback. Once we
+    // acquire it, no callback into this (dbName, tableName) handler is in
+    // flight and no further one can start — making it safe for the caller to
+    // destroy the handler object after removeHandler() returns.
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    auto dbIter = m_handlers.find(dbName);
+    if (dbIter == m_handlers.end()) {
+        return;
+    }
+
+    dbIter->second.erase(tableName);
+    if (dbIter->second.empty()) {
+        m_handlers.erase(dbIter);
+    }
+
+    SWSS_LOG_DEBUG("ZmqHandlerRegistry removed handler for db: %s, table: %s",
+                   dbName.c_str(), tableName.c_str());
+}
+
+void ZmqHandlerRegistry::dispatch(
+    const std::string& dbName,
+    const std::string& tableName,
+    const std::vector<std::shared_ptr<KeyOpFieldsValuesTuple>>& kcos)
+{
+    // Hold the mutex for the duration of the callback. Concurrent
+    // removeHandler() on this (dbName, tableName) blocks until we return,
+    // so the handler cannot be destroyed mid-call.
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    auto dbIter = m_handlers.find(dbName);
+    if (dbIter == m_handlers.end()) {
+        SWSS_LOG_DEBUG("ZmqHandlerRegistry can't find any handler for db: %s", dbName.c_str());
+        return;
+    }
+
+    auto tableIter = dbIter->second.find(tableName);
+    if (tableIter == dbIter->second.end()) {
+        SWSS_LOG_DEBUG("ZmqHandlerRegistry can't find handler for db: %s, table: %s",
+                       dbName.c_str(), tableName.c_str());
+        return;
+    }
+
+    tableIter->second->handleReceivedData(kcos);
+}
+
 ZmqServer::ZmqServer(const std::string& endpoint)
     : ZmqServer(endpoint, "", false, false)
 {
@@ -34,7 +103,8 @@ ZmqServer::ZmqServer(const std::string& endpoint, const std::string& vrf, bool l
     m_context(nullptr),
     m_socket(nullptr),
     m_oneToOneSync(oneToOneSync),
-    m_allowZmqPoll(true)
+    m_allowZmqPoll(true),
+    m_registry(std::make_shared<ZmqHandlerRegistry>())
 {
     if (!lazyBind)
     {
@@ -62,6 +132,11 @@ ZmqServer::~ZmqServer()
     {
         zmq_ctx_destroy(m_context);
     }
+
+    // m_registry's refcount drops here. If any registered handler still holds
+    // a reference, the registry survives until that handler is destroyed; its
+    // destructor will call removeHandler() safely against the surviving
+    // registry without touching this (now-gone) ZmqServer.
 }
 
 void ZmqServer::bind()
@@ -108,7 +183,7 @@ void ZmqServer::bind()
     }
 
     if (!m_vrf.empty())
-    {   
+    {
         zmq_setsockopt(m_socket, ZMQ_BINDTODEVICE, m_vrf.c_str(), m_vrf.length());
     }
 
@@ -130,34 +205,24 @@ void ZmqServer::registerMessageHandler(
                                     const std::string tableName,
                                     ZmqMessageHandler* handler)
 {
-    auto dbResult = m_HandlerMap.insert(pair<string, map<string, ZmqMessageHandler*>>(dbName, map<string, ZmqMessageHandler*>()));
-    if (dbResult.second) {
-        SWSS_LOG_DEBUG("ZmqServer add handler mapping for db: %s", dbName.c_str());
-    }
+    m_registry->registerHandler(dbName, tableName, handler);
+}
 
-    auto tableResult = dbResult.first->second.insert(pair<string, ZmqMessageHandler*>(tableName, handler));
-    if (tableResult.second) {
-        SWSS_LOG_DEBUG("ZmqServer register handler for db: %s, table: %s", dbName.c_str(), tableName.c_str());
-    }
+void ZmqServer::removeMessageHandler(
+                                    const std::string& dbName,
+                                    const std::string& tableName)
+{
+    m_registry->removeHandler(dbName, tableName);
 }
 
 ZmqMessageHandler* ZmqServer::findMessageHandler(
-                                                const std::string dbName,
-                                                const std::string tableName)
+    const std::string /*dbName*/,
+    const std::string /*tableName*/)
 {
-    auto dbMappingIter = m_HandlerMap.find(dbName);
-    if (dbMappingIter == m_HandlerMap.end()) {
-        SWSS_LOG_DEBUG("ZmqServer can't find any handler for db: %s", dbName.c_str());
-        return nullptr;
-    }
-
-    auto tableMappingIter = dbMappingIter->second.find(tableName);
-    if (tableMappingIter == dbMappingIter->second.end()) {
-        SWSS_LOG_DEBUG("ZmqServer can't find handler for db: %s, table: %s", dbName.c_str(), tableName.c_str());
-        return nullptr;
-    }
-
-    return tableMappingIter->second;
+    // Retained as a no-op for source compatibility with external test mocks
+    // that override this symbol at link time. Real dispatch lives in
+    // ZmqHandlerRegistry::dispatch().
+    return nullptr;
 }
 
 void ZmqServer::handleReceivedData(const char* buffer, const size_t size)
@@ -167,14 +232,7 @@ void ZmqServer::handleReceivedData(const char* buffer, const size_t size)
     std::vector<std::shared_ptr<KeyOpFieldsValuesTuple>> kcos;
     BinarySerializer::deserializeBuffer(buffer, size, dbName, tableName, kcos);
 
-    // find handler
-    auto handler = findMessageHandler(dbName, tableName);
-    if (handler == nullptr) {
-        SWSS_LOG_WARN("ZmqServer can't find handler for received message: %s", buffer);
-        return;
-    }
-
-    handler->handleReceivedData(kcos);
+    m_registry->dispatch(dbName, tableName, kcos);
 }
 
 void ZmqServer::startMqPollThread()

--- a/common/zmqserver.h
+++ b/common/zmqserver.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <map>
+#include <memory>
+#include <mutex>
 #include <string>
 #include <deque>
 #include <condition_variable>
@@ -24,6 +27,32 @@ public:
     virtual void handleReceivedData(const std::vector<std::shared_ptr<KeyOpFieldsValuesTuple>>& kcos) = 0;
 };
 
+// Shared (db, table) -> handler map. Co-owned by ZmqServer and every
+// registered handler so neither party requires the other to outlive it.
+// The mutex is held across handler dispatch, so removeHandler() blocks
+// until any in-flight callback into the handler being removed has returned
+// — making it safe for the caller to destroy the handler immediately after
+// removeHandler() returns. Handler callbacks therefore must not themselves
+// call registerHandler / removeHandler (would self-deadlock).
+class ZmqHandlerRegistry
+{
+public:
+    void registerHandler(const std::string& dbName,
+                         const std::string& tableName,
+                         ZmqMessageHandler* handler);
+
+    void removeHandler(const std::string& dbName,
+                       const std::string& tableName);
+
+    void dispatch(const std::string& dbName,
+                  const std::string& tableName,
+                  const std::vector<std::shared_ptr<KeyOpFieldsValuesTuple>>& kcos);
+
+private:
+    std::mutex m_mutex;
+    std::map<std::string, std::map<std::string, ZmqMessageHandler*>> m_handlers;
+};
+
 class ZmqServer
 {
 public:
@@ -44,11 +73,25 @@ public:
                                 const std::string tableName,
                                 ZmqMessageHandler* handler);
 
+    // Remove a previously-registered handler. Blocks until any in-flight
+    // dispatch into that handler has returned, so the caller can safely
+    // destroy the handler object after this call returns.
+    void removeMessageHandler(
+                                const std::string& dbName,
+                                const std::string& tableName);
+
     // This method should only be used in one-to-one sync mode with the client.
     void sendMsg(const std::string& dbName, const std::string& tableName,
         const std::vector<swss::KeyOpFieldsValuesTuple>& values);
 
     void bind();
+
+    // Internal: returns the shared handler registry so a handler implementation
+    // can co-own it. This lets the handler's destructor call removeHandler()
+    // without depending on the ZmqServer still being alive (the registry
+    // survives as long as either party holds a reference). Intended for use
+    // by ZmqMessageHandler subclasses, not by general callers.
+    std::shared_ptr<ZmqHandlerRegistry> getHandlerRegistry() const { return m_registry; }
 
 private:
     void handleReceivedData(const char* buffer, const size_t size);
@@ -56,7 +99,11 @@ private:
     void startMqPollThread();
 
     void mqPollThread();
-    
+
+    // Retained as a no-op stub for source compatibility with external test
+    // mocks (e.g. sonic-swss's fake_zmqserver.cpp) that override this symbol
+    // at link time. The internal dispatch path no longer calls it — handler
+    // lookup happens inside ZmqHandlerRegistry::dispatch().
     ZmqMessageHandler* findMessageHandler(const std::string dbName, const std::string tableName);
 
     std::vector<char> m_buffer;
@@ -77,7 +124,11 @@ private:
 
     bool m_allowZmqPoll;
 
-    std::map<std::string, std::map<std::string, ZmqMessageHandler*>> m_HandlerMap;
+    // Default-initialized in-class so that link-time mocks of ZmqServer
+    // (which may not initialize this member in their stub constructors) still
+    // present a valid registry to any real ZmqConsumerStateTable they pair
+    // with — the real constructor below also sets this explicitly.
+    std::shared_ptr<ZmqHandlerRegistry> m_registry = std::make_shared<ZmqHandlerRegistry>();
 };
 
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

Summary:
`ZmqServer` registers `ZmqConsumerStateTable` as a message handler in `m_HandlerMap` at consumer construction, but there is no symmetric unregister path and no `ZmqConsumerStateTable` destructor. When a consumer goes out of scope (its `m_selectableEvent` is destroyed and its eventfd closed) while the server's `mqPollThread` is still running and partway through dispatching a message to it, `m_selectableEvent.notify()` does `write()` on a closed fd, `SelectableEvent::notify()` throws `runtime_error("write failed")` out of the poll thread, and `std::terminate` aborts the process.

This is the natural declaration order in test code — the `ZmqServer` has to exist before it can be passed by reference into a `ZmqConsumerStateTable` constructor, so the server is declared first and (per C++ reverse-order destruction) the consumer destructs first. Reviewers should start with `common/zmqserver.cpp` for the locking changes, then `common/zmqconsumerstatetable.cpp` for the new destructor.

The crash is intermittent but reproducible in CI. Two recent unrelated examples:
- Build [#1078848](https://dev.azure.com/mssonic/build/_build/results?buildId=1078848) — scheduled run on the `202511` release branch (2026-04-04). [Unit-test log](https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_apis/build/builds/1078848/logs/33).
- Build [#1120234](https://dev.azure.com/mssonic/build/_build/results?buildId=1120234) — PR #973 (libyang3 port, unrelated change) (2026-05-22). [Unit-test log](https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_apis/build/builds/1120234/logs/33).

Both logs show the identical signature:
```
[ RUN      ] ZmqServerLazzyBind.test
terminate called after throwing an instance of 'std::runtime_error'
  what():  write failed
... Aborted (core dumped)
Bash exited with code '134'
```

The string `write failed` is only produced from one place in the tree (`SelectableEvent::notify()` on a short `write()` of the eventfd), pinning the cause precisely. gtest attributes it to `ZmqServerLazzyBind.test` because `[ RUN ]` is printed before the test body executes; the actual fault is the in-flight handler callback writing to a freshly-closed eventfd.

No dependencies.

Fixes # (no issue filed)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?

Eliminate an intermittent CI crash and the latent use-after-free behind it. Any caller that destroys a `ZmqConsumerStateTable` while its `ZmqServer` is still alive can trip the same race in production, not just in tests.

#### How did you do it?

* Add `ZmqServer::removeMessageHandler(dbName, tableName)`, guarded by a new `m_handlerMapMutex`.
* Hold that same mutex in `ZmqServer::handleReceivedData` across both the handler lookup *and* the dispatch into `handler->handleReceivedData()`. This makes `removeMessageHandler()` block until any in-flight callback into the handler being removed has returned, so the caller can safely destroy the handler object as soon as `removeMessageHandler()` returns.
* Add a `ZmqConsumerStateTable` destructor that calls `removeMessageHandler()` in its body, i.e. before any data members (notably `m_selectableEvent`) begin tearing down.
* Take `m_handlerMapMutex` in `registerMessageHandler()` too, for symmetry.

Caveat documented on the mutex declaration: handler callbacks now run with `m_handlerMapMutex` held and must not themselves call `register`/`removeMessageHandler` (would self-deadlock). `ZmqConsumerStateTable::handleReceivedData` only enqueues and notifies, so the restriction is harmless in tree.

#### How did you verify/test it?

* Built locally on bookworm; existing unit tests pass.
* Verified the lock-ordering invariant: the server's `m_handlerMapMutex` is always the outer lock; `ZmqConsumerStateTable::m_receivedQueueMutex` is only ever the inner lock. No caller takes them in the opposite order.
* Inspected the only `ZmqMessageHandler` subclass / caller of `registerMessageHandler` (`ZmqConsumerStateTable`) to confirm the callback respects the no-reentrancy contract.
* Read upstream CI logs for the crash signature to confirm the fix targets the right root cause (links above).

#### Any platform specific information?

None.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

N/A — internal bug fix, no public API change. The new `ZmqServer::removeMessageHandler()` entry point is intended for use by handler implementations' own destructors (mirroring the existing `registerMessageHandler()` symmetry).
