### PR TITLE
[tokenize] Avoid istringstream in delimiter-based tokenize

### DIFF
--- a/common/tokenize.cpp
+++ b/common/tokenize.cpp
@@ -6,12 +6,32 @@ namespace swss {
 
 vector<string> tokenize(const string &str, const char token)
 {
-    string tmp;
     vector<string> ret;
-    istringstream iss(str);
 
-    while (getline(iss, tmp, token))
-        ret.push_back(tmp);
+    if (str.empty())
+    {
+        return ret;
+    }
+
+    ret.reserve(4);
+
+    size_t start = 0;
+    while (true)
+    {
+        size_t pos = str.find(token, start);
+        if (pos == string::npos)
+        {
+            break;
+        }
+
+        ret.push_back(str.substr(start, pos - start));
+        start = pos + 1;
+    }
+
+    if (start < str.size())
+    {
+        ret.push_back(str.substr(start));
+    }
 
     return ret;
 }

--- a/tests/tokenize_ut.cpp
+++ b/tests/tokenize_ut.cpp
@@ -28,6 +28,20 @@ TEST(TOKENIZE, basic)
     EXPECT_EQ(origin, result);
 }
 
+TEST(TOKENIZE, edge_cases)
+{
+    EXPECT_EQ(tokenize("", ','), vector<string>({}));
+    EXPECT_EQ(tokenize("a", ','), vector<string>({"a"}));
+    EXPECT_EQ(tokenize("a,b", ','), vector<string>({"a", "b"}));
+    EXPECT_EQ(tokenize("a,b,", ','), vector<string>({"a", "b"}));
+    EXPECT_EQ(tokenize(",a", ','), vector<string>({"", "a"}));
+    EXPECT_EQ(tokenize("a,,b", ','), vector<string>({"a", "", "b"}));
+    EXPECT_EQ(tokenize(",", ','), vector<string>({""}));
+    EXPECT_EQ(tokenize(",,", ','), vector<string>({"", ""}));
+    EXPECT_EQ(tokenize("10.0.0.1,10.0.0.2", ','), vector<string>({"10.0.0.1", "10.0.0.2"}));
+    EXPECT_EQ(tokenize("Ethernet0,Ethernet4", ','), vector<string>({"Ethernet0", "Ethernet4"}));
+}
+
 TEST(TOKENIZE, IP)
 {
     IpAddresses origin("192.168.0.1,192.168.0.2");


### PR DESCRIPTION
### Problem

`tokenize(str, token)` currently constructs a `std::istringstream` for every call.
This is more expensive than needed for splitting a string on a single delimiter,
because it brings in iostream and locale machinery.

This helper is used in SWSS hot paths, including route processing in orchagent.
During route burst profiling, perf showed time in:

- `swss::tokenize`
- `std::getline`
- `std::basic_ios::_M_cache_locale`
- `std::locale`
- `std::vector<std::string>` growth
- `operator new`

### Fix

Replace the `istringstream`/`getline` implementation with direct
`std::string::find()` / `substr()` delimiter scanning.

This matches the implementation style already used by the limited-token tokenize
overload added in #96, while preserving the observed behavior of the base overload.

### Testing

Configured locally with YANG modules disabled:

```bash
./autogen.sh
./configure --enable-debug --disable-yangmodules 'CXXFLAGS=-O0 -g'