### PR TITLE
ci: download libnexthopgroup deb for the sonic-swss build stage

### DIFF
--- a/.azure-pipelines/build-swss-template.yml
+++ b/.azure-pipelines/build-swss-template.yml
@@ -107,6 +107,7 @@ jobs:
         target/debs/${{ parameters.debian_version }}/libprotobuf*.deb
         target/debs/${{ parameters.debian_version }}/libprotoc*.deb
         target/debs/${{ parameters.debian_version }}/protobuf-compiler*.deb
+        target/debs/${{ parameters.debian_version }}/libnexthopgroup*.deb
     displayName: "Download common libs"
   - task: DownloadPipelineArtifact@2
     inputs:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

Summary:
sonic-swss commit [`e6c482ca`](https://github.com/sonic-net/sonic-swss/commit/e6c482ca) ("[fpmsyncd]: add libnexthopgroup in Makefile.am to support rib/fib", PR sonic-net/sonic-swss#4394) added `-lnexthopgroup` to `fpmsyncd`'s link line, expecting `libnexthopgroup_*.deb` to already be installed when the swss build runs. sonic-swss-common's downstream "Compile sonic swss" stage in `.azure-pipelines/build-swss-template.yml` installs everything it needs from the common-lib artifact, but its pattern list never picked up the new package, so the link now fails with `cannot find -lnexthopgroup` whenever this pipeline cascades into a sonic-swss build.

Fix: add the `libnexthopgroup*.deb` pattern next to the other `Azure.sonic-buildimage.common_libs` entries so `dpkg` picks it up in the existing install step.

Reviewer entry point: `.azure-pipelines/build-swss-template.yml` (one-line addition).

Fixes # (no issue filed)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?

Unblock the sonic-swss build stage of the sonic-swss-common pipeline, which is currently failing at fpmsyncd's link step on any PR that cascades into a sonic-swss build.

#### How did you do it?

Added one pattern (`libnexthopgroup*.deb`) to the existing `DownloadPipelineArtifact@2` step that pulls `common_libs` from `Azure.sonic-buildimage`. The deb is built upstream by sonic-buildimage and already present in the artifact; the pipeline just wasn't asking for it.

#### How did you verify/test it?

Local verification: confirmed via the [failing build log](https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_apis/build/builds/1120397/logs/180) that `fpmsyncd` is linking against `-lnexthopgroup` and failing because the lib isn't present on the build agent. CI re-run on this PR will exercise the fix end-to-end.

#### Any platform specific information?

None. The pattern is parameterized by `${{ parameters.debian_version }}` like every other entry in the same list.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

N/A — CI plumbing only, no public-facing change.
