### PR TITLE
Revert quickfix for sonic-swss-common builds

### DIFF
--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -106,10 +106,6 @@ jobs:
   - script: |
       set -ex
       sudo dpkg -i $(find ./download -name *.deb)
-      # common-lib doesn't publish python3-libyang (LIBYANG3_PY3 isn't in
-      # slave.mk's lib-packages), so install the CFFI bindings from PyPI;
-      # they link against the libyang3 we just installed.
-      sudo pip3 install --no-build-isolation 'libyang==3.3.0'
     workingDirectory: $(Build.ArtifactStagingDirectory)
     displayName: "Install libyang from common lib"
   - task: DownloadPipelineArtifact@2


### PR DESCRIPTION
Revert the quickfix merged in https://github.com/sonic-net/sonic-swss-common/pull/1206 to fix sonic-swss-common builds now that the long-term fix has merged and had time to take effect in https://github.com/sonic-net/sonic-buildimage/pull/27836.