### PR TITLE
Fix sonic-swss-common build

### DIFF
--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -106,6 +106,10 @@ jobs:
   - script: |
       set -ex
       sudo dpkg -i $(find ./download -name *.deb)
+      # common-lib doesn't publish python3-libyang (LIBYANG3_PY3 isn't in
+      # slave.mk's lib-packages), so install the CFFI bindings from PyPI;
+      # they link against the libyang3 we just installed.
+      sudo pip3 install --no-build-isolation 'libyang==3.3.0'
     workingDirectory: $(Build.ArtifactStagingDirectory)
     displayName: "Install libyang from common lib"
   - task: DownloadPipelineArtifact@2


### PR DESCRIPTION
# Background / Motivation

I noticed that the sonic-swss-common build is failing during compilation because libyang python dependencies are not correctly installed by the build pipeline prior to attempting to compile.

This PR contains a short-term fix. The proper fix is in sonic-buildimage (https://github.com/sonic-net/sonic-buildimage/pull/27836), but won't resolve the problem until the next nightly build fires and publishes the correct packages. This PR can be reverted once that fix takes effect.

# Testing
The compilation step in the build pipeline now works as expected: https://dev.azure.com/mssonic/build/_build/results?buildId=1136291&view=logs&j=a5b8631f-d2a8-5bf4-c5b7-ed5dd46e146c&t=b99e062e-9dda-5ff0-ad0b-d7a7533b64b9