### PR TITLE
[ci][202511] replace python3-pip with uv in vs test pipeline

### DIFF
--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -72,7 +72,7 @@ jobs:
   - script: |
       set -ex
       # install packages for vs test
-      sudo pip3 install pytest flaky exabgp docker redis
+      sudo uv pip install --system pytest flaky exabgp docker redis
 
       # install packages for kvm test
       sudo apt-get -o DPkg::Lock::Timeout=600 install -y libvirt-clients \


### PR DESCRIPTION
cherry-pick: https://github.com/sonic-net/sonic-swss-common/pull/1225

S360 flags `python3-pip` on the CI agent as a security vulnerability
Remove usage of `pip3` from the vs test pipeline script following the removal of `python3-pip` from the CI agent. Replace all `pip3 install` calls with `uv pip install --system` to maintain equivalent system-wide package installation behaviour.