### PR TITLE
NotificationConsumer: add pluggable Queue strategy

### DIFF
--- a/common/notificationconsumer.cpp
+++ b/common/notificationconsumer.cpp
@@ -8,12 +8,14 @@
 #define REDIS_PUBLISH_MESSAGE_INDEX (2)
 #define REDIS_PUBLISH_MESSAGE_ELEMNTS (3)
 
-swss::NotificationConsumer::NotificationConsumer(swss::DBConnector *db, const std::string &channel, int pri, size_t popBatchSize):
+swss::NotificationConsumer::NotificationConsumer(swss::DBConnector *db, const std::string &channel, int pri,
+                                                 size_t popBatchSize, std::shared_ptr<Queue> queue):
     Selectable(pri),
     POP_BATCH_SIZE(popBatchSize),
     m_db(db),
     m_subscribe(NULL),
-    m_channel(channel)
+    m_channel(channel),
+    m_queue(std::move(queue))
 {
     SWSS_LOG_ENTER();
 
@@ -105,12 +107,12 @@ uint64_t swss::NotificationConsumer::readData()
 
 bool swss::NotificationConsumer::hasData()
 {
-    return m_queue.size() > 0;
+    return m_queue->size() > 0;
 }
 
 bool swss::NotificationConsumer::hasCachedData()
 {
-    return m_queue.size() > 1;
+    return m_queue->size() > 1;
 }
 
 void swss::NotificationConsumer::processReply(redisReply *reply)
@@ -138,21 +140,21 @@ void swss::NotificationConsumer::processReply(redisReply *reply)
 
     SWSS_LOG_DEBUG("got message: %s", msg.c_str());
 
-    m_queue.push(msg);
+    m_queue->push(msg);
 }
 
 void swss::NotificationConsumer::pop(std::string &op, std::string &data, std::vector<FieldValueTuple> &values)
 {
     SWSS_LOG_ENTER();
 
-    if (m_queue.empty())
+    if (m_queue->empty())
     {
         SWSS_LOG_ERROR("notification queue is empty, can't pop");
         throw std::runtime_error("notification queue is empty, can't pop");
     }
 
-    std::string msg = m_queue.front();
-    m_queue.pop();
+    std::string msg = m_queue->front();
+    m_queue->pop();
 
     values.clear();
     JSon::readJson(msg, values);
@@ -170,9 +172,9 @@ void swss::NotificationConsumer::pops(std::deque<KeyOpFieldsValuesTuple> &vkco)
     SWSS_LOG_ENTER();
 
     vkco.clear();
-    while(!m_queue.empty())
+    while(!m_queue->empty())
     {
-        while(!m_queue.empty())
+        while(!m_queue->empty())
         {
             std::string op;
             std::string data;
@@ -198,7 +200,7 @@ void swss::NotificationConsumer::pops(std::deque<KeyOpFieldsValuesTuple> &vkco)
 int swss::NotificationConsumer::peek()
 {
     SWSS_LOG_ENTER();
-    if (m_queue.empty())
+    if (m_queue->empty())
     {
         // Peek for more data in redis socket
         int rc = swss::peekRedisContext(m_subscribe->getContext());
@@ -209,5 +211,5 @@ int swss::NotificationConsumer::peek()
         readData();
     }
 
-    return m_queue.empty() ? 0 : 1;
+    return m_queue->empty() ? 0 : 1;
 }

--- a/common/notificationconsumer.h
+++ b/common/notificationconsumer.h
@@ -4,6 +4,11 @@
 #include <string>
 #include <vector>
 #include <queue>
+#include <memory>
+#include <unordered_map>
+#include <list>
+#include <chrono>
+#include <cinttypes>
 
 #include <hiredis/hiredis.h>
 
@@ -21,7 +26,91 @@ static constexpr size_t DEFAULT_NC_POP_BATCH_SIZE = 2048;
 class NotificationConsumer : public Selectable
 {
 public:
-    NotificationConsumer(swss::DBConnector *db, const std::string &channel, int pri = 100, size_t popBatchSize = DEFAULT_NC_POP_BATCH_SIZE);
+    class Queue
+    {
+    public:
+        virtual ~Queue() = default;
+        virtual void push(const std::string& value) = 0;
+        virtual void pop() = 0;
+        virtual const std::string& front() const = 0;
+        virtual size_t size() const noexcept = 0;
+        virtual bool empty() const noexcept = 0;
+    };
+
+    class StandardQueue : public Queue
+    {
+        std::queue<std::string> m_queue;
+    public:
+        void push(const std::string& value) override { m_queue.push(value); }
+        void pop() override { m_queue.pop(); }
+        const std::string& front() const override
+        {
+            assert(!m_queue.empty());
+            return m_queue.front();
+        }
+        size_t size() const noexcept override { return m_queue.size(); }
+        bool empty() const noexcept override { return m_queue.empty(); }
+    };
+
+    class DedupQueue : public Queue
+    {
+        std::list<std::string> m_list;
+        std::unordered_map<std::string, std::list<std::string>::iterator> m_map;
+        uint64_t m_dupCount = 0;
+        uint64_t m_totalPush = 0;
+        std::chrono::steady_clock::time_point m_lastLog = std::chrono::steady_clock::now();
+
+    public:
+        void push(const std::string& value) override
+        {
+            logStats();
+            m_totalPush++;
+            auto it = m_map.find(value);
+            if (it != m_map.end())
+            {
+                m_dupCount++;
+                // Move the existing entry to the back of the queue. Note that
+                // this reorders events that were already queued: the duplicate
+                // is delivered in the position of the most recent occurrence
+                // rather than the original one.
+                m_list.splice(m_list.end(), m_list, it->second);
+                return;
+            }
+            m_list.push_back(value);
+            m_map[value] = std::prev(m_list.end());
+        }
+        void pop() override
+        {
+            assert(!m_list.empty());
+            m_map.erase(m_list.front());
+            m_list.pop_front();
+        }
+        const std::string& front() const override
+        {
+            assert(!m_list.empty());
+            return m_list.front();
+        }
+        size_t size() const noexcept override { return m_list.size(); }
+        bool empty() const noexcept override { return m_list.empty(); }
+    private:
+        void logStats()
+        {
+            auto now = std::chrono::steady_clock::now();
+            auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(now - m_lastLog).count();
+            if (elapsed >= 60)
+            {
+                SWSS_LOG_DEBUG("DedupQueue stats: queue_size=%zu, total_push=%" PRIu64 ", duplicates_skipped=%" PRIu64,
+                        m_list.size(), m_totalPush, m_dupCount);
+                m_lastLog = now;
+                m_totalPush = 0;
+                m_dupCount = 0;
+            }
+        }
+    };
+
+    NotificationConsumer(swss::DBConnector *db, const std::string &channel, int pri = 100,
+                         size_t popBatchSize = DEFAULT_NC_POP_BATCH_SIZE,
+                         std::shared_ptr<Queue> queue = std::make_shared<StandardQueue>());
 
     // Pop one or multiple data from the internal queue which fed from redis socket
     // Note:
@@ -55,7 +144,7 @@ private:
     swss::DBConnector *m_db;
     swss::DBConnector *m_subscribe;
     std::string m_channel;
-    std::queue<std::string> m_queue;
+    std::shared_ptr<Queue> m_queue;
 };
 
 }


### PR DESCRIPTION
**What I did**

Refactored NotificationConsumer to delegate its internal storage to a pluggable Queue strategy injected via the constructor. Added two implementations:

StandardQueue — plain FIFO, used as the default so existing callers compile and behave unchanged.
DedupQueue — backed by a `std::list + std::unordered_map`, collapses duplicate messages and re-orders the surviving entry to the back of the queue.
DedupQueue also tracks total_push and duplicates_skipped counters.

**Why I did it**

Some notification channels (e.g. FDB) can be flooded with duplicate events under load (MAC move storms), causing the consumer to backlog and process stale state. Until now NotificationConsumer always used a plain std::queue, with no way to apply dedup or any other policy on a per-channel basis. Making the queue strategy injectable lets each caller pick the right policy for its channel without touching NotificationConsumer or affecting other consumers and leaves the door open for additional strategies in the future.