### PR TITLE
[ci] Pin GitHub Actions to commit SHAs to fix Semgrep master failures

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,11 +29,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2.1.29
+      uses: github/codeql-action/init@ec3cf9c605b848da5f1e41e8452719eb1ccfb9a6 # v2.1.29
       with:
         config-file: ./.github/codeql/codeql-config.yml
         languages: ${{ matrix.language }}
@@ -78,6 +78,6 @@ jobs:
         dpkg-buildpackage -rfakeroot -us -uc -b -Pnoyangmod,nopython2 -j$(nproc)
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2.1.29
+      uses: github/codeql-action/analyze@ec3cf9c605b848da5f1e41e8452719eb1ccfb9a6 # v2.1.29
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/prevent-cfg.yml
+++ b/.github/workflows/prevent-cfg.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
     - name: Check for new CFG_ macros in schema.h
       run: |

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -16,7 +16,7 @@ jobs:
     container:
       image: returntocorp/semgrep
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - run: semgrep ci
         env:
            SEMGREP_RULES: p/default


### PR DESCRIPTION
#### What I did

Pinned the GitHub Actions in `codeql-analysis.yml`, `prevent-cfg.yml`, and `semgrep.yml` to full 40-character commit SHAs, keeping the original tag in a trailing comment:

| Action | Was | Now |
|--------|-----|-----|
| `actions/checkout` | `@v3` | `@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3` |
| `github/codeql-action/init` | `@v2.1.29` | `@ec3cf9c605b848da5f1e41e8452719eb1ccfb9a6 # v2.1.29` |
| `github/codeql-action/analyze` | `@v2.1.29` | `@ec3cf9c605b848da5f1e41e8452719eb1ccfb9a6 # v2.1.29` |

These are the exact commits the tags currently resolve to, so there is no version or behavior change (and it stays Dependabot-compatible). Note `checkout@v3` appears in all three workflow files here.

#### Root cause

Semgrep (`SEMGREP_RULES: p/default`) has been failing on every push to `master` since ~June 30, 2026, while PRs stay green. Semgrep's registry-served `p/default` pack began including the rule `yaml.github-actions.security.github-actions-mutable-action-tag`, which blocks on Actions pinned to mutable tags/branches instead of a full commit SHA (a supply-chain risk — mutable tags can be silently repointed). `semgrep ci` runs a full scan on push to `master` but a diff-only scan on PRs, so master blocks on these pre-existing workflow files while PRs don't.

#### Verification

Reproduced locally with Semgrep 1.169.0 against `master`:

- **Before:** `semgrep ci` -> exit 1, **5 blocking findings**, all `github-actions-mutable-action-tag` (in `codeql-analysis.yml`, `prevent-cfg.yml`, and `semgrep.yml`).
- **After (this change):** `semgrep ci` -> exit 0, **0 findings**.

This is the same fix already merged/validated for `sonic-swss` (sonic-net/sonic-swss#4750), where full CI passed green.

#### Follow-up (not in this PR)

`semgrep.yml` uses an unpinned, deprecated container image (`returntocorp/semgrep`). Pinning it to a versioned `semgrep/semgrep:<tag>` would prevent similar drift, but it isn't flagged by the rule, so it's left out of this minimal fix.