### PR TITLE
[202605][ci] Install libyang python bindings in coverage build

### DIFF
--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -108,6 +108,13 @@ jobs:
       sudo dpkg -i $(find ./download -name *.deb)
     workingDirectory: $(Build.ArtifactStagingDirectory)
     displayName: "Install libyang from common lib"
+  - script: |
+      set -ex
+      sudo apt-get install -y python3-cffi
+      sudo pip3 install --no-build-isolation 'libyang==3.3.0'
+    workingDirectory: $(Build.ArtifactStagingDirectory)
+    displayName: "Install libyang python bindings"
+    condition: ne('${{ parameters.debian_version }}', 'trixie')
   - task: DownloadPipelineArtifact@2
     inputs:
       source: specific


### PR DESCRIPTION
#### Why I did it
The "Compile sonic swss common with coverage enabled" task in `.azure-pipelines/build-template.yml` fails with:
```
ModuleNotFoundError: No module named 'libyang'
make[2]: *** [Makefile:3669: common/cfg_schema.h] Error 1
```
`gen_cfg_schema.py` imports `sonic_yang`, which imports `libyang`. The coverage job installs the **C** libyang3 libraries (`dpkg -i`) but never installs the **Python** bindings.

The inline amd64 job in `azure-pipelines.yml` already installs the Python bindings via pip (added in commit 1431c3d), but the shared `build-template.yml` coverage job was missed.

Example failure: https://dev.azure.com/mssonic/build/_build/results?buildId=1138021 (branch 202605)

#### How I did it
Add a step to `build-template.yml` — immediately after the libyang C-lib install — that installs the Python bindings, mirroring `azure-pipelines.yml`:
```
sudo apt-get install -y python3-cffi
sudo pip3 install --no-build-isolation 'libyang==3.3.0'
```
Gated off `trixie` (`condition: ne(... 'trixie')`) to match the existing pattern in the file.

#### How to verify it
The coverage build's `cfg_schema.h` generation step succeeds (no `ModuleNotFoundError`). Verified by CI re-run on this PR.
