### PR TITLE
[test][ci] Fix two flaky unit tests + reduce CI flakiness

### DIFF
--- a/.azure-pipelines/build-sairedis-template.yml
+++ b/.azure-pipelines/build-sairedis-template.yml
@@ -50,6 +50,20 @@ jobs:
     options:  "--privileged"
 
   steps:
+  - script: |
+      echo "Disk usage before cleanup:"; df -h /
+      # The sonic-sairedis build (syncd + vs + saiplayer, plus the produced .debs
+      # and dbgsym packages) is large and the hosted agent's disk is limited, so
+      # this stage intermittently runs out of space. Reclaim space by dropping big
+      # preinstalled toolchains this build never uses. Runs on the agent host
+      # (target: host) rather than the sonic-slave container -- that is where the
+      # space is consumed -- and is best-effort so it can never fail the build.
+      sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup \
+                  /opt/hostedtoolcache/CodeQL /usr/share/swift /usr/local/share/boost 2>/dev/null || true
+      docker image prune -af 2>/dev/null || true
+      echo "Disk usage after cleanup:"; df -h /
+    displayName: "Free up disk space"
+    target: host
   - checkout: sonic-sairedis
     submodules: true
     clean: true

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -129,7 +129,7 @@ jobs:
       # Run the tests in parallel and retry
       retry=3
       IMAGE_NAME=docker-sonic-vs:$(Build.DefinitionName).$(Build.BuildNumber)
-      echo $all_tests | xargs -n 1 | xargs -P 8 -I TEST_MODULE sudo ./run-tests.sh "$IMAGE_NAME" "--force-recreate-dvs" "TEST_MODULE" 3
+      echo $all_tests | xargs -n 1 | xargs -P 8 -I TEST_MODULE sudo ./run-tests.sh "$IMAGE_NAME" "--force-flaky --force-recreate-dvs" "TEST_MODULE" 3
 
       rm -rf $(Build.ArtifactStagingDirectory)/download
     displayName: "Run vs tests"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -209,6 +209,9 @@ stages:
     parameters:
       arch: amd64
       pool: sonicso1ES-amd64
+      # sonic-swss is a large compile that intermittently exceeds the 90m default;
+      # give it more headroom to avoid spurious timeouts.
+      timeout: 120
       swss_common_artifact_name: sonic-swss-common-${{ parameters.debian_version }}
       sairedis_artifact_name: sonic-sairedis-${{ parameters.debian_version }}
       artifact_name: sonic-swss-${{ parameters.debian_version }}

--- a/tests/ntf_ut.cpp
+++ b/tests/ntf_ut.cpp
@@ -330,9 +330,14 @@ TEST(Notifications, LruDedupPolicyConstructorAndLabelPropagation)
     send("fdb_event");
     send("fdb_event");    // byte-identical to first -- LruDedup should collapse
 
-    // Drain so processReply is invoked.
+    // Drain so processReply is invoked. Both messages are delivered over Redis
+    // pub/sub, but the second reply may not have arrived by the time the first
+    // select() returns -- especially under load. LruDedup collapses the two
+    // byte-identical messages into a single queued item, so stopping at the first
+    // pop races the second reply and can observe received==1. Keep draining until
+    // both messages have been received (processReply'd), or we time out.
     size_t pops = 0;
-    for (int i = 0; i < 50 && pops == 0; ++i) {
+    for (int i = 0; i < 100 && nc.getStats().received < 2; ++i) {
         swss::Selectable *sel = nullptr;
         if (s.select(&sel, 100 /* ms */) == swss::Select::TIMEOUT) continue;
         std::deque<swss::KeyOpFieldsValuesTuple> vkco;

--- a/tests/test_redis_ut.py
+++ b/tests/test_redis_ut.py
@@ -873,9 +873,18 @@ def test_TableOpsMemoryLeak():
     t = swsscommon.Table(app_db, "TABLE")
     long_data = "x" * 100
     fvs = swsscommon.FieldValuePairs([(long_data, long_data)])
+
+    def run_ops():
+        for _ in range(OP_COUNT):
+            t.set("long_data", fvs)
+            t.get("long_data")
+
+    # Warm up first: a fresh process grows RSS by a one-time amount (allocator
+    # arenas, redis client buffers, interpreter caches) that is unrelated to any
+    # leak. Measure the SECOND, steady-state batch instead -- a real per-op leak
+    # keeps growing linearly, so post-warmup growth must stay near zero.
+    run_ops()
     rss = psutil.Process(os.getpid()).memory_info().rss
-    for _ in range(OP_COUNT):
-        t.set("long_data", fvs)
-        t.get("long_data")
+    run_ops()
     assert psutil.Process(os.getpid()).memory_info().rss - rss < OP_COUNT
 


### PR DESCRIPTION
## What / why

The Azure CI for this repo is intermittently red due to two flaky unit tests (they redden `master` too). This PR fixes both, and adds two small CI-robustness tweaks for stages that intermittently fail for infra reasons.

### 1. Fix `Notifications.LruDedupPolicyConstructorAndLabelPropagation` (`tests/ntf_ut.cpp`)
The drain loop stopped at the first `pop`, but the two byte-identical `fdb_event` messages arrive over Redis pub/sub and the second reply may not have been read yet. `LruDedup` collapses them into a single queued item, so the test observed `received == 1` and failed `EXPECT_EQ(received, 2)`. **Fix:** drain until both messages have been received (`received >= 2`) or a timeout, then assert.

### 2. Fix `test_TableOpsMemoryLeak` (`tests/test_redis_ut.py`)
It asserted `< 50000` bytes of RSS growth over 50000 fresh-process ops, but that growth is one-time allocator / client-buffer warmup, not a leak. **Fix:** warm up first, then measure the steady-state second batch — a real per-op leak keeps growing linearly, so post-warmup growth must stay near zero (threshold unchanged).

### 3. Raise the sonic-swss build timeout (90m → 120m)
`BuildSwss` compiles sonic-swss and intermittently exceeds the 90-minute default.

### 4. Free host disk before the sonic-sairedis build stage
`BuildSairedis` runs on a hosted `ubuntu-22.04` agent and intermittently runs out of disk. A best-effort `target: host` step drops big preinstalled toolchains the build never uses and prunes docker images (with `df` before/after).

### 5. Enable flaky VS test retry
Pass `--force-flaky` to VS test so any test failures are retried

## Verification
Reproduced and verified in a `sonic-slave-bookworm` container under 32-worker CPU load (the flakes are load-sensitive):

| Test | Before (master) | After (this PR) |
|------|-----------------|-----------------|
| `LruDedup` ×150 | **135 failed** (`received`=1) | **0 failed** |
| `test_TableOpsMemoryLeak` ×20 | **20 failed** | **0 failed** |
