### PR TITLE
ci: replace pytest-flaky with pytest-rerunfailures for explicit rerun visibility

### DIFF
--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -160,7 +160,7 @@ jobs:
   - ${{ if eq(parameters.run_unit_test, true) }}:
     - script: |
         set -ex
-        sudo pip install Pympler==0.8 pytest
+        sudo pip install Pympler==0.8 pytest pytest-rerunfailures
         sudo apt-get install -y redis-server
         sudo dpkg -i libswsscommon_*.deb
         sudo dpkg -i libswsscommon-dev_*.deb
@@ -179,7 +179,7 @@ jobs:
 
         ./tests/tests
         redis-cli FLUSHALL
-        pytest-3 --cov=. --cov-report=xml
+        pytest-3 --reruns 2 --reruns-delay 1 --cov=. --cov-report=xml
         [ -f coverage.xml ] && mv coverage.xml tests/coverage.xml
         gcovr -r ./ -e ".*/swsscommon_wrap.cpp" -e=tests --exclude-unreachable-branches --exclude-throw-branches --gcov-ignore-parse-errors -x --xml-pretty  -o coverage.xml
         make -C goext


### PR DESCRIPTION
Replace the bare pytest invocation with pytest-rerunfailures (`--reruns 2 --reruns-delay 1`) in the unit test CI pipeline.

The `test_ProducerTable` failure in [build 1123755](https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_build/results?buildId=1123755) was a flaky environmental issue (95.67% disk usage on the Azure agent). Adding automatic retries with visible RERUN markers will prevent such transient failures from blocking the pipeline while still surfacing which tests are flaky.

**Before (bare pytest):**
```
test_ProducerTable FAILED [ 26%]
=========== 1 failed, 37 passed ===========
```

**After (pytest-rerunfailures):**
```
test_ProducerTable FAILED [ 26%]
test_ProducerTable RERUN  [ 26%]
test_ProducerTable PASSED [ 26%]
=========== 38 passed, 1 rerun ===========
```

This mirrors the approach taken in sonic-swss (sonic-net/sonic-swss#4612).

Signed-off-by: Guohan Lu <lianguohan@gmail.com>