### PR TITLE
Revert "zmq: prevent use-after-free of ZmqConsumerStateTable handler"

### DIFF
--- a/common/zmqconsumerstatetable.cpp
+++ b/common/zmqconsumerstatetable.cpp
@@ -21,8 +21,7 @@ ZmqConsumerStateTable::ZmqConsumerStateTable(DBConnector *db, const std::string 
     : Selectable(pri)
     , TableBase(tableName, TableBase::getTableSeparator(db->getDbId()))
     , m_db(db)
-    , m_dbName(db->getDbName())
-    , m_handlerRegistry(zmqServer.getHandlerRegistry())
+    , m_zmqServer(zmqServer)
 {
     if (popBatchSize > 0)
     {
@@ -45,20 +44,9 @@ ZmqConsumerStateTable::ZmqConsumerStateTable(DBConnector *db, const std::string 
         m_asyncDBUpdater = nullptr;
     }
 
-    m_handlerRegistry->registerHandler(m_dbName, tableName, this);
+    m_zmqServer.registerMessageHandler(m_db->getDbName(), tableName, this);
 
     SWSS_LOG_DEBUG("ZmqConsumerStateTable ctor tableName: %s", tableName.c_str());
-}
-
-ZmqConsumerStateTable::~ZmqConsumerStateTable()
-{
-    // Detach from the registry before any of our members (notably the
-    // SelectableEvent, whose eventfd we'd write to from handleReceivedData)
-    // are destroyed. removeHandler() blocks until any in-flight dispatch
-    // into us returns. The registry is co-owned with the ZmqServer that
-    // created us, so this is safe even if that ZmqServer has already been
-    // destroyed — only the shared registry is touched.
-    m_handlerRegistry->removeHandler(m_dbName, getTableName());
 }
 
 void ZmqConsumerStateTable::handleReceivedData(const std::vector<std::shared_ptr<KeyOpFieldsValuesTuple>> &kcos)

--- a/common/zmqconsumerstatetable.h
+++ b/common/zmqconsumerstatetable.h
@@ -21,8 +21,6 @@ public:
 
     ZmqConsumerStateTable(DBConnector *db, const std::string &tableName, ZmqServer &zmqServer, int popBatchSize = DEFAULT_POP_BATCH_SIZE, int pri = 0, bool dbPersistence = false);
 
-    ~ZmqConsumerStateTable() override;
-
     /* Get multiple pop elements */
     void pops(std::deque<KeyOpFieldsValuesTuple> &vkco, const std::string &prefix = EMPTY_PREFIX);
 
@@ -83,13 +81,7 @@ private:
 
     DBConnector *m_db;
 
-    // Cached at construction time so the destructor can call
-    // m_handlerRegistry->removeHandler() without dereferencing m_db.
-    std::string m_dbName;
-
-    // Co-owned with the ZmqServer that created us. Lets the destructor
-    // unregister cleanly even if the ZmqServer has already been destroyed.
-    std::shared_ptr<ZmqHandlerRegistry> m_handlerRegistry;
+    ZmqServer& m_zmqServer;
 
     std::unique_ptr<AsyncDBUpdater> m_asyncDBUpdater;
 

--- a/common/zmqserver.cpp
+++ b/common/zmqserver.cpp
@@ -12,75 +12,6 @@ using namespace std;
 
 namespace swss {
 
-void ZmqHandlerRegistry::registerHandler(
-    const std::string& dbName,
-    const std::string& tableName,
-    ZmqMessageHandler* handler)
-{
-    std::lock_guard<std::mutex> lock(m_mutex);
-
-    auto dbResult = m_handlers.insert(make_pair(dbName, map<string, ZmqMessageHandler*>()));
-    if (dbResult.second) {
-        SWSS_LOG_DEBUG("ZmqHandlerRegistry add mapping for db: %s", dbName.c_str());
-    }
-
-    auto tableResult = dbResult.first->second.insert(make_pair(tableName, handler));
-    if (tableResult.second) {
-        SWSS_LOG_DEBUG("ZmqHandlerRegistry register handler for db: %s, table: %s",
-                       dbName.c_str(), tableName.c_str());
-    }
-}
-
-void ZmqHandlerRegistry::removeHandler(
-    const std::string& dbName,
-    const std::string& tableName)
-{
-    // Take the same mutex that dispatch() holds across the callback. Once we
-    // acquire it, no callback into this (dbName, tableName) handler is in
-    // flight and no further one can start — making it safe for the caller to
-    // destroy the handler object after removeHandler() returns.
-    std::lock_guard<std::mutex> lock(m_mutex);
-
-    auto dbIter = m_handlers.find(dbName);
-    if (dbIter == m_handlers.end()) {
-        return;
-    }
-
-    dbIter->second.erase(tableName);
-    if (dbIter->second.empty()) {
-        m_handlers.erase(dbIter);
-    }
-
-    SWSS_LOG_DEBUG("ZmqHandlerRegistry removed handler for db: %s, table: %s",
-                   dbName.c_str(), tableName.c_str());
-}
-
-void ZmqHandlerRegistry::dispatch(
-    const std::string& dbName,
-    const std::string& tableName,
-    const std::vector<std::shared_ptr<KeyOpFieldsValuesTuple>>& kcos)
-{
-    // Hold the mutex for the duration of the callback. Concurrent
-    // removeHandler() on this (dbName, tableName) blocks until we return,
-    // so the handler cannot be destroyed mid-call.
-    std::lock_guard<std::mutex> lock(m_mutex);
-
-    auto dbIter = m_handlers.find(dbName);
-    if (dbIter == m_handlers.end()) {
-        SWSS_LOG_DEBUG("ZmqHandlerRegistry can't find any handler for db: %s", dbName.c_str());
-        return;
-    }
-
-    auto tableIter = dbIter->second.find(tableName);
-    if (tableIter == dbIter->second.end()) {
-        SWSS_LOG_DEBUG("ZmqHandlerRegistry can't find handler for db: %s, table: %s",
-                       dbName.c_str(), tableName.c_str());
-        return;
-    }
-
-    tableIter->second->handleReceivedData(kcos);
-}
-
 ZmqServer::ZmqServer(const std::string& endpoint)
     : ZmqServer(endpoint, "", false, false)
 {
@@ -103,8 +34,7 @@ ZmqServer::ZmqServer(const std::string& endpoint, const std::string& vrf, bool l
     m_context(nullptr),
     m_socket(nullptr),
     m_oneToOneSync(oneToOneSync),
-    m_allowZmqPoll(true),
-    m_registry(std::make_shared<ZmqHandlerRegistry>())
+    m_allowZmqPoll(true)
 {
     if (!lazyBind)
     {
@@ -132,11 +62,6 @@ ZmqServer::~ZmqServer()
     {
         zmq_ctx_destroy(m_context);
     }
-
-    // m_registry's refcount drops here. If any registered handler still holds
-    // a reference, the registry survives until that handler is destroyed; its
-    // destructor will call removeHandler() safely against the surviving
-    // registry without touching this (now-gone) ZmqServer.
 }
 
 void ZmqServer::bind()
@@ -183,7 +108,7 @@ void ZmqServer::bind()
     }
 
     if (!m_vrf.empty())
-    {
+    {   
         zmq_setsockopt(m_socket, ZMQ_BINDTODEVICE, m_vrf.c_str(), m_vrf.length());
     }
 
@@ -205,24 +130,34 @@ void ZmqServer::registerMessageHandler(
                                     const std::string tableName,
                                     ZmqMessageHandler* handler)
 {
-    m_registry->registerHandler(dbName, tableName, handler);
-}
+    auto dbResult = m_HandlerMap.insert(pair<string, map<string, ZmqMessageHandler*>>(dbName, map<string, ZmqMessageHandler*>()));
+    if (dbResult.second) {
+        SWSS_LOG_DEBUG("ZmqServer add handler mapping for db: %s", dbName.c_str());
+    }
 
-void ZmqServer::removeMessageHandler(
-                                    const std::string& dbName,
-                                    const std::string& tableName)
-{
-    m_registry->removeHandler(dbName, tableName);
+    auto tableResult = dbResult.first->second.insert(pair<string, ZmqMessageHandler*>(tableName, handler));
+    if (tableResult.second) {
+        SWSS_LOG_DEBUG("ZmqServer register handler for db: %s, table: %s", dbName.c_str(), tableName.c_str());
+    }
 }
 
 ZmqMessageHandler* ZmqServer::findMessageHandler(
-    const std::string /*dbName*/,
-    const std::string /*tableName*/)
+                                                const std::string dbName,
+                                                const std::string tableName)
 {
-    // Retained as a no-op for source compatibility with external test mocks
-    // that override this symbol at link time. Real dispatch lives in
-    // ZmqHandlerRegistry::dispatch().
-    return nullptr;
+    auto dbMappingIter = m_HandlerMap.find(dbName);
+    if (dbMappingIter == m_HandlerMap.end()) {
+        SWSS_LOG_DEBUG("ZmqServer can't find any handler for db: %s", dbName.c_str());
+        return nullptr;
+    }
+
+    auto tableMappingIter = dbMappingIter->second.find(tableName);
+    if (tableMappingIter == dbMappingIter->second.end()) {
+        SWSS_LOG_DEBUG("ZmqServer can't find handler for db: %s, table: %s", dbName.c_str(), tableName.c_str());
+        return nullptr;
+    }
+
+    return tableMappingIter->second;
 }
 
 void ZmqServer::handleReceivedData(const char* buffer, const size_t size)
@@ -232,7 +167,14 @@ void ZmqServer::handleReceivedData(const char* buffer, const size_t size)
     std::vector<std::shared_ptr<KeyOpFieldsValuesTuple>> kcos;
     BinarySerializer::deserializeBuffer(buffer, size, dbName, tableName, kcos);
 
-    m_registry->dispatch(dbName, tableName, kcos);
+    // find handler
+    auto handler = findMessageHandler(dbName, tableName);
+    if (handler == nullptr) {
+        SWSS_LOG_WARN("ZmqServer can't find handler for received message: %s", buffer);
+        return;
+    }
+
+    handler->handleReceivedData(kcos);
 }
 
 void ZmqServer::startMqPollThread()

--- a/common/zmqserver.h
+++ b/common/zmqserver.h
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <map>
-#include <memory>
-#include <mutex>
 #include <string>
 #include <deque>
 #include <condition_variable>
@@ -27,32 +24,6 @@ public:
     virtual void handleReceivedData(const std::vector<std::shared_ptr<KeyOpFieldsValuesTuple>>& kcos) = 0;
 };
 
-// Shared (db, table) -> handler map. Co-owned by ZmqServer and every
-// registered handler so neither party requires the other to outlive it.
-// The mutex is held across handler dispatch, so removeHandler() blocks
-// until any in-flight callback into the handler being removed has returned
-// — making it safe for the caller to destroy the handler immediately after
-// removeHandler() returns. Handler callbacks therefore must not themselves
-// call registerHandler / removeHandler (would self-deadlock).
-class ZmqHandlerRegistry
-{
-public:
-    void registerHandler(const std::string& dbName,
-                         const std::string& tableName,
-                         ZmqMessageHandler* handler);
-
-    void removeHandler(const std::string& dbName,
-                       const std::string& tableName);
-
-    void dispatch(const std::string& dbName,
-                  const std::string& tableName,
-                  const std::vector<std::shared_ptr<KeyOpFieldsValuesTuple>>& kcos);
-
-private:
-    std::mutex m_mutex;
-    std::map<std::string, std::map<std::string, ZmqMessageHandler*>> m_handlers;
-};
-
 class ZmqServer
 {
 public:
@@ -73,25 +44,11 @@ public:
                                 const std::string tableName,
                                 ZmqMessageHandler* handler);
 
-    // Remove a previously-registered handler. Blocks until any in-flight
-    // dispatch into that handler has returned, so the caller can safely
-    // destroy the handler object after this call returns.
-    void removeMessageHandler(
-                                const std::string& dbName,
-                                const std::string& tableName);
-
     // This method should only be used in one-to-one sync mode with the client.
     void sendMsg(const std::string& dbName, const std::string& tableName,
         const std::vector<swss::KeyOpFieldsValuesTuple>& values);
 
     void bind();
-
-    // Internal: returns the shared handler registry so a handler implementation
-    // can co-own it. This lets the handler's destructor call removeHandler()
-    // without depending on the ZmqServer still being alive (the registry
-    // survives as long as either party holds a reference). Intended for use
-    // by ZmqMessageHandler subclasses, not by general callers.
-    std::shared_ptr<ZmqHandlerRegistry> getHandlerRegistry() const { return m_registry; }
 
 private:
     void handleReceivedData(const char* buffer, const size_t size);
@@ -99,11 +56,7 @@ private:
     void startMqPollThread();
 
     void mqPollThread();
-
-    // Retained as a no-op stub for source compatibility with external test
-    // mocks (e.g. sonic-swss's fake_zmqserver.cpp) that override this symbol
-    // at link time. The internal dispatch path no longer calls it — handler
-    // lookup happens inside ZmqHandlerRegistry::dispatch().
+    
     ZmqMessageHandler* findMessageHandler(const std::string dbName, const std::string tableName);
 
     std::vector<char> m_buffer;
@@ -124,11 +77,7 @@ private:
 
     bool m_allowZmqPoll;
 
-    // Default-initialized in-class so that link-time mocks of ZmqServer
-    // (which may not initialize this member in their stub constructors) still
-    // present a valid registry to any real ZmqConsumerStateTable they pair
-    // with — the real constructor below also sets this explicitly.
-    std::shared_ptr<ZmqHandlerRegistry> m_registry = std::make_shared<ZmqHandlerRegistry>();
+    std::map<std::string, std::map<std::string, ZmqMessageHandler*>> m_HandlerMap;
 };
 
 }


### PR DESCRIPTION
Test PR to verify whether reverting commit 6ce7121 fixes the test_ProducerTable failure in CI.

The failing test uses ProducerTable/ConsumerTable (Redis lua scripts), not ZMQ code, so this revert is expected to have no effect on the failure — confirming the root cause lies elsewhere (likely a flaky test or CI environment issue with 95% disk usage).

This PR is for CI testing purposes only — do not merge.